### PR TITLE
feat: `params.ChainConfig` extra payload can use root JSON

### DIFF
--- a/params/config.libevm_test.go
+++ b/params/config.libevm_test.go
@@ -104,8 +104,6 @@ func TestRegisterExtras(t *testing.T) {
 			require.NoError(t, json.Unmarshal(buf, got))
 			assert.Equal(t, tt.ccExtra.Interface(), got.extraPayload().Interface())
 			assert.Equal(t, in, got)
-			// TODO: do we need an explicit test of the JSON output, or is a
-			// Marshal-Unmarshal round trip sufficient?
 
 			gotRules := got.Rules(nil, false, 0)
 			assert.Equal(t, tt.wantRulesExtra, gotRules.extraPayload().Interface())

--- a/params/json.libevm.go
+++ b/params/json.libevm.go
@@ -1,0 +1,119 @@
+package params
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/libevm/pseudo"
+)
+
+var _ interface {
+	json.Marshaler
+	json.Unmarshaler
+} = (*ChainConfig)(nil)
+
+// chainConfigWithoutMethods avoids infinite recurion into
+// [ChainConfig.UnmarshalJSON].
+type chainConfigWithoutMethods ChainConfig
+
+// chainConfigWithExportedExtra supports JSON (un)marshalling of a [ChainConfig]
+// while exposing the `extra` field as the "extra" JSON key.
+type chainConfigWithExportedExtra struct {
+	*chainConfigWithoutMethods              // embedded to achieve regular JSON unmarshalling
+	Extra                      *pseudo.Type `json:"extra"` // `c.extra` is otherwise unexported
+}
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
+func (c *ChainConfig) UnmarshalJSON(data []byte) error {
+	extras := registeredExtras
+
+	if extras != nil && !extras.reuseJSONRoot {
+		return c.unmarshalJSONWithExtra(data)
+	}
+
+	if err := json.Unmarshal(data, (*chainConfigWithoutMethods)(c)); err != nil {
+		return err
+	}
+	if extras == nil {
+		return nil
+	}
+
+	// Invariants if here:
+	// - reg.reuseJSONRoot == true
+	// - Non-extra ChainConfig fields already unmarshalled
+
+	c.extra = extras.chainConfig.NilPointer()
+	if err := json.Unmarshal(data, c.extra); err != nil {
+		c.extra = nil
+		return err
+	}
+	return nil
+}
+
+// unmarshalJSONWithExtra unmarshals JSON under the assumption that the
+// registered [Extras] payload is in the JSON "extra" key. All other
+// unmarshalling is performed as if no [Extras] were registered.
+func (c *ChainConfig) unmarshalJSONWithExtra(data []byte) error {
+	cc := &chainConfigWithExportedExtra{
+		chainConfigWithoutMethods: (*chainConfigWithoutMethods)(c),
+		Extra:                     registeredExtras.chainConfig.NilPointer(),
+	}
+	if err := json.Unmarshal(data, cc); err != nil {
+		return err
+	}
+	c.extra = cc.Extra
+	return nil
+}
+
+// MarshalJSON implements the [json.Marshaler] interface.
+func (c *ChainConfig) MarshalJSON() ([]byte, error) {
+	switch extras := registeredExtras; {
+	case extras == nil:
+		return json.Marshal((*chainConfigWithoutMethods)(c))
+
+	case !extras.reuseJSONRoot:
+		return c.marshalJSONWithExtra()
+
+	default:
+		// The inverse of reusing the JSON root is merging two JSON buffers,
+		// which isn't supported by the native package. So we use
+		// map[string]json.RawMessage intermediates.
+		geth, err := toJSONRawMessages((*chainConfigWithoutMethods)(c))
+		if err != nil {
+			return nil, err
+		}
+		extra, err := toJSONRawMessages(c.extra)
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range extra {
+			if _, ok := geth[k]; ok {
+				return nil, fmt.Errorf("duplicate JSON key %q in both %T and registered extra", k, c)
+			}
+			geth[k] = v
+		}
+		return json.Marshal(geth)
+	}
+}
+
+// marshalJSONWithExtra is the inverse of unmarshalJSONWithExtra().
+func (c *ChainConfig) marshalJSONWithExtra() ([]byte, error) {
+	cc := &chainConfigWithExportedExtra{
+		chainConfigWithoutMethods: (*chainConfigWithoutMethods)(c),
+		Extra:                     c.extra,
+	}
+	return json.Marshal(cc)
+}
+
+func toJSONRawMessages(v any) (map[string]json.RawMessage, error) {
+	buf, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	msgs := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(buf, &msgs); err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}

--- a/params/json.libevm_test.go
+++ b/params/json.libevm_test.go
@@ -1,0 +1,99 @@
+package params
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/libevm/pseudo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type nestedChainConfigExtra struct {
+	NestedFoo string `json:"foo"`
+
+	NOOPHooks
+}
+
+type rootJSONChainConfigExtra struct {
+	TopLevelFoo string `json:"foo"`
+
+	NOOPHooks
+}
+
+func TestChainConfigJSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		register  func()
+		jsonInput string
+		want      *ChainConfig
+	}{
+		{
+			name:     "no registered extras",
+			register: func() {},
+			jsonInput: `{
+				"chainId": 1234
+			}`,
+			want: &ChainConfig{
+				ChainID: big.NewInt(1234),
+			},
+		},
+		{
+			name: "reuse top-level JSON",
+			register: func() {
+				RegisterExtras(Extras[rootJSONChainConfigExtra, NOOPHooks]{
+					ReuseJSONRoot: true,
+				})
+			},
+			jsonInput: `{
+				"chainId": 5678,
+				"foo": "hello"
+			}`,
+			want: &ChainConfig{
+				ChainID: big.NewInt(5678),
+				extra:   pseudo.From(&rootJSONChainConfigExtra{TopLevelFoo: "hello"}).Type,
+			},
+		},
+		{
+			name: "nested JSON",
+			register: func() {
+				RegisterExtras(Extras[nestedChainConfigExtra, NOOPHooks]{
+					ReuseJSONRoot: false, // explicit zero value only for tests
+				})
+			},
+			jsonInput: `{
+				"chainId": 42,
+				"extra": {"foo": "world"}
+			}`,
+			want: &ChainConfig{
+				ChainID: big.NewInt(42),
+				extra:   pseudo.From(&nestedChainConfigExtra{NestedFoo: "world"}).Type,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			TestOnlyClearRegisteredExtras()
+			t.Cleanup(TestOnlyClearRegisteredExtras)
+			tt.register()
+
+			t.Run("json.Unmarshal()", func(t *testing.T) {
+				got := new(ChainConfig)
+				require.NoError(t, json.Unmarshal([]byte(tt.jsonInput), got))
+				assert.Equal(t, tt.want, got)
+			})
+
+			t.Run("json.Marshal()", func(t *testing.T) {
+				var want bytes.Buffer
+				require.NoError(t, json.Compact(&want, []byte(tt.jsonInput)), "json.Compact()")
+
+				got, err := json.Marshal(tt.want)
+				require.NoError(t, err)
+				assert.Equal(t, want.String(), string(got))
+			})
+		})
+	}
+}

--- a/params/json.libevm_test.go
+++ b/params/json.libevm_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/libevm/pseudo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -83,7 +82,7 @@ func TestChainConfigJSONRoundTrip(t *testing.T) {
 			t.Run("json.Unmarshal()", func(t *testing.T) {
 				got := new(ChainConfig)
 				require.NoError(t, json.Unmarshal([]byte(tt.jsonInput), got))
-				assert.Equal(t, tt.want, got)
+				require.Equal(t, tt.want, got)
 			})
 
 			t.Run("json.Marshal()", func(t *testing.T) {
@@ -91,8 +90,8 @@ func TestChainConfigJSONRoundTrip(t *testing.T) {
 				require.NoError(t, json.Compact(&want, []byte(tt.jsonInput)), "json.Compact()")
 
 				got, err := json.Marshal(tt.want)
-				require.NoError(t, err)
-				assert.Equal(t, want.String(), string(got))
+				require.NoError(t, err, "json.Marshal()")
+				require.Equal(t, want.String(), string(got))
 			})
 		})
 	}


### PR DESCRIPTION
## Why this should be merged

Adds support for backwards compatibility with JSON format of `ava-labs/{subnet-evm,coreth}/params.ChainConfig`.

## How this works

The `params.Extras.ReuseJSONRoot bool` flag is added to allow the end user to signal the need for backwards compatibility. This isn't the default because of the need for multi-pass (un)marshalling.

For extra payload:

```go
type ChainConfigExtra struct {
  Foo string `json:"foo"`
}
//...
params.RegisterExtras(Extras[ChainConfigExtra,...]{
  ReuseJSONRoot: ...
})
```

`ReuseJSONRoot == false` => 

```json
{
  "chainId": 42,
  "extra": {"foo": "bar"}
}
```

`ReuseJSONRoot == true` => 

```json
{
  "chainId": 42,
  "foo": "bar"
}
```

## How this was tested

Unit tests for JSON (un)marshalling  for all cases; i.e when:

1. No registered extras: plain JSON (un)marshalling;
2. Flag not set: as before this PR, "promoting" the `extra` field to be exported with the `json: "extra"` tag; and
3. Flag set: feature added in this PR.