### PR TITLE
feat: `PrecompileEnvironment.ChainConfig()`

### DIFF
--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -94,6 +94,7 @@ func (p statefulPrecompile) Run([]byte) ([]byte, error) {
 // A PrecompileEnvironment provides information about the context in which a
 // precompiled contract is being run.
 type PrecompileEnvironment interface {
+	ChainConfig() *params.ChainConfig
 	Rules() params.Rules
 	ReadOnly() bool
 	// StateDB will be non-nil i.f.f !ReadOnly().
@@ -121,7 +122,8 @@ type PrecompileEnvironment interface {
 
 var _ PrecompileEnvironment = (*evmCallArgs)(nil)
 
-func (args *evmCallArgs) Rules() params.Rules { return args.evm.chainRules }
+func (args *evmCallArgs) ChainConfig() *params.ChainConfig { return args.evm.chainConfig }
+func (args *evmCallArgs) Rules() params.Rules              { return args.evm.chainRules }
 
 func (args *evmCallArgs) ReadOnly() bool {
 	if args.readWrite == inheritReadOnly {


### PR DESCRIPTION
## Why this should be merged

Makes `params.ChainConfig` available to a stateful precompile.

## How this works

New method on `PrecompileEnvironment`, following the same approach as plumbing other values.

## How this was tested

Confirm plumbing of `ChainID` through existing integration test. To allow this, a new `ethtest.EVMOption` is added to allow setting of the `ChainConfig`.