### PR TITLE
feat: override `EVM.Reset()` args

### DIFF
--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
+
 package vm
 
 import (

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -159,8 +159,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 // Reset resets the EVM with a new transaction context.Reset
 // This is not threadsafe and should only be done very cautiously.
 func (evm *EVM) Reset(txCtx TxContext, statedb StateDB) {
-	evm.TxContext = txCtx
-	evm.StateDB = statedb
+	evm.TxContext, evm.StateDB = overrideEVMResetArgs(txCtx, statedb)
 }
 
 // Cancel cancels any running EVM operation. This may be called concurrently and

--- a/core/vm/stack.libevm.go
+++ b/core/vm/stack.libevm.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
+
 package vm
 
 import "github.com/holiman/uint256"


### PR DESCRIPTION
## Why this should be merged

Similar rationale to hook that overrides `NewEVM()` args (#35).

## How this works

As above.

The empty lines between the copyright headers and the `package vm` statements are to stop `godoc` from interpreting the headers as package comments.

## How this was tested

New unit test.