### PR TITLE
fix: run flaky upstream tests sequentially

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Run tests
         run: | # Upstream flakes are race conditions exacerbated by concurrent tests
           FLAKY_REGEX='go-ethereum/(eth|accounts/keystore|eth/downloader|miner)$';
-          go test -short $(go list ./... | grep -Pv "${FLAKY_REGEX}");
           go list ./... | grep -P "${FLAKY_REGEX}" | xargs -n 1 go test -short;
+          go test -short $(go list ./... | grep -Pv "${FLAKY_REGEX}");

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,4 +17,7 @@ jobs:
         with:
           go-version: 1.21.4
       - name: Run tests
-        run: go test -short $(go list ./... | grep -Pv 'go-ethereum/(accounts/keystore|eth/downloader|miner)$')
+        run: | # Upstream flakes are race conditions exacerbated by concurrent tests
+          FLAKY_REGEX='go-ethereum/(eth|accounts/keystore|eth/downloader|miner)$';
+          go test -short $(go list ./... | grep -Pv "${FLAKY_REGEX}");
+          go list ./... | grep -P "${FLAKY_REGEX}" | xargs -n 1 go test -short;


### PR DESCRIPTION
## Why this should be merged

Some upstream tests are flaky and had been disabled. Others required multiple CI runs until green. This (should) address the problem while allowing all tests to be run.

Fixes #10 

## How this works

The flakes are race conditions, exacerbated by tests being run concurrently (higher load). The flaky tests are excluded from the primary run and are instead run sequentially; this is done first so they can fail quickly and allow a CI re-run without waiting ~5 minutes for the regular tests to pass.

## How this was tested

CI trial and error.