### PR TITLE
chore: post-rename cleanup + `libevm` intro

### DIFF
--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -10,8 +10,8 @@ on:
 jobs:
   diffs:
     env:
-      # Last commit on `renamed-go-module` branch to be merged into `main`
-      LIBEVM_BASE: a7f08d0e757d5a69d3e269c69dcea7e45bab97e3
+      # Last commit from rename-module workflow job to be included in `main`
+      LIBEVM_BASE: 0b56af5a01b8a0c6fc9d60247bb79ffd03d1bcfd
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
+# libevm
+
+[![API Reference](
+https://pkg.go.dev/badge/github.com/ava-labs/libevm
+)](https://pkg.go.dev/github.com/ava-labs/libevm?tab=doc)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ava-labs/libevm)](https://goreportcard.com/report/github.com/ava-labs/libevm)
+[![Go Build & Test](https://github.com/ava-labs/libevm/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/ava-labs/libevm/actions/workflows/go.yml)
+
+The Ethereum Virtual Machine (EVM) as a library, `libevm` is a fork of [`geth`](https://github.com/ethereum/go-ethereum) with
+injectable configuration directives. Although designed to support the Avalanche [C-Chain](https://github.com/ava-labs/coreth) and
+[EVM-L1s](https://github.com/ava-labs/subnet-evm) (formerly _subnets_), configuration is general-purpose and backwards-compatible
+with `geth`.
+
+
+We are immensely grateful for the hard work of the `geth` authors, and hope that our contribution can be of value to others too. Thank you!
+
 ## Go Ethereum
 
 Golang execution layer implementation of the Ethereum protocol.
-
-[![API Reference](
-https://pkg.go.dev/badge/github.com/ethereum/go-ethereum
-)](https://pkg.go.dev/github.com/ethereum/go-ethereum?tab=doc)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ethereum/go-ethereum)](https://goreportcard.com/report/github.com/ethereum/go-ethereum)
-[![Travis](https://app.travis-ci.com/ethereum/go-ethereum.svg?branch=master)](https://app.travis-ci.com/github/ethereum/go-ethereum)
-[![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/nthXNEv)
 
 Automated builds are available for stable releases and the unstable master branch. Binary
 archives are published at https://geth.ethereum.org/downloads/.

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
+
 package core
 
 // canExecuteTransaction is a convenience wrapper for calling the

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
+
 package libevm
 
 import (

--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
+
 package params
 
 import (

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
+
 package params
 
 import (

--- a/params/json.libevm.go
+++ b/params/json.libevm.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
+
 package params
 
 import (


### PR DESCRIPTION
## Why this should be merged

Cleans up loose ends after renaming the Go module. Also adds an introduction to the README to explain the purpose of libevm.

## How this works

The changed hash in the workflow is just a fix (although a no-op). The spaces after the copyright headers are to stop them from [showing up in documentation](https://pkg.go.dev/github.com/ava-labs/libevm@v1.13.14-0.1.0-rc.1/params).

## How this was tested

n/a