### PR TITLE
snapshot + db backend modifications for use by coreth & subnet-evm

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -880,7 +880,7 @@ func newTimestampCompatError(what string, storedtime, newtime *uint64) *ConfigCo
 		NewTime:      newtime,
 		RewindToTime: 0,
 	}
-	if rew != nil {
+	if rew != nil && *rew != 0 {
 		err.RewindToTime = *rew - 1
 	}
 	return err
@@ -890,7 +890,15 @@ func (err *ConfigCompatError) Error() string {
 	if err.StoredBlock != nil {
 		return fmt.Sprintf("mismatching %s in database (have block %d, want block %d, rewindto block %d)", err.What, err.StoredBlock, err.NewBlock, err.RewindToBlock)
 	}
-	return fmt.Sprintf("mismatching %s in database (have timestamp %d, want timestamp %d, rewindto timestamp %d)", err.What, err.StoredTime, err.NewTime, err.RewindToTime)
+
+	if err.StoredTime == nil && err.NewTime == nil {
+		return ""
+	} else if err.StoredTime == nil && err.NewTime != nil {
+		return fmt.Sprintf("mismatching %s in database (have timestamp nil, want timestamp %d, rewindto timestamp %d)", err.What, *err.NewTime, err.RewindToTime)
+	} else if err.StoredTime != nil && err.NewTime == nil {
+		return fmt.Sprintf("mismatching %s in database (have timestamp %d, want timestamp nil, rewindto timestamp %d)", err.What, *err.StoredTime, err.RewindToTime)
+	}
+	return fmt.Sprintf("mismatching %s in database (have timestamp %d, want timestamp %d, rewindto timestamp %d)", err.What, *err.StoredTime, *err.NewTime, err.RewindToTime)
 }
 
 // Rules wraps ChainConfig and is merely syntactic sugar or can be used for functions

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/libevm/common/math"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckCompatible(t *testing.T) {
@@ -136,4 +137,21 @@ func TestConfigRules(t *testing.T) {
 	if r := c.Rules(big.NewInt(0), true, stamp); !r.IsShanghai {
 		t.Errorf("expected %v to be shanghai", stamp)
 	}
+}
+
+func TestTimestampCompatError(t *testing.T) {
+	require.Equal(t, new(ConfigCompatError).Error(), "")
+
+	errWhat := "Shanghai fork timestamp"
+	require.Equal(t, newTimestampCompatError(errWhat, nil, newUint64(1681338455)).Error(),
+		"mismatching Shanghai fork timestamp in database (have timestamp nil, want timestamp 1681338455, rewindto timestamp 1681338454)")
+
+	require.Equal(t, newTimestampCompatError(errWhat, newUint64(1681338455), nil).Error(),
+		"mismatching Shanghai fork timestamp in database (have timestamp 1681338455, want timestamp nil, rewindto timestamp 1681338454)")
+
+	require.Equal(t, newTimestampCompatError(errWhat, newUint64(1681338455), newUint64(600624000)).Error(),
+		"mismatching Shanghai fork timestamp in database (have timestamp 1681338455, want timestamp 600624000, rewindto timestamp 600623999)")
+
+	require.Equal(t, newTimestampCompatError(errWhat, newUint64(0), newUint64(1681338455)).Error(),
+		"mismatching Shanghai fork timestamp in database (have timestamp 0, want timestamp 1681338455, rewindto timestamp 0)")
 }

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -27,15 +27,14 @@ import (
 	"github.com/ava-labs/libevm/trie/triestate"
 	"github.com/ava-labs/libevm/triedb/database"
 	"github.com/ava-labs/libevm/triedb/hashdb"
-	"github.com/ava-labs/libevm/triedb/pathdb"
 )
 
 // Config defines all necessary options for database.
 type Config struct {
-	Preimages bool           // Flag whether the preimage of node key is recorded
-	IsVerkle  bool           // Flag whether the db is holding a verkle tree
-	HashDB    *hashdb.Config // Configs for hash-based scheme
-	PathDB    *pathdb.Config // Configs for experimental path-based scheme
+	Preimages bool          // Flag whether the preimage of node key is recorded
+	IsVerkle  bool          // Flag whether the db is holding a verkle tree
+	HashDB    hashBackender // Configs for hash-based scheme
+	PathDB    pathBackender // Configs for experimental path-based scheme
 }
 
 // HashDefaults represents a config for using hash-based scheme with
@@ -43,6 +42,15 @@ type Config struct {
 var HashDefaults = &Config{
 	Preimages: false,
 	HashDB:    hashdb.Defaults,
+}
+
+type Backend backend
+
+type hashBackender interface {
+	New(diskdb ethdb.Database, resolver hashdb.ChildResolver) database.HashBackend
+}
+type pathBackender interface {
+	New(diskdb ethdb.Database) database.PathBackend
 }
 
 // backend defines the methods needed to access/update trie nodes in different
@@ -76,6 +84,10 @@ type backend interface {
 
 	// Close closes the trie database backend and releases all held resources.
 	Close() error
+
+	// Reader returns a node reader associated with the specific state.
+	// An error will be returned if the specified state is not available.
+	Reader(stateRoot common.Hash) (database.Reader, error)
 }
 
 // Database is the wrapper of the underlying backend which is shared by different
@@ -108,7 +120,7 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 		log.Crit("Both 'hash' and 'path' mode are configured")
 	}
 	if config.PathDB != nil {
-		db.backend = pathdb.New(diskdb, config.PathDB)
+		db.backend = config.PathDB.New(diskdb)
 	} else {
 		var resolver hashdb.ChildResolver
 		if config.IsVerkle {
@@ -117,7 +129,11 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 		} else {
 			resolver = trie.MerkleResolver{}
 		}
-		db.backend = hashdb.New(diskdb, config.HashDB, resolver)
+		if config.HashDB == nil {
+			// some tests don't set this yet pass a non-nil config
+			config.HashDB = hashdb.Defaults
+		}
+		db.backend = config.HashDB.New(diskdb, resolver)
 	}
 	return db
 }
@@ -125,13 +141,7 @@ func NewDatabase(diskdb ethdb.Database, config *Config) *Database {
 // Reader returns a reader for accessing all trie nodes with provided state root.
 // An error will be returned if the requested state is not available.
 func (db *Database) Reader(blockRoot common.Hash) (database.Reader, error) {
-	switch b := db.backend.(type) {
-	case *hashdb.Database:
-		return b.Reader(blockRoot)
-	case *pathdb.Database:
-		return b.Reader(blockRoot)
-	}
-	return nil, errors.New("unknown backend")
+	return db.backend.Reader(blockRoot)
 }
 
 // Update performs a state transition by committing dirty nodes contained in the
@@ -221,7 +231,7 @@ func (db *Database) InsertPreimage(preimages map[common.Hash][]byte) {
 //
 // It's only supported by hash-based database and will return an error for others.
 func (db *Database) Cap(limit common.StorageSize) error {
-	hdb, ok := db.backend.(*hashdb.Database)
+	hdb, ok := db.backend.(database.HashBackend)
 	if !ok {
 		return errors.New("not supported")
 	}
@@ -237,7 +247,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 //
 // It's only supported by hash-based database and will return an error for others.
 func (db *Database) Reference(root common.Hash, parent common.Hash) error {
-	hdb, ok := db.backend.(*hashdb.Database)
+	hdb, ok := db.backend.(database.HashBackend)
 	if !ok {
 		return errors.New("not supported")
 	}
@@ -248,7 +258,7 @@ func (db *Database) Reference(root common.Hash, parent common.Hash) error {
 // Dereference removes an existing reference from a root node. It's only
 // supported by hash-based database and will return an error for others.
 func (db *Database) Dereference(root common.Hash) error {
-	hdb, ok := db.backend.(*hashdb.Database)
+	hdb, ok := db.backend.(database.HashBackend)
 	if !ok {
 		return errors.New("not supported")
 	}
@@ -261,7 +271,7 @@ func (db *Database) Dereference(root common.Hash) error {
 // corresponding trie histories are existent. It's only supported by path-based
 // database and will return an error for others.
 func (db *Database) Recover(target common.Hash) error {
-	pdb, ok := db.backend.(*pathdb.Database)
+	pdb, ok := db.backend.(database.PathBackend)
 	if !ok {
 		return errors.New("not supported")
 	}
@@ -279,7 +289,7 @@ func (db *Database) Recover(target common.Hash) error {
 // recovered. It's only supported by path-based database and will return an
 // error for others.
 func (db *Database) Recoverable(root common.Hash) (bool, error) {
-	pdb, ok := db.backend.(*pathdb.Database)
+	pdb, ok := db.backend.(database.PathBackend)
 	if !ok {
 		return false, errors.New("not supported")
 	}
@@ -292,7 +302,7 @@ func (db *Database) Recoverable(root common.Hash) (bool, error) {
 //
 // It's only supported by path-based database and will return an error for others.
 func (db *Database) Disable() error {
-	pdb, ok := db.backend.(*pathdb.Database)
+	pdb, ok := db.backend.(database.PathBackend)
 	if !ok {
 		return errors.New("not supported")
 	}
@@ -302,7 +312,7 @@ func (db *Database) Disable() error {
 // Enable activates database and resets the state tree with the provided persistent
 // state root once the state sync is finished.
 func (db *Database) Enable(root common.Hash) error {
-	pdb, ok := db.backend.(*pathdb.Database)
+	pdb, ok := db.backend.(database.PathBackend)
 	if !ok {
 		return errors.New("not supported")
 	}
@@ -314,7 +324,7 @@ func (db *Database) Enable(root common.Hash) error {
 // flattening everything down (bad for reorgs). It's only supported by path-based
 // database and will return an error for others.
 func (db *Database) Journal(root common.Hash) error {
-	pdb, ok := db.backend.(*pathdb.Database)
+	pdb, ok := db.backend.(database.PathBackend)
 	if !ok {
 		return errors.New("not supported")
 	}
@@ -325,7 +335,7 @@ func (db *Database) Journal(root common.Hash) error {
 // It's only supported by path-based database and will return an error for
 // others.
 func (db *Database) SetBufferSize(size int) error {
-	pdb, ok := db.backend.(*pathdb.Database)
+	pdb, ok := db.backend.(database.PathBackend)
 	if !ok {
 		return errors.New("not supported")
 	}

--- a/triedb/database/database.go
+++ b/triedb/database/database.go
@@ -18,6 +18,8 @@ package database
 
 import (
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/trie/trienode"
+	"github.com/ava-labs/libevm/trie/triestate"
 )
 
 // Reader wraps the Node method of a backing trie reader.
@@ -45,4 +47,60 @@ type Database interface {
 	// Reader returns a node reader associated with the specific state.
 	// An error will be returned if the specified state is not available.
 	Reader(stateRoot common.Hash) (Reader, error)
+}
+
+// Backend defines the methods needed to access/update trie nodes in different
+// state scheme.
+type Backend interface {
+	// Scheme returns the identifier of used storage scheme.
+	Scheme() string
+
+	// Initialized returns an indicator if the state data is already initialized
+	// according to the state scheme.
+	Initialized(genesisRoot common.Hash) bool
+
+	// Size returns the current storage size of the diff layers on top of the
+	// disk layer and the storage size of the nodes cached in the disk layer.
+	//
+	// For hash scheme, there is no differentiation between diff layer nodes
+	// and dirty disk layer nodes, so both are merged into the second return.
+	Size() (common.StorageSize, common.StorageSize)
+
+	// Update performs a state transition by committing dirty nodes contained
+	// in the given set in order to update state from the specified parent to
+	// the specified root.
+	//
+	// The passed in maps(nodes, states) will be retained to avoid copying
+	// everything. Therefore, these maps must not be changed afterwards.
+	Update(root common.Hash, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set) error
+
+	// Commit writes all relevant trie nodes belonging to the specified state
+	// to disk. Report specifies whether logs will be displayed in info level.
+	Commit(root common.Hash, report bool) error
+
+	// Close closes the trie database backend and releases all held resources.
+	Close() error
+
+	// Reader returns a node reader associated with the specific state.
+	// An error will be returned if the specified state is not available.
+	Reader(stateRoot common.Hash) (Reader, error)
+}
+
+type HashBackend interface {
+	Backend
+
+	Cap(limit common.StorageSize) error
+	Reference(root common.Hash, parent common.Hash)
+	Dereference(root common.Hash)
+}
+
+type PathBackend interface {
+	Backend
+
+	Recover(root common.Hash, loader triestate.TrieLoader) error
+	Recoverable(root common.Hash) bool
+	Disable() error
+	Enable(root common.Hash) error
+	Journal(root common.Hash) error
+	SetBufferSize(size int) error
 }

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ava-labs/libevm/rlp"
 	"github.com/ava-labs/libevm/trie/trienode"
 	"github.com/ava-labs/libevm/trie/triestate"
+	"github.com/ava-labs/libevm/triedb/database"
 )
 
 var (
@@ -77,6 +78,10 @@ var Defaults = &Config{
 	// otherwise database must be closed when it's no longer needed to
 	// prevent memory leak.
 	CleanCacheSize: 0,
+}
+
+func (c *Config) New(diskdb ethdb.Database, resolver ChildResolver) database.HashBackend {
+	return New(diskdb, c, resolver)
 }
 
 // Database is an intermediate write layer between the trie data structures and
@@ -631,7 +636,7 @@ func (db *Database) Scheme() string {
 
 // Reader retrieves a node reader belonging to the given state root.
 // An error will be returned if the requested state is not available.
-func (db *Database) Reader(root common.Hash) (*reader, error) {
+func (db *Database) Reader(root common.Hash) (database.Reader, error) {
 	if _, err := db.node(root); err != nil {
 		return nil, fmt.Errorf("state %#x is not available, %v", root, err)
 	}

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/trie/trienode"
 	"github.com/ava-labs/libevm/trie/triestate"
+	"github.com/ava-labs/libevm/triedb/database"
 )
 
 const (
@@ -90,6 +91,10 @@ type Config struct {
 	CleanCacheSize int    // Maximum memory allowance (in bytes) for caching clean nodes
 	DirtyCacheSize int    // Maximum memory allowance (in bytes) for caching dirty nodes
 	ReadOnly       bool   // Flag whether the database is opened in read only mode.
+}
+
+func (c *Config) New(diskdb ethdb.Database) database.PathBackend {
+	return New(diskdb, c)
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -208,7 +213,7 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 }
 
 // Reader retrieves a layer belonging to the given state root.
-func (db *Database) Reader(root common.Hash) (layer, error) {
+func (db *Database) Reader(root common.Hash) (database.Reader, error) {
 	l := db.tree.get(root)
 	if l == nil {
 		return nil, fmt.Errorf("state %#x is not available", root)


### PR DESCRIPTION
## Why this should be merged
- subnet-evm / coreth use block hash based snapshots,
- subnet-evm / coreth use modified hashdb (and later pathdb) backends so we can pass these in

## How this works
This pull request makes changes to the `core/state` and `triedb` packages to enhance the flexibility of the state management and database handling. The changes involve introducing new interfaces, updating function implementations.

### Changes to `core/state`:

* Introduced the `snapshotTree` interface to abstract the snapshot handling in `StateDB` (`core/state/statedb.go`).
* Updated the `StateDB` struct to use the new `snapshotTree` interface (`core/state/statedb.go`).
* Modified the `New` function to handle `snapshotTree` and ensure proper handling of `nil` pointers (`core/state/statedb.go`). <-- not sure if there is a better way to handle this

### Changes to `triedb`:

* Refactored the `Config` struct in `triedb/database.go` to use interfaces for `HashDB` and `PathDB` (`triedb/database.go`). -- Trying to keep changes minimal esp. to tests.
* Introduced new interfaces `Backend`, `HashBackend`, and `PathBackend` to define methods for different state schemes (`triedb/database/database.go`).
* Updated the `NewDatabase` function to use the new `Backend` interfaces and handle `nil` configurations (`triedb/database.go`).
* Simplified various methods in `triedb/database.go` to use the new `Backend` interfaces (`triedb/database.go`) [[1]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L224-R234) [[2]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L240-R250) [[3]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L251-R261) [[4]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L264-R274) [[5]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L282-R292) [[6]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L295-R305) [[7]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L305-R315) [[8]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L317-R327) [[9]](diffhunk://#diff-e5ec1c8dc7a0cc270e9f8ccb6135776569bde10f2b9726f282ddb61ad4579eb3L328-R338).
* Added `New` methods to `Config` structs in `triedb/hashdb/database.go` and `triedb/pathdb/database.go` to instantiate `HashBackend` and `PathBackend` respectively (`triedb/hashdb/database.go`) [[1]](diffhunk://#diff-1de51404a72746ab05e1af86ca5ccaea4e8cc2944a27c2491add383c54c1c43fR83-R86) (`triedb/pathdb/database.go`) [[2]](diffhunk://#diff-857fb5a23c8a9d400e179802702daddef6e2d495d67e9b9b9c0b09a79eb16679R96-R99).

## How this was tested
CI