### PR TITLE
feat: `vm.PrecompiledStatefulContract` can make `CALL`s

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,6 @@ jobs:
           go-version: 1.21.4
       - name: Run tests
         run: | # Upstream flakes are race conditions exacerbated by concurrent tests
-          FLAKY_REGEX='go-ethereum/(eth|accounts/keystore|eth/downloader|miner|ethclient/gethclient|eth/catalyst)$';
+          FLAKY_REGEX='go-ethereum/(eth|accounts/keystore|eth/downloader|miner|ethclient|ethclient/gethclient|eth/catalyst)$';
           go list ./... | grep -P "${FLAKY_REGEX}" | xargs -n 1 go test -short;
           go test -short $(go list ./... | grep -Pv "${FLAKY_REGEX}");

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -119,9 +119,9 @@ type PrecompileEnvironment interface {
 	BlockNumber() *big.Int
 	BlockTime() uint64
 
-	// Call is equivalent to [EVM.Call], with the caller defaulting to the
-	// precompile receiving the environment, or to its own caller if invoked via
-	// a delegated call.
+	// Call is equivalent to [EVM.Call] except that the `caller` argument is
+	// automatically determined according to the type of call that invoked the
+	// precompile.
 	Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, _ ...CallOption) (ret []byte, gasRemaining uint64, _ error)
 }
 
@@ -133,12 +133,12 @@ func (args *evmCallArgs) env() *environment {
 	}
 
 	var self common.Address
-	switch addr := args.addr; args.callType {
+	switch args.callType {
 	case staticCall:
 		args.value = new(uint256.Int)
 		fallthrough
 	case call:
-		self = addr
+		self = args.addr
 
 	case delegateCall:
 		args.value = nil

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -37,7 +37,7 @@ import (
 // Instantiation can be achieved by merely copying the parameter names, in
 // order, which is trivially achieved with AST manipulation:
 //
-//	func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) ... {
+//	func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte, gas uint64) ... {
 //	    ...
 //	    args := &evmCallArgs{evm, staticCall, caller, addr, input, gas, nil /*value*/}
 type evmCallArgs struct {

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -220,22 +220,23 @@ func (args *evmCallArgs) Call(addr common.Address, input []byte, gas uint64, val
 	// methods to pass to [EVMInterpreter.Run], which are then propagated by the
 	// *CALL* opcodes as the caller.
 	precompile := NewContract(args.caller, AccountRef(args.self()), args.value, args.gas)
-	if args.delegation == delegated {
-		precompile = precompile.AsDelegate()
-	}
-	var caller ContractRef = precompile
 
+	asDelegate := args.delegation == delegated // precompile was DELEGATECALLed
 	for _, o := range opts {
 		switch o := o.(type) {
-		case withCallerOpt:
-			caller = o.ContractRef
+		case callOptForceDelegate:
+			// See documentation of [WithUNSAFEForceDelegate].
+			asDelegate = true
 		case nil:
 		default:
 			return nil, gas, fmt.Errorf("unsupported option %T", o)
 		}
 	}
+	if asDelegate {
+		precompile = precompile.AsDelegate()
+	}
 
-	return args.evm.Call(caller, addr, input, gas, value)
+	return args.evm.Call(precompile, addr, input, gas, value)
 }
 
 var (

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -1,0 +1,94 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/libevm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+var _ PrecompileEnvironment = (*environment)(nil)
+
+type environment struct {
+	evm      *EVM
+	readOnly bool
+	addrs    libevm.AddressContext
+	self     *Contract
+	callType callType
+}
+
+func (e *environment) ChainConfig() *params.ChainConfig  { return e.evm.chainConfig }
+func (e *environment) Rules() params.Rules               { return e.evm.chainRules }
+func (e *environment) ReadOnly() bool                    { return e.readOnly }
+func (e *environment) ReadOnlyState() libevm.StateReader { return e.evm.StateDB }
+func (e *environment) Addresses() *libevm.AddressContext { return &e.addrs }
+func (e *environment) BlockNumber() *big.Int             { return new(big.Int).Set(e.evm.Context.BlockNumber) }
+func (e *environment) BlockTime() uint64                 { return e.evm.Context.Time }
+
+func (e *environment) StateDB() StateDB {
+	if e.ReadOnly() {
+		return nil
+	}
+	return e.evm.StateDB
+}
+
+func (e *environment) BlockHeader() (types.Header, error) {
+	hdr := e.evm.Context.Header
+	if hdr == nil {
+		// Although [core.NewEVMBlockContext] sets the field and is in the
+		// typical hot path (e.g. miner), there are other ways to create a
+		// [vm.BlockContext] (e.g. directly in tests) that may result in no
+		// available header.
+		return types.Header{}, fmt.Errorf("nil %T in current %T", hdr, e.evm.Context)
+	}
+	return *hdr, nil
+}
+
+func (e *environment) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) ([]byte, uint64, error) {
+	in := e.evm.interpreter
+
+	// The precompile run didn't increment the depth so this is necessary even
+	// though Call() will eventually result in it being done again.
+	in.evm.depth++
+	defer func() { in.evm.depth-- }()
+
+	if e.callType == staticCall && !in.readOnly {
+		in.readOnly = true
+		defer func() { in.readOnly = false }()
+	}
+
+	var caller ContractRef = e.self
+	for _, o := range opts {
+		switch o := o.(type) {
+		case callOptUNSAFECallerAddressProxy:
+			// Note that, in addition to being unsafe, this breaks an EVM
+			// assumption that the caller ContractRef is always a *Contract.
+			caller = AccountRef(e.addrs.Caller)
+		case nil:
+		default:
+			return nil, gas, fmt.Errorf("unsupported option %T", o)
+		}
+	}
+
+	return e.evm.Call(caller, addr, input, gas, value)
+}

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -76,7 +76,8 @@ func (e *environment) Call(addr common.Address, input []byte, gas uint64, value 
 
 func (e *environment) callContract(typ callType, addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) ([]byte, uint64, error) {
 	// Depth and read-only setting are handled by [EVMInterpreter.Run], which
-	// isn't used for precompiles, so we need to do it ourselves.
+	// isn't used for precompiles, so we need to do it ourselves to maintain the
+	// expected invariants.
 	in := e.evm.interpreter
 
 	in.evm.depth++

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -103,6 +103,9 @@ func (e *environment) callContract(typ callType, addr common.Address, input []by
 
 	switch typ {
 	case call:
+		if in.readOnly && !value.IsZero() {
+			return nil, gas, ErrWriteProtection
+		}
 		return e.evm.Call(caller, addr, input, gas, value)
 	case callCode, delegateCall, staticCall:
 		// TODO(arr4n): these cases should be very similar to CALL, hence the

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/libevm"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/holiman/uint256"
 )
 
 var _ PrecompileEnvironment = (*environment)(nil)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -230,7 +230,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 
 	if isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, value, inheritReadOnly, notDelegated}
+		args := &evmCallArgs{evm, call, caller, addr, input, gas, value}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -294,7 +294,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, value, inheritReadOnly, notDelegated}
+		args := &evmCallArgs{evm, callCode, caller, addr, input, gas, value}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -340,7 +340,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, nil, inheritReadOnly, delegated}
+		args := &evmCallArgs{evm, delegateCall, caller, addr, input, gas, nil}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -390,7 +390,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, nil, forceReadOnly, notDelegated}
+		args := &evmCallArgs{evm, staticCall, caller, addr, input, gas, nil}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -230,7 +230,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 
 	if isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, value, inheritReadOnly}
+		args := &evmCallArgs{evm, caller, addr, input, gas, value, inheritReadOnly, notDelegated}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -294,7 +294,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, value, inheritReadOnly}
+		args := &evmCallArgs{evm, caller, addr, input, gas, value, inheritReadOnly, notDelegated}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -340,7 +340,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, nil, inheritReadOnly}
+		args := &evmCallArgs{evm, caller, addr, input, gas, nil, inheritReadOnly, delegated}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -390,7 +390,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, caller, addr, input, gas, nil, forceReadOnly}
+		args := &evmCallArgs{evm, caller, addr, input, gas, nil, forceReadOnly, notDelegated}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will

--- a/core/vm/options.libevm.go
+++ b/core/vm/options.libevm.go
@@ -21,16 +21,18 @@ type CallOption interface {
 	libevmCallOption() // noop to only allow internally defined options
 }
 
-// WithUNSAFEForceDelegate results in precompiles making contract calls acting
-// as if they themselves were DELEGATECALLed. This is not safe for regular use
-// as the precompile will act as its own caller even when not expected to.
+// WithUNSAFECallerAddressProxying results in precompiles making contract calls
+// specifying their own caller's address as the caller. This is NOT SAFE for
+// regular use as callers of the precompile may not understand that they are
+// escalating the precompile's privileges.
 //
 // Deprecated: this option MUST NOT be used other than to allow migration to
 // libevm when backwards compatibility is required.
-func WithUNSAFEForceDelegate() CallOption {
-	return callOptForceDelegate{}
+func WithUNSAFECallerAddressProxying() CallOption {
+	return callOptUNSAFECallerAddressProxy{}
 }
 
-type callOptForceDelegate struct{}
+// Deprecated: see [WithUNSAFECallerAddressProxying].
+type callOptUNSAFECallerAddressProxy struct{}
 
-func (callOptForceDelegate) libevmCallOption() {}
+func (callOptUNSAFECallerAddressProxy) libevmCallOption() {}

--- a/core/vm/options.libevm.go
+++ b/core/vm/options.libevm.go
@@ -21,13 +21,16 @@ type CallOption interface {
 	libevmCallOption() // noop to only allow internally defined options
 }
 
-// WithCaller overrides the default caller.
-func WithCaller(c ContractRef) CallOption {
-	return withCallerOpt{c}
+// WithUNSAFEForceDelegate results in precompiles making contract calls acting
+// as if they themselves were DELEGATECALLed. This is not safe for regular use
+// as the precompile will act as its own caller even when not expected to.
+//
+// Deprecated: this option MUST NOT be used other than to allow migration to
+// libevm when backwards compatibility is required.
+func WithUNSAFEForceDelegate() CallOption {
+	return callOptForceDelegate{}
 }
 
-type withCallerOpt struct {
-	ContractRef
-}
+type callOptForceDelegate struct{}
 
-func (withCallerOpt) libevmCallOption() {}
+func (callOptForceDelegate) libevmCallOption() {}

--- a/core/vm/options.libevm.go
+++ b/core/vm/options.libevm.go
@@ -1,0 +1,33 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package vm
+
+// A CallOption modifies the default behaviour of a contract call.
+type CallOption interface {
+	libevmCallOption() // noop to only allow internally defined options
+}
+
+// WithCaller overrides the default caller.
+func WithCaller(c ContractRef) CallOption {
+	return withCallerOpt{c}
+}
+
+type withCallerOpt struct {
+	ContractRef
+}
+
+func (withCallerOpt) libevmCallOption() {}


### PR DESCRIPTION
## Why this should be merged

Allow stateful precompiles to call other contracts; e.g. for `ava-labs/coreth`'s `NativeAssetCall`.

## How this works

The `vm.PrecompileEnvironment.Call()` method is added to mirror `vm.EVM.Call()` in behaviour and in all syntax except the first argument, `caller`—the caller is the precompile itself, which is deterministic. An option to override the caller is included for backwards compatibility with `NativeAssetCall` but it MUST NOT otherwise be used.

Determining the correct `ContractRef` to use as the `caller` uncovered existing bugs in the `libevm.AddressContext` values passed to the precompile. Specifically, the `Self` and `Caller` addresses under `CallCode()` and `DelegateCall()` invocation of the precompile were incorrect. These are fixed via a refactor to abstract env behaviour into a new `environment` type although most of this is existing code just in a new file. Note that this fix means that stateful precompiles now behave as Solidity developers expect (other than #41).

The `evmCallArgs` field for read-write inheritance is replaced with a call-type field that indicates the `EVM` method through which the precompile was invoked. This implies RW inheritance (i.e. `StaticCall()` vs not) while also allowing other behaviour and simplifying the construction of an `evmCallArgs`.

## How this was tested

An integration test exercises typical behaviour of a precompile calling another contract: origin (EOA) -> regular bytecode contract -> precompile -> any other contract. This demonstrates plumbing of data as well as correct setting of the `caller`.

The existing test of new precompiles is updated to demonstrate the fix of the `AddressContext` values.