### PR TITLE
fix: pre-state tracer logging storage after call from precompile

### DIFF
--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -54,29 +54,38 @@ type evmCallArgs struct {
 }
 
 // A CallType refers to a *CALL* [OpCode] / respective method on [EVM].
-type CallType uint8
+type CallType OpCode
 
 const (
-	UnknownCallType CallType = iota
-	Call
-	CallCode
-	DelegateCall
-	StaticCall
+	Call         = CallType(CALL)
+	CallCode     = CallType(CALLCODE)
+	DelegateCall = CallType(DELEGATECALL)
+	StaticCall   = CallType(STATICCALL)
 )
+
+func (t CallType) isValid() bool {
+	switch t {
+	case Call, CallCode, DelegateCall, StaticCall:
+		return true
+	default:
+		return false
+	}
+}
 
 // String returns a human-readable representation of the CallType.
 func (t CallType) String() string {
-	switch t {
-	case Call:
-		return "Call"
-	case CallCode:
-		return "CallCode"
-	case DelegateCall:
-		return "DelegateCall"
-	case StaticCall:
-		return "StaticCall"
+	if t.isValid() {
+		return t.OpCode().String()
 	}
 	return fmt.Sprintf("Unknown %T(%d)", t, t)
+}
+
+// OpCode returns t's equivalent OpCode.
+func (t CallType) OpCode() OpCode {
+	if t.isValid() {
+		return OpCode(t)
+	}
+	return INVALID
 }
 
 // run runs the [PrecompiledContract], differentiating between stateful and

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -127,7 +127,15 @@ func (e *environment) callContract(typ CallType, addr common.Address, input []by
 		if in.readOnly && !value.IsZero() {
 			return nil, gas, ErrWriteProtection
 		}
-		return e.evm.Call(caller, addr, input, gas, value)
+		if e.evm.Config.Tracer != nil {
+			e.evm.Config.Tracer.CaptureEnter(CALL, caller.Address(), addr, input, gas, value.ToBig())
+		}
+		startGas := gas
+		ret, gas, err := e.evm.Call(caller, addr, input, gas, value)
+		if e.evm.Config.Tracer != nil {
+			e.evm.Config.Tracer.CaptureEnd(ret, startGas-gas, err)
+		}
+		return ret, gas, err
 	case CallCode, DelegateCall, StaticCall:
 		// TODO(arr4n): these cases should be very similar to CALL, hence the
 		// early abstraction, to signal to future maintainers. If implementing

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -90,7 +90,7 @@ func (e *environment) Call(addr common.Address, input []byte, gas uint64, value 
 	return e.callContract(Call, addr, input, gas, value, opts...)
 }
 
-func (e *environment) callContract(typ CallType, addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) ([]byte, uint64, error) {
+func (e *environment) callContract(typ CallType, addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) (retData []byte, retGas uint64, retErr error) {
 	// Depth and read-only setting are handled by [EVMInterpreter.Run], which
 	// isn't used for precompiles, so we need to do it ourselves to maintain the
 	// expected invariants.
@@ -122,20 +122,25 @@ func (e *environment) callContract(typ CallType, addr common.Address, input []by
 		}
 	}
 
+	if in.readOnly && value != nil && !value.IsZero() {
+		return nil, gas, ErrWriteProtection
+	}
+	if t := e.evm.Config.Tracer; t != nil {
+		var bigVal *big.Int
+		if value != nil {
+			bigVal = value.ToBig()
+		}
+		t.CaptureEnter(typ.OpCode(), caller.Address(), addr, input, gas, bigVal)
+
+		startGas := gas
+		defer func() {
+			t.CaptureEnd(retData, startGas-retGas, retErr)
+		}()
+	}
+
 	switch typ {
 	case Call:
-		if in.readOnly && !value.IsZero() {
-			return nil, gas, ErrWriteProtection
-		}
-		if e.evm.Config.Tracer != nil {
-			e.evm.Config.Tracer.CaptureEnter(CALL, caller.Address(), addr, input, gas, value.ToBig())
-		}
-		startGas := gas
-		ret, gas, err := e.evm.Call(caller, addr, input, gas, value)
-		if e.evm.Config.Tracer != nil {
-			e.evm.Config.Tracer.CaptureEnd(ret, startGas-gas, err)
-		}
-		return ret, gas, err
+		return e.evm.Call(caller, addr, input, gas, value)
 	case CallCode, DelegateCall, StaticCall:
 		// TODO(arr4n): these cases should be very similar to CALL, hence the
 		// early abstraction, to signal to future maintainers. If implementing

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -89,6 +89,10 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Trace
 	}, nil
 }
 
+func (t *prestateTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	t.lookupAccount(to)
+}
+
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
 func (t *prestateTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 	t.env = env

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -89,10 +89,6 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Trace
 	}, nil
 }
 
-func (t *prestateTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
-	t.lookupAccount(to)
-}
-
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
 func (t *prestateTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 	t.env = env

--- a/eth/tracers/native/prestate_libevm.go
+++ b/eth/tracers/native/prestate_libevm.go
@@ -24,13 +24,14 @@ import (
 )
 
 // CaptureEnter implements the [vm.EVMLogger] hook for entering a new scope (via
-// call, create or selfdestruct).
+// CALL*, CREATE or SELFDESTRUCT).
 func (t *prestateTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	// Although [prestateTracer.lookupStorage] expects
 	// [prestateTracer.lookupAccount] to have been called, the invariant is
-	// maintained by [prestateTracer.CaptureState] when encountering an opcode
+	// maintained by [prestateTracer.CaptureState] when it encounters an OpCode
 	// corresponding to scope entry. This, however, doesn't work when using a
-	// call method exposed by [vm.PrecompileEnvironment], so we expose it here
-	// as it is idempotent.
+	// call method exposed by [vm.PrecompileEnvironment], and is restored by a
+	// call to this CaptureEnter implementation. Note that lookupAccount(x) is
+	// idempotent.
 	t.lookupAccount(to)
 }

--- a/eth/tracers/native/prestate_libevm.go
+++ b/eth/tracers/native/prestate_libevm.go
@@ -1,0 +1,36 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package native
+
+import (
+	"math/big"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/vm"
+)
+
+// CaptureEnter implements the [vm.EVMLogger] hook for entering a new scope (via
+// call, create or selfdestruct).
+func (t *prestateTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	// Although [prestateTracer.lookupStorage] expects
+	// [prestateTracer.lookupAccount] to have been called, the invariant is
+	// maintained by [prestateTracer.CaptureState] when encountering an opcode
+	// corresponding to scope entry. This, however, doesn't work when using a
+	// call method exposed by [vm.PrecompileEnvironment], so we expose it here
+	// as it is idempotent.
+	t.lookupAccount(to)
+}


### PR DESCRIPTION
## Why this should be merged

Fixes tracing when a stateful precompile calls another contract that itself accesses storage.

## How this works

The pre-state tracer from `eth/tracers/native` doesn't implement `CaptureEnter()` (entry of a new context), instead relying on `CaptureState()` (per-opcode tracing) to detect that a new contract has been entered. In doing so, it [maintains an invariant](https://github.com/ava-labs/libevm/blob/cb7eb89341132f301680848d8faea6a5568dc326/eth/tracers/native/prestate.go#L160) that is expected when `CaptureState(vm.SLOAD, ...)` is called—breaking the invariant results in a panic due to a nil map.

The fix involves (a) maintaining the invariant as part of `CaptureEnter()` (previously a no-op); and (b) calling said method inside `vm.PrecompileEnvironment.Call()`. The latter has the added benefit of properly handling all tracing involving an outbound call from precompiles.

## How this was tested

New integration test demonstrates that the tracer can log the retrieved storage value.