### PR TITLE
feat: `hookstest.Register()`

### DIFF
--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -25,7 +25,7 @@ func TestCanExecuteTransaction(t *testing.T) {
 			return makeErr(from, to, s.GetState(account, slot))
 		},
 	}
-	hooks.RegisterForRules(t)
+	hooks.Register(t)
 
 	value := rng.Hash()
 

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -64,7 +64,7 @@ func TestPrecompileOverride(t *testing.T) {
 					},
 				},
 			}
-			hooks.RegisterForRules(t)
+			hooks.Register(t)
 
 			t.Run(fmt.Sprintf("%T.Call([overridden precompile address = %v])", &vm.EVM{}, tt.addr), func(t *testing.T) {
 				_, evm := ethtest.NewZeroEVM(t)
@@ -103,7 +103,7 @@ func TestNewStatefulPrecompile(t *testing.T) {
 			),
 		},
 	}
-	hooks.RegisterForRules(t)
+	hooks.Register(t)
 
 	caller := rng.Address()
 	input := rng.Bytes(8)
@@ -133,7 +133,7 @@ func TestCanCreateContract(t *testing.T) {
 			return makeErr(cc, s.GetState(account, slot))
 		},
 	}
-	hooks.RegisterForRules(t)
+	hooks.Register(t)
 
 	origin := rng.Address()
 	caller := rng.Address()


### PR DESCRIPTION
## Why this should be merged

Provides general support for registering `params.Extras` for the lifetime of a single test.

## How this works

Instead of calling `params.RegisterExtras()`, tests SHOULD call `hookstest.Register()`. Other than accepting a `testing.TB`, the syntax is identical.

> [!NOTE]
> This will clear any existing `Extras` registered in `init()` functions. Tests MUST therefore not make any assumptions about existing registration.

## How this was tested

Existing tests. The functionality was abstracted out of code already under test.