### PR TITLE
refactor!: gas consumption for stateful precompiles

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -174,8 +174,7 @@ func (args *evmCallArgs) RunPrecompiledContract(p PrecompiledContract, input []b
 		return nil, 0, ErrOutOfGas
 	}
 	suppliedGas -= gasCost
-	output, err := args.run(p, input)
-	return output, suppliedGas, err
+	return args.run(p, input, suppliedGas)
 }
 
 // ECRECOVER implemented as a native contract.

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -50,42 +50,39 @@ const (
 
 // run runs the [PrecompiledContract], differentiating between stateful and
 // regular types.
-func (args *evmCallArgs) run(p PrecompiledContract, input []byte) (ret []byte, err error) {
+func (args *evmCallArgs) run(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
 	if p, ok := p.(statefulPrecompile); ok {
-		return p.run(args, input)
+		return p(args, input, suppliedGas)
 	}
-	return p.Run(input)
+	// Gas consumption for regular precompiles was already handled by the native
+	// RunPrecompiledContract(), which called this method.
+	ret, err = p.Run(input)
+	return ret, suppliedGas, err
 }
 
-// PrecompiledStatefulRun is the stateful equivalent of the Run() method of a
+// PrecompiledStatefulContract is the stateful equivalent of a
 // [PrecompiledContract].
-type PrecompiledStatefulRun func(env PrecompileEnvironment, input []byte) ([]byte, error)
+type PrecompiledStatefulContract func(env PrecompileEnvironment, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error)
 
 // NewStatefulPrecompile constructs a new PrecompiledContract that can be used
 // via an [EVM] instance but MUST NOT be called directly; a direct call to Run()
 // reserves the right to panic. See other requirements defined in the comments
 // on [PrecompiledContract].
-func NewStatefulPrecompile(run PrecompiledStatefulRun, requiredGas func([]byte) uint64) PrecompiledContract {
-	return statefulPrecompile{
-		gas: requiredGas,
-		run: run,
-	}
+func NewStatefulPrecompile(run PrecompiledStatefulContract) PrecompiledContract {
+	return statefulPrecompile(run)
 }
 
-type statefulPrecompile struct {
-	gas func([]byte) uint64
-	run PrecompiledStatefulRun
-}
+type statefulPrecompile PrecompiledStatefulContract
 
-func (p statefulPrecompile) RequiredGas(input []byte) uint64 {
-	return p.gas(input)
-}
+// RequiredGas always returns zero as this gas is consumed before the contract
+// is run.
+func (p statefulPrecompile) RequiredGas(input []byte) uint64 { return 0 }
 
 func (p statefulPrecompile) Run([]byte) ([]byte, error) {
 	// https://google.github.io/styleguide/go/best-practices.html#when-to-panic
 	// This would indicate an API misuse and would occur in tests, not in
 	// production.
-	panic(fmt.Sprintf("BUG: call to %T.Run(); MUST call %T", p, p.run))
+	panic(fmt.Sprintf("BUG: call to %T.Run(); MUST call %T itself", p, p))
 }
 
 // A PrecompileEnvironment provides information about the context in which a

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -76,7 +76,7 @@ type statefulPrecompile PrecompiledStatefulContract
 
 // RequiredGas always returns zero as this gas is consumed before the contract
 // is run.
-func (p statefulPrecompile) RequiredGas(input []byte) uint64 { return 0 }
+func (statefulPrecompile) RequiredGas([]byte) uint64 { return 0 }
 
 func (p statefulPrecompile) Run([]byte) ([]byte, error) {
 	// https://google.github.io/styleguide/go/best-practices.html#when-to-panic

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -72,10 +72,14 @@ func NewStatefulPrecompile(run PrecompiledStatefulContract) PrecompiledContract 
 	return statefulPrecompile(run)
 }
 
+// statefulPrecompile implements the [PrecompiledContract] interface to allow a
+// [PrecompiledStatefulContract] to be carried with regular geth plumbing. The
+// methods are defined on this unexported type instead of directly on
+// [PrecompiledStatefulContract] to hide implementation details.
 type statefulPrecompile PrecompiledStatefulContract
 
-// RequiredGas always returns zero as this gas is consumed before the contract
-// is run.
+// RequiredGas always returns zero as this gas is consumed by native geth code
+// before the contract is run.
 func (statefulPrecompile) RequiredGas([]byte) uint64 { return 0 }
 
 func (p statefulPrecompile) Run([]byte) ([]byte, error) {


### PR DESCRIPTION
## Why this should be merged

Support simultaneous running of a stateful precompile and computation of its gas consumption.

Closes #17. Re the `Caution` in said issue, the 63/64 rule is already handled by geth.

## How this works

The `requiredGas func(...)` argument of `NewStatefulPrecompile()` is removed. In its place, the function signature of a stateful precompile accepts supplied gas and returns gas remaining; this was renamed from `PrecompiledStatefulRun` to `PrecompiledStatefulContract` as it's no longer just the execution.

```go
type PrecompiledStatefulContract func(env PrecompileEnvironment, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error)
```

## How this was tested

Existing unit tests for stateful precompiles, refactored accordingly.