### PR TITLE
feat: read-only stateful precompiles

### DIFF
--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -118,9 +118,7 @@ func (args *evmCallArgs) Rules() params.Rules { return args.evm.chainRules }
 
 func (args *evmCallArgs) ReadOnly() bool {
 	if args.readWrite == inheritReadOnly {
-		// The verbose `if true { return true }` pattern allows better
-		// inspection of code coverage.
-		if args.evm.interpreter.readOnly {
+		if args.evm.interpreter.readOnly { //nolint:gosimple // Clearer code coverage for difficult-to-test branch
 			return true
 		}
 		return false

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -32,10 +32,11 @@ type evmCallArgs struct {
 	value  *uint256.Int
 	// args:end
 
-	// evm.interpreter.readOnly is only set in a call to EVMInterpreter.Run().
-	// If a precompile is called directly with StaticCall() then it won't have
-	// been set yet. StaticCall() MUST set this to true and all others to false;
-	// i.e. the same boolean passed to EVMInterpreter.Run().
+	// evm.interpreter.readOnly is only set to true via a call to
+	// EVMInterpreter.Run() so, if a precompile is called directly with
+	// StaticCall(), then readOnly might not be set yet. StaticCall() MUST set
+	// this to true and all other methods MUST set it to false; i.e. the same
+	// boolean as they each pass to EVMInterpreter.Run().
 	forceReadOnly bool
 }
 
@@ -90,6 +91,18 @@ type PrecompileEnvironment interface {
 	ReadOnlyState() libevm.StateReader
 	Addresses() *libevm.AddressContext
 }
+
+//
+// ****** SECURITY ******
+//
+// If you are updating PrecompileEnvironment to provide the ability to call back
+// into another contract, you MUST revisit the evmCallArgs.forceReadOnly flag.
+//
+// It is possible that forceReadOnly is true but evm.interpreter.readOnly is
+// false. This is safe for now, but may not be if recursive calling *from* a
+// precompile is enabled.
+//
+// ****** SECURITY ******
 
 var _ PrecompileEnvironment = (*evmCallArgs)(nil)
 

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/libevm"
 	"github.com/ethereum/go-ethereum/libevm/ethtest"
 	"github.com/ethereum/go-ethereum/libevm/hookstest"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 type precompileStub struct {
@@ -95,9 +94,10 @@ func TestNewStatefulPrecompile(t *testing.T) {
 	hooks := &hookstest.Stub{
 		PrecompileOverrides: map[common.Address]libevm.PrecompiledContract{
 			precompile: vm.NewStatefulPrecompile(
-				func(env vm.PrecompileEnvironment, _ *params.Rules, caller, self common.Address, input []byte) ([]byte, error) {
+				func(env vm.PrecompileEnvironment, input []byte) ([]byte, error) {
+					addrs := env.Addresses()
 					val := env.StateDB().GetState(precompile, slot)
-					return makeOutput(caller, self, input, val, env.ReadOnly()), nil
+					return makeOutput(addrs.Caller, addrs.Self, input, val, env.ReadOnly()), nil
 				},
 				func(b []byte) uint64 {
 					return gasCost

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -228,7 +228,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 
 	if isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, value, false /*forceReadOnly*/}
+		args := &evmCallArgs{evm, caller, addr, input, gas, value, inheritReadOnly}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -292,7 +292,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, value, false /*forceReadOnly*/}
+		args := &evmCallArgs{evm, caller, addr, input, gas, value, inheritReadOnly}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -338,7 +338,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, nil, false /*forceReadOnly*/}
+		args := &evmCallArgs{evm, caller, addr, input, gas, nil, inheritReadOnly}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -388,7 +388,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, nil, true /*forceReadOnly*/}
+		args := &evmCallArgs{evm, caller, addr, input, gas, nil, forceReadOnly}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -228,7 +228,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 
 	if isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, value}
+		args := &evmCallArgs{evm, caller, addr, input, gas, value, false /*forceReadOnly*/}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -292,7 +292,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, value}
+		args := &evmCallArgs{evm, caller, addr, input, gas, value, false /*forceReadOnly*/}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -338,7 +338,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, nil}
+		args := &evmCallArgs{evm, caller, addr, input, gas, nil, false /*forceReadOnly*/}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -388,7 +388,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, nil}
+		args := &evmCallArgs{evm, caller, addr, input, gas, nil, true /*forceReadOnly*/}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will


### PR DESCRIPTION
## Why this should be merged

Adds support for signalling to a stateful precompile that it's running in a read-only context.

## How this works

The `vm.PrecompiledStatefulRun` function signature was becoming bloated so everything except for `input []byte` has been collapsed into a `vm.PrecompileEnvironment`. Using a single argument also means that future features won't be breaking changes. A `ReadOnly() bool` method is available from the `env`. I called it an environment and not a context so that the idiomatic variable name can be `env` and not `ctx`.

Both a `StateDB() vm.StateDB` and a `ReadOnlyState() libevm.StateReader` are available from an `env`. The read-only version never returns nil while the full `StateDB()` method returns a non-nil state _iff_ not in a read-only state (i.e. when `ReadOnly()` returns `false`). Without this, it would be too easy for a precompile implementation to forget to check `ReadOnly()` before writing to state.

## How this was tested

A precompile is in a read-only state when there is at least one `STATICCALL` in the callstack that led to it being run. This can happen when either (a) there is a _direct_ `vm.EVM.StaticCall()` to the precompile or; (b) there is a `StaticCall()` to some _other_ contract that later calls the precompile via any `*CALL*` op code.

Scenario (a) is tested by extending the existing `TestNewStatefulPrecompile` test. Scenario (b) is more complex but thoroughly documented in `TestPrecompileFromReadOnlyState`.