### PR TITLE
feat: `vm.MutableStack` wrapper

### DIFF
--- a/core/vm/stack.libevm.go
+++ b/core/vm/stack.libevm.go
@@ -1,0 +1,14 @@
+package vm
+
+import "github.com/holiman/uint256"
+
+// A MutableStack embeds a Stack to expose unexported mutation methods.
+type MutableStack struct {
+	*Stack
+}
+
+// Push pushes a value to the stack.
+func (s MutableStack) Push(d *uint256.Int) { s.Stack.push(d) }
+
+// Pop pops a value from the stack.
+func (s MutableStack) Pop() uint256.Int { return s.Stack.pop() }

--- a/core/vm/stack.libevm_test.go
+++ b/core/vm/stack.libevm_test.go
@@ -1,0 +1,27 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+func TestMutableStack(t *testing.T) {
+	s := &vm.Stack{}
+	m := vm.MutableStack{Stack: s}
+
+	push := func(u uint64) uint256.Int {
+		u256 := uint256.NewInt(u)
+		m.Push(u256)
+		return *u256
+	}
+
+	require.Len(t, s.Data(), 0)
+	want := []uint256.Int{push(42), push(314159), push(142857)}
+	require.Equalf(t, want, s.Data(), "after pushing %d values to empty stack", len(want))
+	require.Equal(t, want[len(want)-1], m.Pop(), "popped value")
+	require.Equal(t, want[:len(want)-1], s.Data(), "after popping a single value")
+}

--- a/core/vm/stack.libevm_test.go
+++ b/core/vm/stack.libevm_test.go
@@ -19,7 +19,7 @@ func TestMutableStack(t *testing.T) {
 		return *u256
 	}
 
-	require.Len(t, s.Data(), 0)
+	require.Empty(t, s.Data(), "new stack")
 	want := []uint256.Int{push(42), push(314159), push(142857)}
 	require.Equalf(t, want, s.Data(), "after pushing %d values to empty stack", len(want))
 	require.Equal(t, want[len(want)-1], m.Pop(), "popped value")


### PR DESCRIPTION
## Why this should be merged

Provides access to unexported stack-manipulation methods required for #22.

## How this works

By embedding a `*vm.Stack` in the new type, `Push()` and `Pop()` are exposed.

## How this was tested

Unit test.