### PR TITLE
feat!: `params.RulesHooks.CanExecuteTransaction()` receives EIP-2930 access list

### DIFF
--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -1,9 +1,11 @@
 package core
 
+import "github.com/ethereum/go-ethereum/libevm/as"
+
 // canExecuteTransaction is a convenience wrapper for calling the
 // [params.RulesHooks.CanExecuteTransaction] hook.
 func (st *StateTransition) canExecuteTransaction() error {
 	bCtx := st.evm.Context
 	rules := st.evm.ChainConfig().Rules(bCtx.BlockNumber, bCtx.Random != nil, bCtx.Time)
-	return rules.Hooks().CanExecuteTransaction(st.msg.From, st.msg.To, st.state)
+	return rules.Hooks().CanExecuteTransaction(st.msg.From, st.msg.To, as.LibEVMAccessList(st.msg.AccessList), st.state)
 }

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/libevm"
+	"github.com/ethereum/go-ethereum/libevm/as"
 	"github.com/ethereum/go-ethereum/libevm/ethtest"
 	"github.com/ethereum/go-ethereum/libevm/hookstest"
 	"github.com/stretchr/testify/require"
@@ -17,12 +19,12 @@ func TestCanExecuteTransaction(t *testing.T) {
 	account := rng.Address()
 	slot := rng.Hash()
 
-	makeErr := func(from common.Address, to *common.Address, val common.Hash) error {
-		return fmt.Errorf("From: %v To: %v State: %v", from, to, val)
+	makeErr := func(from common.Address, to *common.Address, l libevm.AccessList, val common.Hash) error {
+		return fmt.Errorf("From: %v To: %v AccessList: %+v State: %v", from, to, l, val)
 	}
 	hooks := &hookstest.Stub{
-		CanExecuteTransactionFn: func(from common.Address, to *common.Address, s libevm.StateReader) error {
-			return makeErr(from, to, s.GetState(account, slot))
+		CanExecuteTransactionFn: func(from common.Address, to *common.Address, l libevm.AccessList, s libevm.StateReader) error {
+			return makeErr(from, to, l, s.GetState(account, slot))
 		},
 	}
 	hooks.RegisterForRules(t)
@@ -34,7 +36,17 @@ func TestCanExecuteTransaction(t *testing.T) {
 	msg := &core.Message{
 		From: rng.Address(),
 		To:   rng.AddressPtr(),
+		AccessList: types.AccessList{
+			{
+				Address:     rng.Address(),
+				StorageKeys: []common.Hash{rng.Hash(), rng.Hash()},
+			},
+			{
+				Address:     rng.Address(),
+				StorageKeys: []common.Hash{rng.Hash()},
+			},
+		},
 	}
 	_, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(30e6))
-	require.EqualError(t, err, makeErr(msg.From, msg.To, value).Error())
+	require.EqualError(t, err, makeErr(msg.From, msg.To, as.LibEVMAccessList(msg.AccessList), value).Error())
 }

--- a/libevm/as/access_tuple_test.go
+++ b/libevm/as/access_tuple_test.go
@@ -1,0 +1,79 @@
+package as_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/libevm"
+	"github.com/ethereum/go-ethereum/libevm/as"
+	"github.com/ethereum/go-ethereum/libevm/ethtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzAccessTupleIdentity(f *testing.F) {
+	{
+		// Before fuzzing, demonstrate easy-to-catch differences between types.
+		// If any of these fail then libevm.Access{List,Tuple} MUST be updated.
+		var (
+			gethVal   types.AccessTuple
+			libevmVal libevm.AccessTuple
+			// If the AccessTuple types are identical then so too are the
+			// AccessList slices.
+			_ []types.AccessTuple  = types.AccessList{}
+			_ []libevm.AccessTuple = libevm.AccessList{}
+		)
+
+		gethT := reflect.TypeOf(gethVal)
+		libevmT := reflect.TypeOf(libevmVal)
+		require.Equal(f, gethT.NumField(), libevmT.NumField(), "number of struct fields")
+
+		for i := 0; i < gethT.NumField(); i++ {
+			gethFld := gethT.Field(i).Type
+			libevmFld := libevmT.Field(i).Type
+			assert.Equalf(f, gethFld, libevmFld, "struct field %d reflect.Types", i)
+		}
+		if f.Failed() {
+			return
+		}
+	}
+
+	for i := uint64(0); i < 10; i++ {
+		f.Add(i)
+	}
+	f.Fuzz(func(t *testing.T, seed uint64) {
+		rng := ethtest.NewPseudoRand(seed)
+		addr := rng.Address()
+		keys := make([]common.Hash, rng.Intn(50))
+		for i := range keys {
+			keys[i] = rng.Hash()
+		}
+
+		gethVal := types.AccessTuple{
+			Address:     addr,
+			StorageKeys: keys,
+		}
+		libevmVal := libevm.AccessTuple{
+			Address:     addr,
+			StorageKeys: keys,
+		}
+
+		// Using pointer conversion via unsafe demonstrates equivalent memory
+		// layout.
+		testConversion(t, libevmVal, gethVal, as.GethAccessTuple)
+		testConversion(t, gethVal, libevmVal, as.LibEVMAccessTuple)
+
+		libList := libevm.AccessList{libevmVal}
+		gethList := types.AccessList{gethVal}
+		testConversion(t, libList, gethList, as.GethAccessList)
+		testConversion(t, gethList, libList, as.LibEVMAccessList)
+	})
+}
+
+func testConversion[From any, To any](t *testing.T, from From, want To, conv func(From) To) {
+	t.Helper()
+	got := conv(from)
+	assert.Equalf(t, want, got, "conversion from %T to %T", from, want)
+}

--- a/libevm/as/access_tuple_test.go
+++ b/libevm/as/access_tuple_test.go
@@ -60,13 +60,10 @@ func FuzzAccessTupleIdentity(f *testing.F) {
 			StorageKeys: keys,
 		}
 
-		// Using pointer conversion via unsafe demonstrates equivalent memory
-		// layout.
 		testConversion(t, libevmVal, gethVal, as.GethAccessTuple)
 		testConversion(t, gethVal, libevmVal, as.LibEVMAccessTuple)
-
-		libList := libevm.AccessList{libevmVal}
-		gethList := types.AccessList{gethVal}
+		libList := libevm.AccessList{libevmVal, libevmVal}
+		gethList := types.AccessList{gethVal, gethVal}
 		testConversion(t, libList, gethList, as.GethAccessList)
 		testConversion(t, gethList, libList, as.LibEVMAccessList)
 	})

--- a/libevm/as/as.go
+++ b/libevm/as/as.go
@@ -15,18 +15,22 @@ import (
 	"github.com/ethereum/go-ethereum/libevm"
 )
 
+// GethAccessList converts the libevm AccessList to its geth equivalent.
 func GethAccessList(l libevm.AccessList) types.AccessList {
 	return *convert[libevm.AccessList, types.AccessList](&l)
 }
 
+// LibEVMAccessList converts the geth AccessList to its libevm equivalent.
 func LibEVMAccessList(l types.AccessList) libevm.AccessList {
 	return *convert[types.AccessList, libevm.AccessList](&l)
 }
 
+// GethAccessTuple converts the libevm AccessTuple to its geth equivalent.
 func GethAccessTuple(t libevm.AccessTuple) types.AccessTuple {
 	return *convert[libevm.AccessTuple, types.AccessTuple](&t)
 }
 
+// LibEVMAccessTuple converts the geth AccessTuple to its libevm equivalent.
 func LibEVMAccessTuple(t types.AccessTuple) libevm.AccessTuple {
 	return *convert[types.AccessTuple, libevm.AccessTuple](&t)
 }

--- a/libevm/as/as.go
+++ b/libevm/as/as.go
@@ -1,0 +1,39 @@
+// Package as converts between native Ethereum types and their libevm
+// equivalents.
+//
+// All functions are named for their returned type, not their input, to improve
+// readability at the call site:
+//
+//	list := as.GethAccessList(...) // list is a geth-native AccessList
+//	list := as.LibEVMAccessList(...) // list is a libevm AccessList mirror
+package as
+
+import (
+	"unsafe"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/libevm"
+)
+
+func GethAccessList(l libevm.AccessList) types.AccessList {
+	return *convert[libevm.AccessList, types.AccessList](&l)
+}
+
+func LibEVMAccessList(l types.AccessList) libevm.AccessList {
+	return *convert[types.AccessList, libevm.AccessList](&l)
+}
+
+func GethAccessTuple(t libevm.AccessTuple) types.AccessTuple {
+	return *convert[libevm.AccessTuple, types.AccessTuple](&t)
+}
+
+func LibEVMAccessTuple(t types.AccessTuple) libevm.AccessTuple {
+	return *convert[types.AccessTuple, libevm.AccessTuple](&t)
+}
+
+// convert uses [unsafe.Pointer] type conversion as allowed by Pattern (1) of
+// its documentation. Any converter using convert MUST have extensive tests in
+// place to prove identity of the two types.
+func convert[T any, U any](v *T) *U {
+	return (*U)(unsafe.Pointer(v))
+}

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -15,7 +15,7 @@ import (
 // hook methods, which otherwise fall back to the default behaviour.
 type Stub struct {
 	PrecompileOverrides     map[common.Address]libevm.PrecompiledContract
-	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
+	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.AccessList, libevm.StateReader) error
 	CanCreateContractFn     func(*libevm.AddressContext, libevm.StateReader) error
 }
 
@@ -40,9 +40,9 @@ func (s Stub) PrecompileOverride(a common.Address) (libevm.PrecompiledContract, 
 	return p, ok
 }
 
-func (s Stub) CanExecuteTransaction(from common.Address, to *common.Address, sr libevm.StateReader) error {
+func (s Stub) CanExecuteTransaction(from common.Address, to *common.Address, al libevm.AccessList, sr libevm.StateReader) error {
 	if f := s.CanExecuteTransactionFn; f != nil {
-		return f(from, to, sr)
+		return f(from, to, al, sr)
 	}
 	return nil
 }

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -5,9 +5,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// PrecompiledContract is an exact copy of vm.PrecompiledContract, mirrored here
-// for instances where importing that package would result in a circular
-// dependency.
+// PrecompiledContract is an exact copy of vm.PrecompiledContract.
 type PrecompiledContract interface {
 	RequiredGas(input []byte) uint64
 	Run(input []byte) ([]byte, error)
@@ -49,4 +47,13 @@ type AddressContext struct {
 	Origin common.Address // equivalent to vm.ORIGIN op code
 	Caller common.Address // equivalent to vm.CALLER op code
 	Self   common.Address // equivalent to vm.ADDRESS op code
+}
+
+// AccessList is an exact copy of types.AccessList.
+type AccessList []AccessTuple
+
+// AccessTuple is an exact copy of types.AccessTuple.
+type AccessTuple struct {
+	Address     common.Address
+	StorageKeys []common.Hash
 }

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -33,7 +33,7 @@ type RulesHooks interface {
 // by returning a nil (allowed) or non-nil (blocked) error.
 type RulesAllowlistHooks interface {
 	CanCreateContract(*libevm.AddressContext, libevm.StateReader) error
-	CanExecuteTransaction(from common.Address, to *common.Address, _ libevm.StateReader) error
+	CanExecuteTransaction(from common.Address, to *common.Address, _ libevm.AccessList, _ libevm.StateReader) error
 }
 
 // Hooks returns the hooks registered with [RegisterExtras], or [NOOPHooks] if
@@ -67,7 +67,7 @@ var _ interface {
 } = NOOPHooks{}
 
 // CanExecuteTransaction allows all (otherwise valid) transactions.
-func (NOOPHooks) CanExecuteTransaction(_ common.Address, _ *common.Address, _ libevm.StateReader) error {
+func (NOOPHooks) CanExecuteTransaction(_ common.Address, _ *common.Address, _ libevm.AccessList, _ libevm.StateReader) error {
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged

Adds support for predicate validation.

## How this works

The `CanExecuteTransaction` hook is updated to accept an access list. This necessitated the introduction of `libevm.AccessList` and `libevm.AccessTuple` mirrors of the geth equivalents in `core/types`; a type-conversion package is therefore included too.

## How this was tested

The existing integration test was updated to demonstrate plumbing of the `AccessList`.