### PR TITLE
feat: stateful precompiles + allowlist hooks

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -365,6 +365,9 @@ func (st *StateTransition) preCheck() error {
 // However if any consensus issue encountered, return the error directly with
 // nil evm execution result.
 func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
+	if err := st.canExecuteTransaction(); err != nil {
+		return nil, err
+	}
 	// First check this message satisfies all consensus rules before
 	// applying the message. The rules include these clauses
 	//

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -1,5 +1,7 @@
 package core
 
+// canExecuteTransaction is a convenience wrapper for calling the
+// [params.RulesHooks.CanExecuteTransaction] hook.
 func (st *StateTransition) canExecuteTransaction() error {
 	bCtx := st.evm.Context
 	rules := st.evm.ChainConfig().Rules(bCtx.BlockNumber, bCtx.Random != nil, bCtx.Time)

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -3,5 +3,5 @@ package core
 func (st *StateTransition) canExecuteTransaction() error {
 	bCtx := st.evm.Context
 	rules := st.evm.ChainConfig().Rules(bCtx.BlockNumber, bCtx.Random != nil, bCtx.Time)
-	return rules.Hooks().CanExecuteTransaction(st.msg.From, st.msg.From, st.state)
+	return rules.Hooks().CanExecuteTransaction(st.msg.From, st.msg.To, st.state)
 }

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -1,0 +1,7 @@
+package core
+
+func (st *StateTransition) canExecuteTransaction() error {
+	bCtx := st.evm.Context
+	rules := st.evm.ChainConfig().Rules(bCtx.BlockNumber, bCtx.Random != nil, bCtx.Time)
+	return rules.Hooks().CanExecuteTransaction(st.msg.From, st.msg.From, st.state)
+}

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCanExecuteTransaction(t *testing.T) {
-	rng := ethtest.NewRand(42)
+	rng := ethtest.NewPseudoRand(42)
 	account := rng.Address()
 	slot := rng.Hash()
 

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/libevm"
+	"github.com/ethereum/go-ethereum/libevm/ethtest"
+	"github.com/ethereum/go-ethereum/libevm/hookstest"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanExecuteTransaction(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	var (
+		from, to    common.Address
+		account     common.Address
+		slot, value common.Hash
+	)
+	rng.Read(from[:])
+	rng.Read(to[:])
+	rng.Read(account[:])
+	rng.Read(slot[:])
+	rng.Read(value[:])
+
+	makeErr := func(from common.Address, to *common.Address, val common.Hash) error {
+		return fmt.Errorf("From: %v To: %v State: %v", from, to, val)
+	}
+	hooks := &hookstest.Stub{
+		CanExecuteTransactionFn: func(from common.Address, to *common.Address, s libevm.StateReader) error {
+			return makeErr(from, to, s.GetState(account, slot))
+		},
+	}
+	params.TestOnlyClearRegisteredExtras()
+	hooks.RegisterForRules()
+	t.Cleanup(params.TestOnlyClearRegisteredExtras)
+
+	state, evm := ethtest.NewZeroEVM(t)
+	state.SetState(account, slot, value)
+	msg := &Message{
+		From: from,
+		To:   &to,
+	}
+	_, err := ApplyMessage(evm, msg, new(GasPool).AddGas(30e6))
+	require.EqualError(t, err, makeErr(from, &to, value).Error())
+}

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/libevm"
 	"github.com/ethereum/go-ethereum/libevm/ethtest"
 	"github.com/ethereum/go-ethereum/libevm/hookstest"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,9 +33,7 @@ func TestCanExecuteTransaction(t *testing.T) {
 			return makeErr(from, to, s.GetState(account, slot))
 		},
 	}
-	params.TestOnlyClearRegisteredExtras()
-	hooks.RegisterForRules()
-	t.Cleanup(params.TestOnlyClearRegisteredExtras)
+	hooks.RegisterForRules(t)
 
 	state, evm := ethtest.NewZeroEVM(t)
 	state.SetState(account, slot, value)

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -1,10 +1,11 @@
-package core
+package core_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/libevm"
 	"github.com/ethereum/go-ethereum/libevm/ethtest"
 	"github.com/ethereum/go-ethereum/libevm/hookstest"
@@ -30,10 +31,10 @@ func TestCanExecuteTransaction(t *testing.T) {
 
 	state, evm := ethtest.NewZeroEVM(t)
 	state.SetState(account, slot, value)
-	msg := &Message{
+	msg := &core.Message{
 		From: rng.Address(),
 		To:   rng.AddressPtr(),
 	}
-	_, err := ApplyMessage(evm, msg, new(GasPool).AddGas(30e6))
+	_, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(30e6))
 	require.EqualError(t, err, makeErr(msg.From, msg.To, value).Error())
 }

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -15,15 +15,11 @@ import (
 func TestCanExecuteTransaction(t *testing.T) {
 	rng := rand.New(rand.NewSource(42))
 	var (
-		from, to    common.Address
-		account     common.Address
-		slot, value common.Hash
+		account common.Address
+		slot    common.Hash
 	)
-	rng.Read(from[:])
-	rng.Read(to[:])
 	rng.Read(account[:])
 	rng.Read(slot[:])
-	rng.Read(value[:])
 
 	makeErr := func(from common.Address, to *common.Address, val common.Hash) error {
 		return fmt.Errorf("From: %v To: %v State: %v", from, to, val)
@@ -34,6 +30,14 @@ func TestCanExecuteTransaction(t *testing.T) {
 		},
 	}
 	hooks.RegisterForRules(t)
+
+	var (
+		from, to common.Address
+		value    common.Hash
+	)
+	rng.Read(from[:])
+	rng.Read(to[:])
+	rng.Read(value[:])
 
 	state, evm := ethtest.NewZeroEVM(t)
 	state.SetState(account, slot, value)

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -168,13 +168,13 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 // - the returned bytes,
 // - the _remaining_ gas,
 // - any error that occurred
-func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
+func (args *evmCallArgs) RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
 	gasCost := p.RequiredGas(input)
 	if suppliedGas < gasCost {
 		return nil, 0, ErrOutOfGas
 	}
 	suppliedGas -= gasCost
-	output, err := p.Run(input)
+	output, err := args.run(p, input)
 	return output, suppliedGas, err
 }
 

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -1,0 +1,77 @@
+package vm
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// evmCallArgs mirrors the parameters of the [EVM] methods Call(), CallCode(),
+// DelegateCall() and StaticCall(). Its fields are identical to those of the
+// parameters, prepended with the receiver name. As {Delegate,Static}Call don't
+// accept a value, they MUST set the respective field to nil.
+//
+// Instantiation can be achieved by merely copying the parameter names, in
+// order, which is trivially achieved with AST manipulation:
+//
+//	func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) ... {
+//		...
+//		args := &evmCallArgs{evm, caller, addr, input, gas, value}
+type evmCallArgs struct {
+	evm    *EVM
+	caller ContractRef
+	addr   common.Address
+	input  []byte
+	gas    uint64
+	value  *uint256.Int
+}
+
+func (args *evmCallArgs) run(p PrecompiledContract, input []byte) (ret []byte, err error) {
+	if p, ok := p.(statefulPrecompile); ok {
+		return p.run(args.evm.StateDB, &args.evm.chainRules, args.caller.Address(), args.addr, input)
+	}
+	return p.Run(input)
+}
+
+// A StatefulPrecompileFunc...
+type StatefulPrecompfileFunc func(_ StateDB, _ *params.Rules, caller, self common.Address, input []byte) ([]byte, error)
+
+// NewStatefulPrecompile...
+func NewStatefulPrecompile(run StatefulPrecompfileFunc, requiredGas func([]byte) uint64) PrecompiledContract {
+	return statefulPrecompile{
+		gas: requiredGas,
+		run: run,
+	}
+}
+
+type statefulPrecompile struct {
+	gas func([]byte) uint64
+	run StatefulPrecompfileFunc
+}
+
+func (p statefulPrecompile) RequiredGas(input []byte) uint64 {
+	return p.gas(input)
+}
+
+func (p statefulPrecompile) Run([]byte) ([]byte, error) {
+	// https://google.github.io/styleguide/go/best-practices.html#when-to-panic
+	// This would indicate an API misuse and would occur in tests, not in
+	// production.
+	panic(fmt.Sprintf("BUG: call to %T.Run(); MUST call %T", p, p.run))
+}
+
+var (
+	// These lock in the assumptions made when implementing [evmCallArgs]. If
+	// these break then the struct fields SHOULD be changed to match these
+	// signatures.
+	_ = [](func(ContractRef, common.Address, []byte, uint64, *uint256.Int) ([]byte, uint64, error)){
+		(*EVM)(nil).Call,
+		(*EVM)(nil).CallCode,
+	}
+	_ = [](func(ContractRef, common.Address, []byte, uint64) ([]byte, uint64, error)){
+		(*EVM)(nil).DelegateCall,
+		(*EVM)(nil).StaticCall,
+	}
+)

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -16,6 +16,10 @@ import (
 	"golang.org/x/exp/rand"
 )
 
+func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
+	return (*evmCallArgs)(nil).RunPrecompiledContract(p, input, suppliedGas)
+}
+
 // precompileOverrides is a [params.RulesHooks] that overrides precompiles from
 // a map of predefined addresses.
 type precompileOverrides struct {

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -78,13 +78,9 @@ func TestPrecompileOverride(t *testing.T) {
 }
 
 func TestNewStatefulPrecompile(t *testing.T) {
-	var (
-		precompile common.Address
-		slot       common.Hash
-	)
-	rng := rand.New(rand.NewSource(314159))
-	rng.Read(precompile[:])
-	rng.Read(slot[:])
+	rng := ethtest.NewRand(314159)
+	precompile := rng.Address()
+	slot := rng.Hash()
 
 	const gasLimit = 1e6
 	gasCost := rng.Uint64n(gasLimit)
@@ -109,14 +105,9 @@ func TestNewStatefulPrecompile(t *testing.T) {
 	}
 	hooks.RegisterForRules(t)
 
-	var (
-		caller common.Address
-		input  = make([]byte, 8)
-		value  common.Hash
-	)
-	rng.Read(caller[:])
-	rng.Read(input)
-	rng.Read(value[:])
+	caller := rng.Address()
+	input := rng.Bytes(8)
+	value := rng.Hash()
 
 	state, evm := ethtest.NewZeroEVM(t)
 	state.SetState(precompile, slot, value)
@@ -130,13 +121,9 @@ func TestNewStatefulPrecompile(t *testing.T) {
 }
 
 func TestCanCreateContract(t *testing.T) {
-	var (
-		account common.Address
-		slot    common.Hash
-	)
-	rng := rand.New(rand.NewSource(142857))
-	rng.Read(account[:])
-	rng.Read(slot[:])
+	rng := ethtest.NewRand(142857)
+	account := rng.Address()
+	slot := rng.Hash()
 
 	makeErr := func(cc *libevm.ContractCreation, stateVal common.Hash) error {
 		return fmt.Errorf("Origin: %v Caller: %v Contract: %v State: %v", cc.Origin, cc.Caller, cc.Contract, stateVal)
@@ -148,17 +135,11 @@ func TestCanCreateContract(t *testing.T) {
 	}
 	hooks.RegisterForRules(t)
 
-	var (
-		origin, caller common.Address
-		value          common.Hash
-		code           = make([]byte, 8)
-		salt           [32]byte
-	)
-	rng.Read(origin[:])
-	rng.Read(caller[:])
-	rng.Read(value[:])
-	rng.Read(code)
-	rng.Read(salt[:])
+	origin := rng.Address()
+	caller := rng.Address()
+	value := rng.Hash()
+	code := rng.Bytes(8)
+	salt := rng.Hash()
 
 	create := crypto.CreateAddress(caller, 0)
 	create2 := crypto.CreateAddress2(caller, salt, crypto.Keccak256(code))

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -2,13 +2,14 @@ package vm
 
 import (
 	"fmt"
-	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/libevm"
+	"github.com/ethereum/go-ethereum/libevm/hookstest"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
@@ -16,24 +17,12 @@ import (
 	"golang.org/x/exp/rand"
 )
 
+// The original RunPrecompiledContract was migrated to being a method on
+// [evmCallArgs]. We need to replace it for use by regular geth tests.
 func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
 	return (*evmCallArgs)(nil).RunPrecompiledContract(p, input, suppliedGas)
 }
 
-// precompileOverrides is a [params.RulesHooks] that overrides precompiles from
-// a map of predefined addresses.
-type precompileOverrides struct {
-	contracts        map[common.Address]PrecompiledContract
-	params.NOOPHooks // all other hooks
-}
-
-func (o precompileOverrides) PrecompileOverride(a common.Address) (libevm.PrecompiledContract, bool) {
-	c, ok := o.contracts[a]
-	return c, ok
-}
-
-// A precompileStub is a [PrecompiledContract] that always returns the same
-// values.
 type precompileStub struct {
 	requiredGas uint64
 	returnData  []byte
@@ -73,21 +62,16 @@ func TestPrecompileOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			precompile := &precompileStub{
-				requiredGas: tt.requiredGas,
-				returnData:  tt.stubData,
-			}
-
-			params.TestOnlyClearRegisteredExtras()
-			params.RegisterExtras(params.Extras[params.NOOPHooks, precompileOverrides]{
-				NewRules: func(_ *params.ChainConfig, _ *params.Rules, _ *params.NOOPHooks, blockNum *big.Int, isMerge bool, timestamp uint64) *precompileOverrides {
-					return &precompileOverrides{
-						contracts: map[common.Address]PrecompiledContract{
-							tt.addr: precompile,
-						},
-					}
+			hooks := &hookstest.Stub{
+				PrecompileOverrides: map[common.Address]libevm.PrecompiledContract{
+					tt.addr: &precompileStub{
+						requiredGas: tt.requiredGas,
+						returnData:  tt.stubData,
+					},
 				},
-			})
+			}
+			params.TestOnlyClearRegisteredExtras()
+			hooks.RegisterForRules()
 
 			t.Run(fmt.Sprintf("%T.Call([overridden precompile address = %v])", &EVM{}, tt.addr), func(t *testing.T) {
 				gotData, gotGasLeft, err := newEVM(t).Call(AccountRef{}, tt.addr, nil, gasLimit, uint256.NewInt(0))
@@ -95,6 +79,101 @@ func TestPrecompileOverride(t *testing.T) {
 				assert.Equal(t, tt.stubData, gotData, "contract's return data")
 				assert.Equal(t, gasLimit-tt.requiredGas, gotGasLeft, "gas left")
 			})
+		})
+	}
+}
+
+func TestCanCreateContract(t *testing.T) {
+	// We need to prove end-to-end plumbing of contract-creation addresses,
+	// state, and any returned error. We therefore condition an error on a state
+	// value being set, and that error contains the addresses.
+	makeErr := func(cc *libevm.ContractCreation) error {
+		return fmt.Errorf("Origin: %v Caller: %v Contract: %v", cc.Origin, cc.Caller, cc.Contract)
+	}
+	slot := common.Hash(crypto.Keccak256([]byte("slot")))
+	value := common.Hash(crypto.Keccak256([]byte("value")))
+	hooks := &hookstest.Stub{
+		CanCreateContractFn: func(cc *libevm.ContractCreation, s libevm.StateReader) error {
+			if s.GetState(common.Address{}, slot).Cmp(value) != 0 {
+				return makeErr(cc)
+			}
+			return nil
+		},
+	}
+	params.TestOnlyClearRegisteredExtras()
+	hooks.RegisterForRules()
+
+	origin := common.Address{'o', 'r', 'i', 'g', 'i', 'n'}
+	caller := common.Address{'c', 'a', 'l', 'l', 'e', 'r'}
+	create := crypto.CreateAddress(caller, 0)
+	var (
+		code []byte
+		salt [32]byte
+	)
+	create2 := crypto.CreateAddress2(caller, salt, crypto.Keccak256(code))
+
+	tests := []struct {
+		name                          string
+		setState                      bool
+		wantCreateErr, wantCreate2Err error
+	}{
+		{
+			name:           "no state => return error",
+			setState:       false,
+			wantCreateErr:  makeErr(&libevm.ContractCreation{Origin: origin, Caller: caller, Contract: create}),
+			wantCreate2Err: makeErr(&libevm.ContractCreation{Origin: origin, Caller: caller, Contract: create2}),
+		},
+		{
+			name:     "state set => no error",
+			setState: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evm := newEVM(t)
+			evm.TxContext.Origin = origin
+
+			if tt.setState {
+				sdb := evm.StateDB.(*state.StateDB)
+				sdb.SetState(common.Address{}, slot, value)
+			}
+
+			methods := []struct {
+				name     string
+				deploy   func() ([]byte, common.Address, uint64, error)
+				wantErr  error
+				wantAddr common.Address
+			}{
+				{
+					name: "Create",
+					deploy: func() ([]byte, common.Address, uint64, error) {
+						return evm.Create(AccountRef(caller), code, 1e6, uint256.NewInt(0))
+					},
+					wantErr:  tt.wantCreateErr,
+					wantAddr: create,
+				},
+				{
+					name: "Create2",
+					deploy: func() ([]byte, common.Address, uint64, error) {
+						return evm.Create2(AccountRef(caller), code, 1e6, uint256.NewInt(0), new(uint256.Int).SetBytes(salt[:]))
+					},
+					wantErr:  tt.wantCreate2Err,
+					wantAddr: create2,
+				},
+			}
+
+			for _, m := range methods {
+				t.Run(m.name, func(t *testing.T) {
+					_, gotAddr, _, err := m.deploy()
+					if want := m.wantErr; want == nil {
+						require.NoError(t, err)
+						assert.Equal(t, m.wantAddr, gotAddr)
+					} else {
+						require.EqualError(t, err, want.Error())
+					}
+				})
+			}
 		})
 	}
 }
@@ -107,7 +186,8 @@ func newEVM(t *testing.T) *EVM {
 
 	return NewEVM(
 		BlockContext{
-			Transfer: func(_ StateDB, _, _ common.Address, _ *uint256.Int) {},
+			CanTransfer: func(_ StateDB, _ common.Address, _ *uint256.Int) bool { return true },
+			Transfer:    func(_ StateDB, _, _ common.Address, _ *uint256.Int) {},
 		},
 		TxContext{},
 		sdb,

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -1,14 +1,14 @@
-package vm
+package vm_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/libevm"
+	"github.com/ethereum/go-ethereum/libevm/ethtest"
 	"github.com/ethereum/go-ethereum/libevm/hookstest"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
@@ -16,12 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
-
-// The original RunPrecompiledContract was migrated to being a method on
-// [evmCallArgs]. We need to replace it for use by regular geth tests.
-func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
-	return (*evmCallArgs)(nil).RunPrecompiledContract(p, input, suppliedGas)
-}
 
 type precompileStub struct {
 	requiredGas uint64
@@ -51,7 +45,7 @@ func TestPrecompileOverride(t *testing.T) {
 	}
 
 	rng := rand.New(rand.NewSource(42))
-	for _, addr := range PrecompiledAddressesCancun {
+	for _, addr := range vm.PrecompiledAddressesCancun {
 		tests = append(tests, test{
 			name:        fmt.Sprintf("existing precompile %v", addr),
 			addr:        addr,
@@ -73,8 +67,9 @@ func TestPrecompileOverride(t *testing.T) {
 			params.TestOnlyClearRegisteredExtras()
 			hooks.RegisterForRules()
 
-			t.Run(fmt.Sprintf("%T.Call([overridden precompile address = %v])", &EVM{}, tt.addr), func(t *testing.T) {
-				gotData, gotGasLeft, err := newEVM(t).Call(AccountRef{}, tt.addr, nil, gasLimit, uint256.NewInt(0))
+			t.Run(fmt.Sprintf("%T.Call([overridden precompile address = %v])", &vm.EVM{}, tt.addr), func(t *testing.T) {
+				_, evm := ethtest.NewZeroEVM(t)
+				gotData, gotGasLeft, err := evm.Call(vm.AccountRef{}, tt.addr, nil, gasLimit, uint256.NewInt(0))
 				require.NoError(t, err)
 				assert.Equal(t, tt.stubData, gotData, "contract's return data")
 				assert.Equal(t, gasLimit-tt.requiredGas, gotGasLeft, "gas left")
@@ -102,6 +97,7 @@ func TestCanCreateContract(t *testing.T) {
 	}
 	params.TestOnlyClearRegisteredExtras()
 	hooks.RegisterForRules()
+	t.Cleanup(params.TestOnlyClearRegisteredExtras)
 
 	origin := common.Address{'o', 'r', 'i', 'g', 'i', 'n'}
 	caller := common.Address{'c', 'a', 'l', 'l', 'e', 'r'}
@@ -131,12 +127,11 @@ func TestCanCreateContract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			evm := newEVM(t)
+			stateDB, evm := ethtest.NewZeroEVM(t)
 			evm.TxContext.Origin = origin
 
 			if tt.setState {
-				sdb := evm.StateDB.(*state.StateDB)
-				sdb.SetState(common.Address{}, slot, value)
+				stateDB.SetState(common.Address{}, slot, value)
 			}
 
 			methods := []struct {
@@ -148,7 +143,7 @@ func TestCanCreateContract(t *testing.T) {
 				{
 					name: "Create",
 					deploy: func() ([]byte, common.Address, uint64, error) {
-						return evm.Create(AccountRef(caller), code, 1e6, uint256.NewInt(0))
+						return evm.Create(vm.AccountRef(caller), code, 1e6, uint256.NewInt(0))
 					},
 					wantErr:  tt.wantCreateErr,
 					wantAddr: create,
@@ -156,7 +151,7 @@ func TestCanCreateContract(t *testing.T) {
 				{
 					name: "Create2",
 					deploy: func() ([]byte, common.Address, uint64, error) {
-						return evm.Create2(AccountRef(caller), code, 1e6, uint256.NewInt(0), new(uint256.Int).SetBytes(salt[:]))
+						return evm.Create2(vm.AccountRef(caller), code, 1e6, uint256.NewInt(0), new(uint256.Int).SetBytes(salt[:]))
 					},
 					wantErr:  tt.wantCreate2Err,
 					wantAddr: create2,
@@ -176,22 +171,4 @@ func TestCanCreateContract(t *testing.T) {
 			}
 		})
 	}
-}
-
-func newEVM(t *testing.T) *EVM {
-	t.Helper()
-
-	sdb, err := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	require.NoError(t, err, "state.New()")
-
-	return NewEVM(
-		BlockContext{
-			CanTransfer: func(_ StateDB, _ common.Address, _ *uint256.Int) bool { return true },
-			Transfer:    func(_ StateDB, _, _ common.Address, _ *uint256.Int) {},
-		},
-		TxContext{},
-		sdb,
-		&params.ChainConfig{},
-		Config{},
-	)
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/libevm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
@@ -427,7 +428,8 @@ func (c *codeAndHash) Hash() common.Hash {
 
 // create creates a new contract using code as deployment code.
 func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *uint256.Int, address common.Address, typ OpCode) ([]byte, common.Address, uint64, error) {
-	if err := evm.chainRules.Hooks().CanCreateContract(caller.Address(), evm.Origin, evm.StateDB); err != nil {
+	cc := &libevm.ContractCreation{Origin: evm.Origin, Caller: caller.Address(), Contract: address}
+	if err := evm.chainRules.Hooks().CanCreateContract(cc, evm.StateDB); err != nil {
 		return nil, common.Address{}, gas, err
 	}
 	// Depth check execution. Fail if we're trying to execute above the

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -428,7 +428,7 @@ func (c *codeAndHash) Hash() common.Hash {
 
 // create creates a new contract using code as deployment code.
 func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *uint256.Int, address common.Address, typ OpCode) ([]byte, common.Address, uint64, error) {
-	cc := &libevm.ContractCreation{Origin: evm.Origin, Caller: caller.Address(), Contract: address}
+	cc := &libevm.AddressContext{Origin: evm.Origin, Caller: caller.Address(), Self: address}
 	if err := evm.chainRules.Hooks().CanCreateContract(cc, evm.StateDB); err != nil {
 		return nil, common.Address{}, gas, err
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -227,7 +227,8 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 
 	if isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas)
+		args := &evmCallArgs{evm, caller, addr, input, gas, value}
+		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -290,7 +291,8 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas)
+		args := &evmCallArgs{evm, caller, addr, input, gas, value}
+		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -335,7 +337,8 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas)
+		args := &evmCallArgs{evm, caller, addr, input, gas, nil}
+		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and make initialise the delegate values
@@ -384,7 +387,8 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas)
+		args := &evmCallArgs{evm, caller, addr, input, gas, nil}
+		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will
 		// leak the 'contract' to the outer scope, and make allocation for 'contract'
@@ -423,6 +427,9 @@ func (c *codeAndHash) Hash() common.Hash {
 
 // create creates a new contract using code as deployment code.
 func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *uint256.Int, address common.Address, typ OpCode) ([]byte, common.Address, uint64, error) {
+	if err := evm.chainRules.Hooks().CanCreateContract(caller.Address(), evm.Origin, evm.StateDB); err != nil {
+		return nil, common.Address{}, gas, err
+	}
 	// Depth check execution. Fail if we're trying to execute above the
 	// limit.
 	if evm.depth > int(params.CallCreateDepth) {

--- a/core/vm/libevm_test.go
+++ b/core/vm/libevm_test.go
@@ -1,0 +1,7 @@
+package vm
+
+// The original RunPrecompiledContract was migrated to being a method on
+// [evmCallArgs]. We need to replace it for use by regular geth tests.
+func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
+	return (*evmCallArgs)(nil).RunPrecompiledContract(p, input, suppliedGas)
+}

--- a/libevm/ethtest/evm.go
+++ b/libevm/ethtest/evm.go
@@ -1,17 +1,23 @@
+// Package ethtest provides utility functions for use in testing
+// Ethereum-related functionality.
 package ethtest
 
 import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
+// NewZeroEVM returns a new EVM backed by a [rawdb.NewMemoryDatabase]; all other
+// arguments to [vm.NewEVM] are the zero values of their respective types,
+// except for the use of [core.CanTransfer] and [core.Transfer] instead of nil
+// functions.
 func NewZeroEVM(tb testing.TB) (*state.StateDB, *vm.EVM) {
 	tb.Helper()
 
@@ -20,8 +26,8 @@ func NewZeroEVM(tb testing.TB) (*state.StateDB, *vm.EVM) {
 
 	return sdb, vm.NewEVM(
 		vm.BlockContext{
-			CanTransfer: func(_ vm.StateDB, _ common.Address, _ *uint256.Int) bool { return true },
-			Transfer:    func(_ vm.StateDB, _, _ common.Address, _ *uint256.Int) {},
+			CanTransfer: core.CanTransfer,
+			Transfer:    core.Transfer,
 		},
 		vm.TxContext{},
 		sdb,

--- a/libevm/ethtest/evm.go
+++ b/libevm/ethtest/evm.go
@@ -1,0 +1,31 @@
+package ethtest
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func NewZeroEVM(tb testing.TB) (*state.StateDB, *vm.EVM) {
+	tb.Helper()
+
+	sdb, err := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	require.NoError(tb, err, "state.New()")
+
+	return sdb, vm.NewEVM(
+		vm.BlockContext{
+			CanTransfer: func(_ vm.StateDB, _ common.Address, _ *uint256.Int) bool { return true },
+			Transfer:    func(_ vm.StateDB, _, _ common.Address, _ *uint256.Int) {},
+		},
+		vm.TxContext{},
+		sdb,
+		&params.ChainConfig{},
+		vm.Config{},
+	)
+}

--- a/libevm/ethtest/rand.go
+++ b/libevm/ethtest/rand.go
@@ -5,30 +5,36 @@ import (
 	"golang.org/x/exp/rand"
 )
 
-type Rand struct {
+// PseudoRand extends [rand.Rand] (*not* crypto/rand).
+type PseudoRand struct {
 	*rand.Rand
 }
 
-func NewRand(seed uint64) *Rand {
-	return &Rand{rand.New(rand.NewSource(seed))}
+// NewPseudoRand returns a new PseudoRand with the given seed.
+func NewPseudoRand(seed uint64) *PseudoRand {
+	return &PseudoRand{rand.New(rand.NewSource(seed))}
 }
 
-func (r *Rand) Address() (a common.Address) {
+// Address returns a pseudorandom address.
+func (r *PseudoRand) Address() (a common.Address) {
 	r.Read(a[:])
 	return a
 }
 
-func (r *Rand) AddressPtr() *common.Address {
+// AddressPtr returns a pointer to a pseudorandom address.
+func (r *PseudoRand) AddressPtr() *common.Address {
 	a := r.Address()
 	return &a
 }
 
-func (r *Rand) Hash() (h common.Hash) {
+// Hash returns a pseudorandom hash.
+func (r *PseudoRand) Hash() (h common.Hash) {
 	r.Read(h[:])
 	return h
 }
 
-func (r *Rand) Bytes(n uint) []byte {
+// Bytes returns `n` pseudorandom bytes.
+func (r *PseudoRand) Bytes(n uint) []byte {
 	b := make([]byte, n)
 	r.Read(b)
 	return b

--- a/libevm/ethtest/rand.go
+++ b/libevm/ethtest/rand.go
@@ -1,0 +1,35 @@
+package ethtest
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/exp/rand"
+)
+
+type Rand struct {
+	*rand.Rand
+}
+
+func NewRand(seed uint64) *Rand {
+	return &Rand{rand.New(rand.NewSource(seed))}
+}
+
+func (r *Rand) Address() (a common.Address) {
+	r.Read(a[:])
+	return a
+}
+
+func (r *Rand) AddressPtr() *common.Address {
+	a := r.Address()
+	return &a
+}
+
+func (r *Rand) Hash() (h common.Hash) {
+	r.Read(h[:])
+	return h
+}
+
+func (r *Rand) Bytes(n uint) []byte {
+	b := make([]byte, n)
+	r.Read(b)
+	return b
+}

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -2,6 +2,7 @@ package hookstest
 
 import (
 	"math/big"
+	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/libevm"
@@ -16,12 +17,14 @@ type Stub struct {
 	CanCreateContractFn     func(*libevm.ContractCreation, libevm.StateReader) error
 }
 
-func (s *Stub) RegisterForRules() {
+func (s *Stub) RegisterForRules(tb testing.TB) {
+	params.TestOnlyClearRegisteredExtras()
 	params.RegisterExtras(params.Extras[params.NOOPHooks, Stub]{
 		NewRules: func(_ *params.ChainConfig, _ *params.Rules, _ *params.NOOPHooks, blockNum *big.Int, isMerge bool, timestamp uint64) *Stub {
 			return s
 		},
 	})
+	tb.Cleanup(params.TestOnlyClearRegisteredExtras)
 }
 
 func (s Stub) PrecompileOverride(a common.Address) (libevm.PrecompiledContract, bool) {

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -1,3 +1,4 @@
+// Package hookstest provides test doubles for testing subsets of libevm hooks.
 package hookstest
 
 import (
@@ -10,13 +11,17 @@ import (
 )
 
 // A Stub is a test double for [params.ChainConfigHooks] and
-// [params.RulesHooks].
+// [params.RulesHooks]. Each of the fields, if non-nil, back their respective
+// hook methods, which otherwise fall back to the default behaviour.
 type Stub struct {
 	PrecompileOverrides     map[common.Address]libevm.PrecompiledContract
 	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
-	CanCreateContractFn     func(*libevm.ContractCreation, libevm.StateReader) error
+	CanCreateContractFn     func(*libevm.AddressContext, libevm.StateReader) error
 }
 
+// RegisterForRules clears any registered [params.Extras] and then registers s
+// as [params.RulesHooks], which are themselves cleared by the
+// [testing.TB.Cleanup] routine.
 func (s *Stub) RegisterForRules(tb testing.TB) {
 	params.TestOnlyClearRegisteredExtras()
 	params.RegisterExtras(params.Extras[params.NOOPHooks, Stub]{
@@ -42,7 +47,7 @@ func (s Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr 
 	return nil
 }
 
-func (s Stub) CanCreateContract(cc *libevm.ContractCreation, sr libevm.StateReader) error {
+func (s Stub) CanCreateContract(cc *libevm.AddressContext, sr libevm.StateReader) error {
 	if f := s.CanCreateContractFn; f != nil {
 		return f(cc, sr)
 	}

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -1,0 +1,52 @@
+package hookstest
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/libevm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// A Stub is a test double for [params.ChainConfigHooks] and
+// [params.RulesHooks].
+type Stub struct {
+	PrecompileOverrides     map[common.Address]libevm.PrecompiledContract
+	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
+	CanCreateContractFn     func(*libevm.ContractCreation, libevm.StateReader) error
+}
+
+func (s *Stub) RegisterForRules() {
+	params.RegisterExtras(params.Extras[params.NOOPHooks, Stub]{
+		NewRules: func(_ *params.ChainConfig, _ *params.Rules, _ *params.NOOPHooks, blockNum *big.Int, isMerge bool, timestamp uint64) *Stub {
+			return s
+		},
+	})
+}
+
+func (s Stub) PrecompileOverride(a common.Address) (libevm.PrecompiledContract, bool) {
+	if len(s.PrecompileOverrides) == 0 {
+		return nil, false
+	}
+	p, ok := s.PrecompileOverrides[a]
+	return p, ok
+}
+
+func (s Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr libevm.StateReader) error {
+	if f := s.CanExecuteTransactionFn; f != nil {
+		return f(from, to, sr)
+	}
+	return nil
+}
+
+func (s Stub) CanCreateContract(cc *libevm.ContractCreation, sr libevm.StateReader) error {
+	if f := s.CanCreateContractFn; f != nil {
+		return f(cc, sr)
+	}
+	return nil
+}
+
+var _ interface {
+	params.ChainConfigHooks
+	params.RulesHooks
+} = Stub{}

--- a/libevm/interfaces_test.go
+++ b/libevm/interfaces_test.go
@@ -5,8 +5,9 @@ import (
 	"github.com/ethereum/go-ethereum/libevm"
 )
 
-// These two interfaces MUST be identical. If this breaks then the libevm copy
-// MUST be updated.
+// IMPORTANT: if any of these break then the libevm copy MUST be updated.
+
+// These two interfaces MUST be identical.
 var (
 	// Each assignment demonstrates that the methods of the LHS interface are a
 	// (non-strict) subset of the RHS interface's; both being possible
@@ -14,3 +15,6 @@ var (
 	_ vm.PrecompiledContract     = (libevm.PrecompiledContract)(nil)
 	_ libevm.PrecompiledContract = (vm.PrecompiledContract)(nil)
 )
+
+// StateReader MUST be a subset vm.StateDB.
+var _ libevm.StateReader = (vm.StateDB)(nil)

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -39,3 +39,7 @@ type StateReader interface {
 	AddressInAccessList(addr common.Address) bool
 	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
 }
+
+type ContractCreation struct {
+	Origin, Caller, Contract common.Address
+}

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -40,6 +40,13 @@ type StateReader interface {
 	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
 }
 
-type ContractCreation struct {
-	Origin, Caller, Contract common.Address
+// AddressContext carries addresses available to contexts such as calls and
+// contract creation.
+//
+// With respect to contract creation, the Self address MAY be the predicted
+// address of the contract about to be deployed, which may not exist yet.
+type AddressContext struct {
+	Origin common.Address // equivalent to vm.ORIGIN op code
+	Caller common.Address // equivalent to vm.CALLER op code
+	Self   common.Address // equivalent to vm.ADDRESS op code
 }

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -1,9 +1,41 @@
 package libevm
 
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
 // PrecompiledContract is an exact copy of vm.PrecompiledContract, mirrored here
 // for instances where importing that package would result in a circular
 // dependency.
 type PrecompiledContract interface {
 	RequiredGas(input []byte) uint64
 	Run(input []byte) ([]byte, error)
+}
+
+// StateReader is a subset of vm.StateDB, exposing only methods that read from
+// but do not modify state. See method comments in vm.StateDB, which aren't
+// copied here as they risk becoming outdated.
+type StateReader interface {
+	GetBalance(common.Address) *uint256.Int
+	GetNonce(common.Address) uint64
+
+	GetCodeHash(common.Address) common.Hash
+	GetCode(common.Address) []byte
+	GetCodeSize(common.Address) int
+
+	GetRefund() uint64
+
+	GetCommittedState(common.Address, common.Hash) common.Hash
+	GetState(common.Address, common.Hash) common.Hash
+
+	GetTransientState(addr common.Address, key common.Hash) common.Hash
+
+	HasSelfDestructed(common.Address) bool
+
+	Exist(common.Address) bool
+	Empty(common.Address) bool
+
+	AddressInAccessList(addr common.Address) bool
+	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
 }

--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -63,8 +63,8 @@ func RegisterExtras[C ChainConfigHooks, R RulesHooks](e Extras[C, R]) ExtraPaylo
 // [RegisterExtras]. It panics if called from a non-testing call stack.
 //
 // In tests it SHOULD be called before every call to [RegisterExtras] and then
-// defer-called afterwards. This is a workaround for the single-call limitation
-// on [RegisterExtras].
+// defer-called afterwards, either directly or via testing.TB.Cleanup(). This is
+// a workaround for the single-call limitation on [RegisterExtras].
 func TestOnlyClearRegisteredExtras() {
 	pc := make([]uintptr, 10)
 	runtime.Callers(0, pc)

--- a/params/example.libevm_test.go
+++ b/params/example.libevm_test.go
@@ -105,7 +105,7 @@ func (r RulesExtra) PrecompileOverride(addr common.Address) (_ libevm.Precompile
 // CanCreateContract implements the required [params.RuleHooks] method. Access
 // to state allows it to be configured on-chain however this is an optional
 // implementation detail.
-func (r RulesExtra) CanCreateContract(*libevm.ContractCreation, libevm.StateReader) error {
+func (r RulesExtra) CanCreateContract(*libevm.AddressContext, libevm.StateReader) error {
 	if time.Unix(int64(r.timestamp), 0).UTC().Day() != int(time.Tuesday) {
 		return errors.New("uh oh!")
 	}

--- a/params/example.libevm_test.go
+++ b/params/example.libevm_test.go
@@ -105,7 +105,7 @@ func (r RulesExtra) PrecompileOverride(addr common.Address) (_ libevm.Precompile
 // CanCreateContract implements the required [params.RuleHooks] method. Access
 // to state allows it to be configured on-chain however this is an optional
 // implementation detail.
-func (r RulesExtra) CanCreateContract(caller, origin common.Address, _ libevm.StateReader) error {
+func (r RulesExtra) CanCreateContract(*libevm.ContractCreation, libevm.StateReader) error {
 	if time.Unix(int64(r.timestamp), 0).UTC().Day() != int(time.Tuesday) {
 		return errors.New("uh oh!")
 	}

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -19,7 +19,7 @@ type ChainConfigHooks interface{}
 // RulesHooks are required for all types registered as [Extras] for [Rules]
 // payloads.
 type RulesHooks interface {
-	CanExecuteTransaction(from, to common.Address, _ libevm.StateReader) error
+	CanExecuteTransaction(from common.Address, to *common.Address, _ libevm.StateReader) error
 	CanCreateContract(caller, origin common.Address, _ libevm.StateReader) error
 	// PrecompileOverride signals whether or not the EVM interpreter MUST
 	// override its treatment of the address when deciding if it is a
@@ -60,7 +60,7 @@ var _ interface {
 	RulesHooks
 } = NOOPHooks{}
 
-func (NOOPHooks) CanExecuteTransaction(_, _ common.Address, _ libevm.StateReader) error {
+func (NOOPHooks) CanExecuteTransaction(_ common.Address, _ *common.Address, _ libevm.StateReader) error {
 	return nil
 }
 

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -19,8 +19,7 @@ type ChainConfigHooks interface{}
 // RulesHooks are required for all types registered as [Extras] for [Rules]
 // payloads.
 type RulesHooks interface {
-	CanExecuteTransaction(from common.Address, to *common.Address, _ libevm.StateReader) error
-	CanCreateContract(*libevm.ContractCreation, libevm.StateReader) error
+	RulesAllowlistHooks
 	// PrecompileOverride signals whether or not the EVM interpreter MUST
 	// override its treatment of the address when deciding if it is a
 	// precompiled contract. If PrecompileOverride returns `true` then the
@@ -28,6 +27,13 @@ type RulesHooks interface {
 	// [PrecompiledContract] is non-nil. If it returns `false` then the default
 	// precompile behaviour is honoured.
 	PrecompileOverride(common.Address) (_ libevm.PrecompiledContract, override bool)
+}
+
+// RulesAllowlistHooks are a subset of [RulesHooks] that gate actions, signalled
+// by returning a nil (allowed) or non-nil (blocked) error.
+type RulesAllowlistHooks interface {
+	CanCreateContract(*libevm.AddressContext, libevm.StateReader) error
+	CanExecuteTransaction(from common.Address, to *common.Address, _ libevm.StateReader) error
 }
 
 // Hooks returns the hooks registered with [RegisterExtras], or [NOOPHooks] if
@@ -60,11 +66,13 @@ var _ interface {
 	RulesHooks
 } = NOOPHooks{}
 
+// CanExecuteTransaction allows all (otherwise valid) transactions.
 func (NOOPHooks) CanExecuteTransaction(_ common.Address, _ *common.Address, _ libevm.StateReader) error {
 	return nil
 }
 
-func (NOOPHooks) CanCreateContract(*libevm.ContractCreation, libevm.StateReader) error {
+// CanCreateContract allows all (otherwise valid) contract deployment.
+func (NOOPHooks) CanCreateContract(*libevm.AddressContext, libevm.StateReader) error {
 	return nil
 }
 

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -20,7 +20,7 @@ type ChainConfigHooks interface{}
 // payloads.
 type RulesHooks interface {
 	CanExecuteTransaction(from common.Address, to *common.Address, _ libevm.StateReader) error
-	CanCreateContract(caller, origin common.Address, _ libevm.StateReader) error
+	CanCreateContract(*libevm.ContractCreation, libevm.StateReader) error
 	// PrecompileOverride signals whether or not the EVM interpreter MUST
 	// override its treatment of the address when deciding if it is a
 	// precompiled contract. If PrecompileOverride returns `true` then the
@@ -64,7 +64,7 @@ func (NOOPHooks) CanExecuteTransaction(_ common.Address, _ *common.Address, _ li
 	return nil
 }
 
-func (NOOPHooks) CanCreateContract(_, _ common.Address, _ libevm.StateReader) error {
+func (NOOPHooks) CanCreateContract(*libevm.ContractCreation, libevm.StateReader) error {
 	return nil
 }
 

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -9,9 +9,18 @@ import (
 // [ChainConfig] payloads.
 type ChainConfigHooks interface{}
 
+// TODO(arr4n): given the choice of whether a hook should be defined on a
+// ChainConfig or on the Rules, what are the guiding principles? A ChainConfig
+// carries the most general information while Rules benefit from "knowing" the
+// block number and timestamp. I am leaning towards the default choice being
+// on Rules (as it's trivial to copy information from ChainConfig to Rules in
+// [Extras.NewRules]) unless the call site only has access to a ChainConfig.
+
 // RulesHooks are required for all types registered as [Extras] for [Rules]
 // payloads.
 type RulesHooks interface {
+	CanExecuteTransaction(from, to common.Address, _ libevm.StateReader) error
+	CanCreateContract(caller, origin common.Address, _ libevm.StateReader) error
 	// PrecompileOverride signals whether or not the EVM interpreter MUST
 	// override its treatment of the address when deciding if it is a
 	// precompiled contract. If PrecompileOverride returns `true` then the
@@ -50,6 +59,14 @@ var _ interface {
 	ChainConfigHooks
 	RulesHooks
 } = NOOPHooks{}
+
+func (NOOPHooks) CanExecuteTransaction(_, _ common.Address, _ libevm.StateReader) error {
+	return nil
+}
+
+func (NOOPHooks) CanCreateContract(_, _ common.Address, _ libevm.StateReader) error {
+	return nil
+}
 
 // PrecompileOverride instructs the EVM interpreter to use the default
 // precompile behaviour.


### PR DESCRIPTION
## Why this should be merged

Introduces:

1. Stateful precompiles
2. `CanExecuteTransaction` and `CanCreateContract` hooks (equivalent to `subnet-evm` allowlists).
  a. Although this makes for a larger PR than I'd have liked, I thought it was important to demonstrate how the equivalent `ava-labs/subnet-evm` functionality can be achieved.

## How this works

### Hooks

`CanExecuteTransaction()` is called from `core.StateTransition.TransitionDb()` and `CanCreateContract()` is called from `vm.EVM.create()` (the common path for `EVM.Create()` and `EVM.Create2()`). If they return nil then functionality continues as normal, otherwise their errors are propagated.

### Stateful precompiles

The PR introduces into `core/vm`:

```go
type vm.StatefulPrecompileRun func(...) ...
// and
func NewStatefulPrecompile(StatefulPrecompileRun, ...) PrecompiledContract
```

Note that the constructor returns the same _interface_ as ordinary precompiles, allowing the returned value to use regular geth plumbing (including the existing `PrecompileOverride` hook). However, the _concrete type_ that it returns has special-case handling when running precompiles.

## How this was tested

Both hooks result in _unhappy_ paths when working correctly so their integration tests assert the equality of returned _errors_, which carry all externally injected arguments to demonstrate correct plumbing. `CanExecuteTransaction` is tested via `core.ApplyMessage()` while `CanCreateContract` is tested via `EVM.Create()` and `EVM.Create2()`.

Stateful precompiles have integration tests exercised via the `PrecompileOverride` hook and `vm.EVM.Call()`, also demonstrating full plumbing of arguments.

The `hookstest` package is introduced to simplify registration of hooks for testing.