### PR TITLE
chore: run workflows on PRs+push to release branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,9 +2,9 @@ name: golangci-lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -2,9 +2,9 @@ name: libevm delta
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Why this should be merged

These workflows are required by branch protection for release branches, but aren't run automatically so release PRs can't currently be merged. 

## How this works

Extends the `branches` filters of necessary workflows.

## How this was tested

n/a