### PR TITLE
feat: `params.RulesHooks.ActivePrecompiles` override

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -148,7 +148,10 @@ func init() {
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
-func ActivePrecompiles(rules params.Rules) []common.Address {
+func ActivePrecompiles(rules params.Rules) (active []common.Address) {
+	defer func() {
+		active = rules.Hooks().ActivePrecompiles(append([]common.Address{}, active...))
+	}()
 	switch {
 	case rules.IsCancun:
 		return PrecompiledAddressesCancun

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -45,6 +45,7 @@ type Stub struct {
 	CheckConfigCompatibleFn func(*params.ChainConfig, *big.Int, uint64) *params.ConfigCompatError
 	DescriptionSuffix       string
 	PrecompileOverrides     map[common.Address]libevm.PrecompiledContract
+	ActivePrecompilesFn     func([]common.Address) []common.Address
 	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
 	CanCreateContractFn     func(*libevm.AddressContext, uint64, libevm.StateReader) (uint64, error)
 }
@@ -69,6 +70,15 @@ func (s Stub) PrecompileOverride(a common.Address) (libevm.PrecompiledContract, 
 	}
 	p, ok := s.PrecompileOverrides[a]
 	return p, ok
+}
+
+// ActivePrecompiles proxies arguments to the s.ActivePrecompilesFn function if
+// non-nil, otherwise it acts as a noop.
+func (s Stub) ActivePrecompiles(active []common.Address) []common.Address {
+	if f := s.ActivePrecompilesFn; f != nil {
+		return f(active)
+	}
+	return active
 }
 
 // CheckConfigForkOrder proxies arguments to the s.CheckConfigForkOrderFn

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -48,6 +48,12 @@ type RulesHooks interface {
 	// [PrecompiledContract] is non-nil. If it returns `false` then the default
 	// precompile behaviour is honoured.
 	PrecompileOverride(common.Address) (_ libevm.PrecompiledContract, override bool)
+	// ActivePrecompiles receives the addresses that would usually be returned
+	// by a call to [vm.ActivePrecompiles] and MUST return the value to be
+	// returned by said function, which will be propagated. It MAY alter the
+	// received slice. The value it returns MUST be consistent with the
+	// behaviour of the PrecompileOverride hook.
+	ActivePrecompiles([]common.Address) []common.Address
 }
 
 // RulesAllowlistHooks are a subset of [RulesHooks] that gate actions, signalled
@@ -119,4 +125,9 @@ func (NOOPHooks) CanCreateContract(_ *libevm.AddressContext, gas uint64, _ libev
 // precompile behaviour.
 func (NOOPHooks) PrecompileOverride(common.Address) (libevm.PrecompiledContract, bool) {
 	return nil, false
+}
+
+// ActivePrecompiles echoes the active addresses unchanged.
+func (NOOPHooks) ActivePrecompiles(active []common.Address) []common.Address {
+	return active
 }


### PR DESCRIPTION
## Why this should be merged

The existing `params.RulesHooks.PrecompileOverride` hook can cause the `vm.ActivePrecompiles()` return values to be incorrect such that access lists aren't pre-populated with precompile addresses. This new hook rectifies the problem.

## How this works

The hook receives the default values that would otherwise be returned by `vm.ActivePrecompiles()` and returns an override. Unlike `PrecompileOverride()` there is no need to return a boolean override flag too as propagating the hook's return value is sufficient and a noop is merely an echo.

The ability to override all addresses is necessary because `PrecompileOverride()` can disable a precompile.

## How this was tested

Integration test of `vm.ActivePrecompiles()` before and after registering a hook.
