### PR TITLE
chore: workflow to print diffs vs `libevm-base` tag

### DIFF
--- a/.github/workflows/diff_from_libevm-base.sh
+++ b/.github/workflows/diff_from_libevm-base.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -ux;
+set -eux;
 
-git checkout "${1}";
+git checkout "${1}" --;
 git diff --diff-filter=a --word-diff --unified=0 libevm-base.."${1}" \
     ':(exclude).golangci.yml' \
     ':(exclude).github/**';

--- a/.github/workflows/diff_from_libevm-base.sh
+++ b/.github/workflows/diff_from_libevm-base.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -eux;
-
-git checkout "${1}" --;
-git diff --diff-filter=a --word-diff --unified=0 libevm-base.."${1}" \
-    ':(exclude).golangci.yml' \
-    ':(exclude).github/**';

--- a/.github/workflows/diff_from_libevm-base.sh
+++ b/.github/workflows/diff_from_libevm-base.sh
@@ -2,6 +2,7 @@
 
 set -u;
 
+git checkout "${1}";
 git diff --diff-filter=a --word-diff --unified=0 libevm-base.."${1}" \
     ':(exclude).golangci.yml' \
-    ':(exclude).github/**'
+    ':(exclude).github/**';

--- a/.github/workflows/diff_from_libevm-base.sh
+++ b/.github/workflows/diff_from_libevm-base.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -u;
+set -ux;
 
 git checkout "${1}";
 git diff --diff-filter=a --word-diff --unified=0 libevm-base.."${1}" \

--- a/.github/workflows/diff_from_libevm-base.sh
+++ b/.github/workflows/diff_from_libevm-base.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -u;
+
+git diff --diff-filter=a --word-diff --unified=0 libevm-base.."${1}" \
+    ':(exclude).golangci.yml' \
+    ':(exclude).github/**'

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
-      - name: Diff libevm-base..[workflow trigger sha]
-        run: |
-          .github/workflows/diff_from_libevm-base.sh ${{ github.sha }}
       - name: Diff libevm-base..libevm
         run: |
           .github/workflows/diff_from_libevm-base.sh libevm
+      - name: Diff libevm-base..HEAD
+        run: |
+          .github/workflows/diff_from_libevm-base.sh HEAD

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -15,16 +15,17 @@ jobs:
         with:
           fetch-depth: 0 # everything
           fetch-tags: true
-      - name: Diff libevm-base..libevm
+      
+      - name: git diff libevm-base
+        run: |
+          git diff --diff-filter=a --word-diff --unified=0 libevm-base \
+            ':(exclude).golangci.yml' \
+            ':(exclude).github/**';
+      
+      - name: git diff libevm-base..libevm
         run: |
           git checkout libevm --;
           git diff --diff-filter=a --word-diff --unified=0 libevm-base..libevm \
             ':(exclude).golangci.yml' \
             ':(exclude).github/**';
 
-      - name: Diff libevm-base..${{ github.ref_name }}
-        run: |
-          git checkout ${{ github.ref }} --;
-          git diff --diff-filter=a --word-diff --unified=0 libevm-base..${{ github.ref }} \
-            ':(exclude).golangci.yml' \
-            ':(exclude).github/**';

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -1,0 +1,20 @@
+name: libevm delta
+
+on:
+  push:
+    branches: [ libevm ]
+  pull_request:
+    branches: [ libevm ]
+  workflow_dispatch:
+
+jobs:
+  go_test_short:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Diff libevm-base..HEAD
+        run: |
+          .github/workflows/diff_from_libevm-base.sh HEAD
+      - name: Diff libevm-base..libevm
+        run: |
+          .github/workflows/diff_from_libevm-base.sh libevm

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Diff libevm-base..${{ github.ref_name }}
         run: |
-          git checkout ${{ github.ref_name }} --;
-          git diff --diff-filter=a --word-diff --unified=0 libevm-base..${{ github.ref_name }} \
+          git checkout ${{ github.ref }} --;
+          git diff --diff-filter=a --word-diff --unified=0 libevm-base..${{ github.ref }} \
             ':(exclude).golangci.yml' \
             ':(exclude).github/**';

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -18,14 +18,16 @@ jobs:
       
       - name: git diff libevm-base
         run: |
-          git diff --diff-filter=a --word-diff --unified=0 libevm-base \
+          git diff --diff-filter=a --word-diff --unified=0 --color=always \
+            libevm-base \
             ':(exclude).golangci.yml' \
             ':(exclude).github/**';
       
       - name: git diff libevm-base..libevm
         run: |
           git checkout libevm --;
-          git diff --diff-filter=a --word-diff --unified=0 libevm-base..libevm \
+          git diff --diff-filter=a --word-diff --unified=0 --color=always \
+            libevm-base \
             ':(exclude).golangci.yml' \
             ':(exclude).github/**';
 

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -17,7 +17,14 @@ jobs:
           fetch-tags: true
       - name: Diff libevm-base..libevm
         run: |
-          .github/workflows/diff_from_libevm-base.sh libevm
+          git checkout libevm --;
+          git diff --diff-filter=a --word-diff --unified=0 libevm-base..libevm \
+            ':(exclude).golangci.yml' \
+            ':(exclude).github/**';
+
       - name: Diff libevm-base..${{ github.ref_name }}
         run: |
-          .github/workflows/diff_from_libevm-base.sh ${{ github.ref_name }}
+          git checkout ${{ github.ref_name }} --;
+          git diff --diff-filter=a --word-diff --unified=0 libevm-base..${{ github.ref_name }} \
+            ':(exclude).golangci.yml' \
+            ':(exclude).github/**';

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  go_test_short:
+  diffs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Diff libevm-base..HEAD
+      - name: Diff libevm-base..{github.ref_name}
         run: |
-          .github/workflows/diff_from_libevm-base.sh HEAD
+          .github/workflows/diff_from_libevm-base.sh ${{ github.ref_name }}
       - name: Diff libevm-base..libevm
         run: |
           .github/workflows/diff_from_libevm-base.sh libevm

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Diff libevm-base..libevm
         run: |
           .github/workflows/diff_from_libevm-base.sh libevm
-      - name: Diff libevm-base..HEAD
+      - name: Diff libevm-base..${{ github.sha }}
         run: |
-          .github/workflows/diff_from_libevm-base.sh HEAD
+          .github/workflows/diff_from_libevm-base.sh ${{ github.sha }}

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0 # everything
           fetch-tags: true
       - name: Diff libevm-base..libevm
         run: |

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Diff libevm-base..[workflow trigger sha]
         run: |
           .github/workflows/diff_from_libevm-base.sh ${{ github.sha }}

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Diff libevm-base..libevm
         run: |
           .github/workflows/diff_from_libevm-base.sh libevm
-      - name: Diff libevm-base..${{ github.sha }}
+      - name: Diff libevm-base..${{ github.ref_name }}
         run: |
-          .github/workflows/diff_from_libevm-base.sh ${{ github.sha }}
+          .github/workflows/diff_from_libevm-base.sh ${{ github.ref_name }}

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -16,6 +16,11 @@ jobs:
           fetch-depth: 0 # everything
           fetch-tags: true
       
+      - name: Color-blindness a11y
+        run: | # https://davidmathlogic.com/colorblind/#%23D81B60-%231E88E5-%23FFC107-%23004D40:~:text=8%20pairs%20of%20contrasting%20colors
+          git config color.diff.old "#DC3220";
+          git config color.diff.new "#005AB5";
+
       - name: git diff libevm-base
         run: |
           git diff --diff-filter=a --word-diff --unified=0 --color=always \

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Diff libevm-base..{github.ref_name}
+      - name: Diff libevm-base..[workflow trigger sha]
         run: |
-          .github/workflows/diff_from_libevm-base.sh ${{ github.ref_name }}
+          .github/workflows/diff_from_libevm-base.sh ${{ github.sha }}
       - name: Diff libevm-base..libevm
         run: |
           .github/workflows/diff_from_libevm-base.sh libevm


### PR DESCRIPTION
## Why this should be merged

Provides an [objective measure of the diff against geth](https://github.com/ava-labs/go-ethereum/actions/runs/10838423867/job/30076597924?pr=18#step:4:1).

![image](https://github.com/user-attachments/assets/d26923c8-9906-45e4-9f88-7a3bee50a942)

## How this works

- `--diff-filter=a` excludes additions (i.e. libevm-specific files), leaving only modifications, deletions, etc.
- `--word-diff` fine-grained diff instead of per-line
- `--unified=0` removes context, which is noisy when viewing the diff as a whole

The `libevm-base` tag MUST now always track the geth version from which the current version of libevm diverges. This workflow performs a diff `libevm-base..HEAD` (i.e. diff if the PR is merged) and `libevm-base..libevm` (i.e. the current status quo).

In the future we can look at performing a "diff of diffs" and warn if a PR increases destructive changes. Basic [+x -y] stats could also be extracted.

## How this was tested

Pain and suffering (look at the commit history).
