### PR TITLE
fix: `vm.WithUNSAFECallerAddressProxying` under `DELEGATECALL`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,6 @@ jobs:
           go-version: 1.21.4
       - name: Run tests
         run: | # Upstream flakes are race conditions exacerbated by concurrent tests
-          FLAKY_REGEX='go-ethereum/(eth|eth/tracers/logger|accounts/keystore|eth/downloader|miner|ethclient|ethclient/gethclient|eth/catalyst)$';
+          FLAKY_REGEX='go-ethereum/(eth|eth/tracers/js|eth/tracers/logger|accounts/keystore|eth/downloader|miner|ethclient|ethclient/gethclient|eth/catalyst)$';
           go list ./... | grep -P "${FLAKY_REGEX}" | xargs -n 1 go test -short;
           go test -short $(go list ./... | grep -Pv "${FLAKY_REGEX}");

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -53,7 +53,7 @@ type evmCallArgs struct {
 	// args:end
 }
 
-// A CallType references a *CALL* [OpCode] / respective method on [EVM].
+// A CallType refers to a *CALL* [OpCode] / respective method on [EVM].
 type CallType uint8
 
 const (

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -153,25 +153,9 @@ func (args *evmCallArgs) env() *environment {
 	}
 
 	return &environment{
-		evm:           args.evm,
-		self:          contract,
-		forceReadOnly: args.readOnly(),
-	}
-}
-
-func (args *evmCallArgs) readOnly() bool {
-	// A switch statement provides clearer code coverage for difficult-to-test
-	// cases.
-	switch {
-	case args.callType == staticCall:
-		// evm.interpreter.readOnly is only set to true via a call to
-		// EVMInterpreter.Run() so, if a precompile is called directly with
-		// StaticCall(), then readOnly might not be set yet.
-		return true
-	case args.evm.interpreter.readOnly:
-		return true
-	default:
-		return false
+		evm:      args.evm,
+		self:     contract,
+		callType: args.callType,
 	}
 }
 

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -42,7 +42,7 @@ import (
 //	    args := &evmCallArgs{evm, staticCall, caller, addr, input, gas, nil /*value*/}
 type evmCallArgs struct {
 	evm      *EVM
-	callType callType
+	callType CallType
 
 	// args:start
 	caller ContractRef
@@ -53,14 +53,31 @@ type evmCallArgs struct {
 	// args:end
 }
 
-type callType uint8
+// A CallType references a *CALL* [OpCode] / respective method on [EVM].
+type CallType uint8
 
 const (
-	call callType = iota + 1
-	callCode
-	delegateCall
-	staticCall
+	UnknownCallType CallType = iota
+	Call
+	CallCode
+	DelegateCall
+	StaticCall
 )
+
+// String returns a human-readable representation of the CallType.
+func (t CallType) String() string {
+	switch t {
+	case Call:
+		return "Call"
+	case CallCode:
+		return "CallCode"
+	case DelegateCall:
+		return "DelegateCall"
+	case StaticCall:
+		return "StaticCall"
+	}
+	return fmt.Sprintf("Unknown %T(%d)", t, t)
+}
 
 // run runs the [PrecompiledContract], differentiating between stateful and
 // regular types.
@@ -115,6 +132,7 @@ type PrecompileEnvironment interface {
 	// ReadOnlyState will always be non-nil.
 	ReadOnlyState() libevm.StateReader
 	Addresses() *libevm.AddressContext
+	IncomingCallType() CallType
 
 	BlockHeader() (types.Header, error)
 	BlockNumber() *big.Int
@@ -132,23 +150,23 @@ func (args *evmCallArgs) env() *environment {
 		value = args.value
 	)
 	switch args.callType {
-	case staticCall:
+	case StaticCall:
 		value = new(uint256.Int)
 		fallthrough
-	case call:
+	case Call:
 		self = args.addr
 
-	case delegateCall:
+	case DelegateCall:
 		value = nil
 		fallthrough
-	case callCode:
+	case CallCode:
 		self = args.caller.Address()
 	}
 
 	// This is equivalent to the `contract` variables created by evm.*Call*()
 	// methods, for non precompiles, to pass to [EVMInterpreter.Run].
 	contract := NewContract(args.caller, AccountRef(self), value, args.gas)
-	if args.callType == delegateCall {
+	if args.callType == DelegateCall {
 		contract = contract.AsDelegate()
 	}
 

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -680,3 +680,25 @@ func TestPrecompileMakeCall(t *testing.T) {
 		})
 	}
 }
+
+func ExamplePrecompileEnvironment() {
+	// To determine the actual caller of a precompile, as against the effective
+	// caller (under EVM rules, as exposed by `Addresses().Caller`):
+	actualCaller := func(env vm.PrecompileEnvironment) common.Address {
+		if env.IncomingCallType() == vm.DelegateCall {
+			// DelegateCall acts as if it were its own caller.
+			return env.Addresses().Self
+		}
+		// CallCode could return either `Self` or `Caller` as it acts as its
+		// caller but doesn't inherit the caller's caller as DelegateCall does.
+		// Having it handled here is arbitrary from a behavioural perspective
+		// and is done only to simplify the code.
+		//
+		// Call and StaticCall don't affect self/caller semantics in any way.
+		return env.Addresses().Caller
+	}
+
+	// actualCaller would typically be a top-level function. It's only a
+	// variable to include it in this example function.
+	_ = actualCaller
+}

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -681,6 +681,7 @@ func TestPrecompileMakeCall(t *testing.T) {
 	}
 }
 
+//nolint:testableexamples // Including output would only make the example more complicated and hide the true intent
 func ExamplePrecompileEnvironment() {
 	// To determine the actual caller of a precompile, as against the effective
 	// caller (under EVM rules, as exposed by `Addresses().Caller`):

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -230,7 +230,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 
 	if isPrecompile {
-		args := &evmCallArgs{evm, call, caller, addr, input, gas, value}
+		args := &evmCallArgs{evm, Call, caller, addr, input, gas, value}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -294,7 +294,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, callCode, caller, addr, input, gas, value}
+		args := &evmCallArgs{evm, CallCode, caller, addr, input, gas, value}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -340,7 +340,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, delegateCall, caller, addr, input, gas, nil}
+		args := &evmCallArgs{evm, DelegateCall, caller, addr, input, gas, nil}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		addrCopy := addr
@@ -390,7 +390,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		args := &evmCallArgs{evm, staticCall, caller, addr, input, gas, nil}
+		args := &evmCallArgs{evm, StaticCall, caller, addr, input, gas, nil}
 		ret, gas, err = args.RunPrecompiledContract(p, input, gas)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will


### PR DESCRIPTION
## Why this should be merged

Correct backwards compatibility for `ava-labs/coreth` `NativeAssetCall` (`NAC`).

## How this works

`NAC` always acted as if it were its _actual_ caller, not its _effective_ caller under EVM rules. As `DelegateCall` modifies both the effective self and caller addresses, the `WithUNSAFECallerAddressProxying()` option now properly selects the actual caller to use when making outgoing calls.

In addition to proxying its actual-caller address on outbound calls, `NAC` charged the actual caller of the precompile. To discern this, the `CallType` is made available via `PrecompileEnvironment`. See the example code for how to determine the actual caller.

## How this was tested

Additional test cases for `TestPrecompileMakeCall` as this asserts the addresses as seen by the contract called by the precompile.