### PR TITLE
feat: override vm.NewEVM() args

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -143,6 +143,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 			blockCtx.BlobBaseFee = new(big.Int)
 		}
 	}
+	blockCtx, txCtx, statedb, chainConfig, config = overrideNewEVMArgs(blockCtx, txCtx, statedb, chainConfig, config)
 	evm := &EVM{
 		Context:     blockCtx,
 		TxContext:   txCtx,

--- a/core/vm/evm.libevm_test.go
+++ b/core/vm/evm.libevm_test.go
@@ -27,6 +27,7 @@ func TestOverrideNewEVMArgs(t *testing.T) {
 	const chainID = 13579
 	libevmHooks = nil
 	RegisterHooks(chainIDOverrider{chainID: chainID})
+	defer func() { libevmHooks = nil }()
 
 	got := NewEVM(BlockContext{}, TxContext{}, nil, nil, Config{}).ChainConfig().ChainID
 	require.Equal(t, big.NewInt(chainID), got)

--- a/core/vm/evm.libevm_test.go
+++ b/core/vm/evm.libevm_test.go
@@ -1,0 +1,32 @@
+package vm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+type chainIDOverrider struct {
+	chainID int64
+}
+
+func (o chainIDOverrider) OverrideNewEVMArgs(BlockContext, TxContext, StateDB, *params.ChainConfig, Config) (BlockContext, TxContext, StateDB, *params.ChainConfig, Config) {
+	return BlockContext{}, TxContext{}, nil, &params.ChainConfig{ChainID: big.NewInt(o.chainID)}, Config{}
+}
+
+func TestOverrideNewEVMArgs(t *testing.T) {
+	// The OverrideNewEVMArgs hook accepts and returns all arguments to
+	// NewEVM(), in order. Here we lock in our assumption of that order. If this
+	// breaks then the Hooks.OverrideNewEVMArgs() signature MUST be changed to
+	// match.
+	var _ func(BlockContext, TxContext, StateDB, *params.ChainConfig, Config) *EVM = NewEVM
+
+	const chainID = 13579
+	libevmHooks = nil
+	RegisterHooks(chainIDOverrider{chainID: chainID})
+
+	got := NewEVM(BlockContext{}, TxContext{}, nil, nil, Config{}).ChainConfig().ChainID
+	require.Equal(t, big.NewInt(chainID), got)
+}

--- a/core/vm/evm.libevm_test.go
+++ b/core/vm/evm.libevm_test.go
@@ -12,15 +12,15 @@ type chainIDOverrider struct {
 	chainID int64
 }
 
-func (o chainIDOverrider) OverrideNewEVMArgs(BlockContext, TxContext, StateDB, *params.ChainConfig, Config) (BlockContext, TxContext, StateDB, *params.ChainConfig, Config) {
-	return BlockContext{}, TxContext{}, nil, &params.ChainConfig{ChainID: big.NewInt(o.chainID)}, Config{}
+func (o chainIDOverrider) OverrideNewEVMArgs(args *NewEVMArgs) *NewEVMArgs {
+	args.ChainConfig = &params.ChainConfig{ChainID: big.NewInt(o.chainID)}
+	return args
 }
 
 func TestOverrideNewEVMArgs(t *testing.T) {
-	// The OverrideNewEVMArgs hook accepts and returns all arguments to
+	// The overrideNewEVMArgs function accepts and returns all arguments to
 	// NewEVM(), in order. Here we lock in our assumption of that order. If this
-	// breaks then the Hooks.OverrideNewEVMArgs() signature MUST be changed to
-	// match.
+	// breaks then all functionality overriding the args MUST be updated.
 	var _ func(BlockContext, TxContext, StateDB, *params.ChainConfig, Config) *EVM = NewEVM
 
 	const chainID = 13579

--- a/core/vm/evm.libevm_test.go
+++ b/core/vm/evm.libevm_test.go
@@ -4,8 +4,9 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/params"
 )
 
 type chainIDOverrider struct {

--- a/core/vm/hooks.libevm.go
+++ b/core/vm/hooks.libevm.go
@@ -15,7 +15,16 @@ var libevmHooks Hooks
 
 // Hooks are arbitrary configuration functions to modify default VM behaviour.
 type Hooks interface {
-	OverrideNewEVMArgs(BlockContext, TxContext, StateDB, *params.ChainConfig, Config) (BlockContext, TxContext, StateDB, *params.ChainConfig, Config)
+	OverrideNewEVMArgs(*NewEVMArgs) *NewEVMArgs
+}
+
+// NewEVMArgs are the arguments received by [NewEVM], available for override.
+type NewEVMArgs struct {
+	BlockContext BlockContext
+	TxContext    TxContext
+	StateDB      StateDB
+	ChainConfig  *params.ChainConfig
+	Config       Config
 }
 
 func overrideNewEVMArgs(
@@ -28,5 +37,6 @@ func overrideNewEVMArgs(
 	if libevmHooks == nil {
 		return blockCtx, txCtx, statedb, chainConfig, config
 	}
-	return libevmHooks.OverrideNewEVMArgs(blockCtx, txCtx, statedb, chainConfig, config)
+	args := libevmHooks.OverrideNewEVMArgs(&NewEVMArgs{blockCtx, txCtx, statedb, chainConfig, config})
+	return args.BlockContext, args.TxContext, args.StateDB, args.ChainConfig, args.Config
 }

--- a/core/vm/hooks.libevm.go
+++ b/core/vm/hooks.libevm.go
@@ -1,0 +1,32 @@
+package vm
+
+import "github.com/ethereum/go-ethereum/params"
+
+// RegisterHooks registers the Hooks. It is expected to be called in an `init()`
+// function and MUST NOT be called more than once.
+func RegisterHooks(h Hooks) {
+	if libevmHooks != nil {
+		panic("already registered")
+	}
+	libevmHooks = h
+}
+
+var libevmHooks Hooks
+
+// Hooks are arbitrary configuration functions to modify default VM behaviour.
+type Hooks interface {
+	OverrideNewEVMArgs(BlockContext, TxContext, StateDB, *params.ChainConfig, Config) (BlockContext, TxContext, StateDB, *params.ChainConfig, Config)
+}
+
+func overrideNewEVMArgs(
+	blockCtx BlockContext,
+	txCtx TxContext,
+	statedb StateDB,
+	chainConfig *params.ChainConfig,
+	config Config,
+) (BlockContext, TxContext, StateDB, *params.ChainConfig, Config) {
+	if libevmHooks == nil {
+		return blockCtx, txCtx, statedb, chainConfig, config
+	}
+	return libevmHooks.OverrideNewEVMArgs(blockCtx, txCtx, statedb, chainConfig, config)
+}


### PR DESCRIPTION
## Why this should be merged

Overriding of `StateDB` upon instantiation of a new `EVM` instance.

## How this works

`vm.Hooks.OverrideNewEVMArgs()`, if registered, intercepts the arguments to `NewEVM()`. It MAY reflect arguments unchanged, or modify them as desired.

## How this was tested

Integration test demonstrating construction of a new `*vm.EVM` having the chain ID modified.