### PR TITLE
fix: run renaming workflow if branch `== main`

### DIFF
--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Open PR to "renamed-go-module" iff workflow dispatched on "main"
         # If we are changing the way in which we manage module renaming then it
         # MUST go through PR review to main; only then can it open PRs.
-        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
         uses: devops-infra/action-pull-request@v0.5.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why this should be merged

#51 had a bug when checking whether or not to open a PR. I was originally blocking everything if _not_ on main instead of doing something if on it. The [manually dispatched run therefore didn't open a PR as expected](https://github.com/ava-labs/libevm/actions/runs/11299366394/job/31430160561).

## How this works

Change `!=` to `==`

## How this was tested

n/a