### PR TITLE
feat!: `vm.Hooks.OverrideEVMResetArgs()` receives `params.Rules`

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -159,7 +159,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 // Reset resets the EVM with a new transaction context.Reset
 // This is not threadsafe and should only be done very cautiously.
 func (evm *EVM) Reset(txCtx TxContext, statedb StateDB) {
-	evm.TxContext, evm.StateDB = overrideEVMResetArgs(txCtx, statedb)
+	evm.TxContext, evm.StateDB = evm.overrideEVMResetArgs(txCtx, statedb)
 }
 
 // Cancel cancels any running EVM operation. This may be called concurrently and

--- a/core/vm/evm.libevm_test.go
+++ b/core/vm/evm.libevm_test.go
@@ -36,7 +36,7 @@ func (o evmArgOverrider) OverrideNewEVMArgs(args *NewEVMArgs) *NewEVMArgs {
 	return args
 }
 
-func (o evmArgOverrider) OverrideEVMResetArgs(*EVMResetArgs) *EVMResetArgs {
+func (o evmArgOverrider) OverrideEVMResetArgs(params.Rules, *EVMResetArgs) *EVMResetArgs {
 	return &EVMResetArgs{
 		TxContext: o.resetTxCtx,
 		StateDB:   o.resetStateDB,

--- a/core/vm/evm.libevm_test.go
+++ b/core/vm/evm.libevm_test.go
@@ -19,6 +19,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/params"
@@ -27,23 +28,25 @@ import (
 type evmArgOverrider struct {
 	newEVMchainID int64
 
-	resetTxCtx   TxContext
-	resetStateDB StateDB
+	gotResetChainID  *big.Int
+	resetTxContextTo TxContext
+	resetStateDBTo   StateDB
 }
 
-func (o evmArgOverrider) OverrideNewEVMArgs(args *NewEVMArgs) *NewEVMArgs {
+func (o *evmArgOverrider) OverrideNewEVMArgs(args *NewEVMArgs) *NewEVMArgs {
 	args.ChainConfig = &params.ChainConfig{ChainID: big.NewInt(o.newEVMchainID)}
 	return args
 }
 
-func (o evmArgOverrider) OverrideEVMResetArgs(params.Rules, *EVMResetArgs) *EVMResetArgs {
+func (o *evmArgOverrider) OverrideEVMResetArgs(r params.Rules, _ *EVMResetArgs) *EVMResetArgs {
+	o.gotResetChainID = r.ChainID
 	return &EVMResetArgs{
-		TxContext: o.resetTxCtx,
-		StateDB:   o.resetStateDB,
+		TxContext: o.resetTxContextTo,
+		StateDB:   o.resetStateDBTo,
 	}
 }
 
-func (o evmArgOverrider) register(t *testing.T) {
+func (o *evmArgOverrider) register(t *testing.T) {
 	t.Helper()
 	libevmHooks = nil
 	RegisterHooks(o)
@@ -71,9 +74,13 @@ func TestOverrideEVMResetArgs(t *testing.T) {
 	// Equivalent to rationale for TestOverrideNewEVMArgs above.
 	var _ func(TxContext, StateDB) = (*EVM)(nil).Reset
 
-	const gasPrice = 1357924680
-	hooks := evmArgOverrider{
-		resetTxCtx: TxContext{
+	const (
+		chainID  = 0xc0ffee
+		gasPrice = 1357924680
+	)
+	hooks := &evmArgOverrider{
+		newEVMchainID: chainID,
+		resetTxContextTo: TxContext{
 			GasPrice: big.NewInt(gasPrice),
 		},
 	}
@@ -81,5 +88,6 @@ func TestOverrideEVMResetArgs(t *testing.T) {
 
 	evm := NewEVM(BlockContext{}, TxContext{}, nil, nil, Config{})
 	evm.Reset(TxContext{}, nil)
-	require.Equalf(t, big.NewInt(gasPrice), evm.GasPrice, "%T.GasPrice set by Reset() hook", evm)
+	assert.Equalf(t, big.NewInt(chainID), hooks.gotResetChainID, "%T.ChainID passed to Reset() hook", params.Rules{})
+	assert.Equalf(t, big.NewInt(gasPrice), evm.GasPrice, "%T.GasPrice set by Reset() hook", evm)
 }

--- a/core/vm/hooks.libevm.go
+++ b/core/vm/hooks.libevm.go
@@ -33,7 +33,7 @@ var libevmHooks Hooks
 // See [RegisterHooks].
 type Hooks interface {
 	OverrideNewEVMArgs(*NewEVMArgs) *NewEVMArgs
-	OverrideEVMResetArgs(*EVMResetArgs) *EVMResetArgs
+	OverrideEVMResetArgs(params.Rules, *EVMResetArgs) *EVMResetArgs
 }
 
 // NewEVMArgs are the arguments received by [NewEVM], available for override
@@ -67,10 +67,10 @@ func overrideNewEVMArgs(
 	return args.BlockContext, args.TxContext, args.StateDB, args.ChainConfig, args.Config
 }
 
-func overrideEVMResetArgs(txCtx TxContext, statedb StateDB) (TxContext, StateDB) {
+func (evm *EVM) overrideEVMResetArgs(txCtx TxContext, statedb StateDB) (TxContext, StateDB) {
 	if libevmHooks == nil {
 		return txCtx, statedb
 	}
-	args := libevmHooks.OverrideEVMResetArgs(&EVMResetArgs{txCtx, statedb})
+	args := libevmHooks.OverrideEVMResetArgs(evm.chainRules, &EVMResetArgs{txCtx, statedb})
 	return args.TxContext, args.StateDB
 }


### PR DESCRIPTION
## Why this should be merged

`coreth` integration of `libevm` requires access to `params.Rules` when overriding the EVM reset.

## How this works

Existing plumbing with extended hook signature.

## How this was tested

Existing unit test extended to record chain ID received via `Rules`.
