### PR TITLE
refactor: `PrecompileEnvironment.{,Use,Refund}Gas()` in lieu of args

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -177,7 +177,9 @@ func (args *evmCallArgs) RunPrecompiledContract(p PrecompiledContract, input []b
 		return nil, 0, ErrOutOfGas
 	}
 	suppliedGas -= gasCost
-	return args.run(p, input, suppliedGas)
+	args.gasRemaining = suppliedGas
+	output, err := args.run(p, input)
+	return output, args.gasRemaining, err
 }
 
 // ECRECOVER implemented as a native contract.

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -92,7 +92,7 @@ func (t CallType) OpCode() OpCode {
 // regular types.
 func (args *evmCallArgs) run(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
 	if p, ok := p.(statefulPrecompile); ok {
-		// `suppliedGas` is already held by the args.
+		// `suppliedGas` is already held by the args, and captured by `env()`.
 		return p.run(args.env(), input)
 	}
 	// Gas consumption for regular precompiles was already handled by the native

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -45,11 +45,11 @@ type evmCallArgs struct {
 	callType CallType
 
 	// args:start
-	caller ContractRef
-	addr   common.Address
-	input  []byte
-	gas    uint64
-	value  *uint256.Int
+	caller       ContractRef
+	addr         common.Address
+	input        []byte
+	gasRemaining uint64
+	value        *uint256.Int
 	// args:end
 }
 
@@ -89,16 +89,17 @@ func (t CallType) OpCode() OpCode {
 }
 
 // run runs the [PrecompiledContract], differentiating between stateful and
-// regular types.
-func (args *evmCallArgs) run(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
-	if p, ok := p.(statefulPrecompile); ok {
-		// `suppliedGas` is already held by the args, and captured by `env()`.
-		return p.run(args.env(), input)
+// regular types, updating `gasRemaining` in the stateful case.
+func (args *evmCallArgs) run(p PrecompiledContract, input []byte) (ret []byte, err error) {
+	switch p := p.(type) {
+	default:
+		return p.Run(input)
+	case statefulPrecompile:
+		env := args.env()
+		ret, err := p(env, input)
+		args.gasRemaining = env.Gas()
+		return ret, err
 	}
-	// Gas consumption for regular precompiles was already handled by the native
-	// RunPrecompiledContract(), which called this method.
-	ret, err = p.Run(input)
-	return ret, suppliedGas, err
 }
 
 // PrecompiledStatefulContract is the stateful equivalent of a
@@ -122,11 +123,6 @@ func NewStatefulPrecompile(run PrecompiledStatefulContract) PrecompiledContract 
 // methods are defined on this unexported type instead of directly on
 // [PrecompiledStatefulContract] to hide implementation details.
 type statefulPrecompile PrecompiledStatefulContract
-
-func (p statefulPrecompile) run(env *environment, input []byte) ([]byte, uint64, error) {
-	ret, err := p(env, input)
-	return ret, env.self.Gas, err
-}
 
 // RequiredGas always returns zero as this gas is consumed by native geth code
 // before the contract is run.
@@ -189,7 +185,7 @@ func (args *evmCallArgs) env() *environment {
 
 	// This is equivalent to the `contract` variables created by evm.*Call*()
 	// methods, for non precompiles, to pass to [EVMInterpreter.Run].
-	contract := NewContract(args.caller, AccountRef(self), value, args.gas)
+	contract := NewContract(args.caller, AccountRef(self), value, args.gasRemaining)
 	if args.callType == DelegateCall {
 		contract = contract.AsDelegate()
 	}

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -104,9 +104,9 @@ func (args *evmCallArgs) run(p PrecompiledContract, input []byte, suppliedGas ui
 // PrecompiledStatefulContract is the stateful equivalent of a
 // [PrecompiledContract].
 //
-// Instead of receiving and returning gas limits, stateful precompiles use the
-// respective methods on [PrecompileEnvironment]. If a call to UseGas() returns
-// false, a stateful precompile SHOULD return [ErrOutOfGas].
+// Instead of receiving and returning gas arguments, stateful precompiles use
+// the respective methods on [PrecompileEnvironment]. If a call to UseGas()
+// returns false, a stateful precompile SHOULD return [ErrOutOfGas].
 type PrecompiledStatefulContract func(env PrecompileEnvironment, input []byte) (ret []byte, err error)
 
 // NewStatefulPrecompile constructs a new PrecompiledContract that can be used

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -89,7 +89,7 @@ func (t CallType) OpCode() OpCode {
 }
 
 // run runs the [PrecompiledContract], differentiating between stateful and
-// regular types, updating `gasRemaining` in the stateful case.
+// regular types, updating `args.gasRemaining` in the stateful case.
 func (args *evmCallArgs) run(p PrecompiledContract, input []byte) (ret []byte, err error) {
 	switch p := p.(type) {
 	default:

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -151,7 +151,7 @@ type PrecompileEnvironment interface {
 	ReadOnly() bool
 	// Equivalent to respective methods on [Contract].
 	Gas() uint64
-	UseGas(uint64) bool
+	UseGas(uint64) (hasEnoughGas bool)
 	Value() *uint256.Int
 
 	BlockHeader() (types.Header, error)

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -149,11 +149,11 @@ func TestNewStatefulPrecompile(t *testing.T) {
 
 	run := func(env vm.PrecompileEnvironment, input []byte, suppliedGas uint64) ([]byte, uint64, error) {
 		if got, want := env.StateDB() != nil, !env.ReadOnly(); got != want {
-			return nil, suppliedGas, fmt.Errorf("PrecompileEnvironment().StateDB() must be non-nil i.f.f. not read-only; got non-nil? %t; want %t", got, want)
+			return nil, 0, fmt.Errorf("PrecompileEnvironment().StateDB() must be non-nil i.f.f. not read-only; got non-nil? %t; want %t", got, want)
 		}
 		hdr, err := env.BlockHeader()
 		if err != nil {
-			return nil, suppliedGas, err
+			return nil, 0, err
 		}
 
 		out := &statefulPrecompileOutput{

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/common/math"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/params"
@@ -36,12 +37,25 @@ type environment struct {
 	callType CallType
 }
 
+func (e *environment) Gas() uint64            { return e.self.Gas }
+func (e *environment) UseGas(gas uint64) bool { return e.self.UseGas(gas) }
+func (e *environment) Value() *uint256.Int    { return e.self.Value() }
+
 func (e *environment) ChainConfig() *params.ChainConfig  { return e.evm.chainConfig }
 func (e *environment) Rules() params.Rules               { return e.evm.chainRules }
 func (e *environment) ReadOnlyState() libevm.StateReader { return e.evm.StateDB }
 func (e *environment) IncomingCallType() CallType        { return e.callType }
 func (e *environment) BlockNumber() *big.Int             { return new(big.Int).Set(e.evm.Context.BlockNumber) }
 func (e *environment) BlockTime() uint64                 { return e.evm.Context.Time }
+
+func (e *environment) refundGas(add uint64) error {
+	gas, overflow := math.SafeAdd(e.self.Gas, add)
+	if overflow {
+		return ErrGasUintOverflow
+	}
+	e.self.Gas = gas
+	return nil
+}
 
 func (e *environment) ReadOnly() bool {
 	// A switch statement provides clearer code coverage for difficult-to-test
@@ -86,11 +100,11 @@ func (e *environment) BlockHeader() (types.Header, error) {
 	return *hdr, nil
 }
 
-func (e *environment) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) ([]byte, uint64, error) {
+func (e *environment) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) ([]byte, error) {
 	return e.callContract(Call, addr, input, gas, value, opts...)
 }
 
-func (e *environment) callContract(typ CallType, addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) (retData []byte, retGas uint64, retErr error) {
+func (e *environment) callContract(typ CallType, addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) (retData []byte, retErr error) {
 	// Depth and read-only setting are handled by [EVMInterpreter.Run], which
 	// isn't used for precompiles, so we need to do it ourselves to maintain the
 	// expected invariants.
@@ -118,13 +132,17 @@ func (e *environment) callContract(typ CallType, addr common.Address, input []by
 			}
 		case nil:
 		default:
-			return nil, gas, fmt.Errorf("unsupported option %T", o)
+			return nil, fmt.Errorf("unsupported option %T", o)
 		}
 	}
 
 	if in.readOnly && value != nil && !value.IsZero() {
-		return nil, gas, ErrWriteProtection
+		return nil, ErrWriteProtection
 	}
+	if !e.UseGas(gas) {
+		return nil, ErrOutOfGas
+	}
+
 	if t := e.evm.Config.Tracer; t != nil {
 		var bigVal *big.Int
 		if value != nil {
@@ -134,13 +152,17 @@ func (e *environment) callContract(typ CallType, addr common.Address, input []by
 
 		startGas := gas
 		defer func() {
-			t.CaptureEnd(retData, startGas-retGas, retErr)
+			t.CaptureEnd(retData, startGas-e.Gas(), retErr)
 		}()
 	}
 
 	switch typ {
 	case Call:
-		return e.evm.Call(caller, addr, input, gas, value)
+		ret, returnGas, err := e.evm.Call(caller, addr, input, gas, value)
+		if err := e.refundGas(returnGas); err != nil {
+			return nil, err
+		}
+		return ret, err
 	case CallCode, DelegateCall, StaticCall:
 		// TODO(arr4n): these cases should be very similar to CALL, hence the
 		// early abstraction, to signal to future maintainers. If implementing
@@ -149,6 +171,6 @@ func (e *environment) callContract(typ CallType, addr common.Address, input []by
 		// compatibility.
 		fallthrough
 	default:
-		return nil, gas, fmt.Errorf("unimplemented precompile call type %v", typ)
+		return nil, fmt.Errorf("unimplemented precompile call type %v", typ)
 	}
 }

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -39,7 +39,7 @@ type environment struct {
 
 func (e *environment) Gas() uint64            { return e.self.Gas }
 func (e *environment) UseGas(gas uint64) bool { return e.self.UseGas(gas) }
-func (e *environment) Value() *uint256.Int    { return e.self.Value() }
+func (e *environment) Value() *uint256.Int    { return new(uint256.Int).Set(e.self.Value()) }
 
 func (e *environment) ChainConfig() *params.ChainConfig  { return e.evm.chainConfig }
 func (e *environment) Rules() params.Rules               { return e.evm.chainRules }

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -158,11 +158,11 @@ func (e *environment) callContract(typ CallType, addr common.Address, input []by
 
 	switch typ {
 	case Call:
-		ret, returnGas, err := e.evm.Call(caller, addr, input, gas, value)
+		ret, returnGas, callErr := e.evm.Call(caller, addr, input, gas, value)
 		if err := e.refundGas(returnGas); err != nil {
 			return nil, err
 		}
-		return ret, err
+		return ret, callErr
 	case CallCode, DelegateCall, StaticCall:
 		// TODO(arr4n): these cases should be very similar to CALL, hence the
 		// early abstraction, to signal to future maintainers. If implementing

--- a/core/vm/libevm_test.go
+++ b/core/vm/libevm_test.go
@@ -18,5 +18,5 @@ package vm
 // The original RunPrecompiledContract was migrated to being a method on
 // [evmCallArgs]. We need to replace it for use by regular geth tests.
 func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
-	return (*evmCallArgs)(nil).RunPrecompiledContract(p, input, suppliedGas)
+	return new(evmCallArgs).RunPrecompiledContract(p, input, suppliedGas)
 }

--- a/libevm/legacy/legacy.go
+++ b/libevm/legacy/legacy.go
@@ -1,0 +1,39 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+// Package legacy provides converters between legacy types and their refactored
+// equivalents.
+package legacy
+
+import "github.com/ava-labs/libevm/core/vm"
+
+// PrecompiledStatefulContract is the legacy signature of
+// [vm.PrecompiledStatefulContract], which explicitly accepts and returns gas
+// values. Instances SHOULD NOT use the [vm.PrecompileEnvironment]
+// gas-management methods as this may result in unexpected behaviour.
+type PrecompiledStatefulContract func(env vm.PrecompileEnvironment, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error)
+
+// Upgrade converts the legacy precompile signature into the now-required form.
+func (c PrecompiledStatefulContract) Upgrade() vm.PrecompiledStatefulContract {
+	return func(env vm.PrecompileEnvironment, input []byte) ([]byte, error) {
+		gas := env.Gas()
+		ret, remainingGas, err := c(env, input, env.Gas())
+		if used := gas - remainingGas; used < gas {
+			env.UseGas(used)
+		}
+		return ret, err
+	}
+}

--- a/libevm/legacy/legacy.go
+++ b/libevm/legacy/legacy.go
@@ -30,7 +30,7 @@ type PrecompiledStatefulContract func(env vm.PrecompileEnvironment, input []byte
 func (c PrecompiledStatefulContract) Upgrade() vm.PrecompiledStatefulContract {
 	return func(env vm.PrecompileEnvironment, input []byte) ([]byte, error) {
 		gas := env.Gas()
-		ret, remainingGas, err := c(env, input, env.Gas())
+		ret, remainingGas, err := c(env, input, gas)
 		if used := gas - remainingGas; used < gas {
 			env.UseGas(used)
 		}


### PR DESCRIPTION
## Why this should be merged

Aligns precompiled contracts with the pattern used in `vm.EVMInterpreter` for regular contracts and simplifies gas accounting by using existing mechanisms. The most notable simplification occurs when there are multiple error paths that return early and have to account for consumed gas (any local solution would likely just mirror this one).

This forms part of a broader, long-term direction of feature parity between precompiled and bytecode contracts, exposed via `vm.PrecompileEnvironment`.

The `vm.Contract.Value()` method is also exposed as a natural accompaniment to this change.

## How this works

The original signature for `vm.PrecompiledStatefulContract` received the amount of gas available and then returned the amount remaining; this has been removed in lieu of exposing the existing `vm.Contract.UseGas()` method via the `vm.PrecompileEnvironment`. A new `legacy` package wraps the old signature and converts it to a new one so `ava-labs/coreth` doesn't need to be refactored.

```go
func oldPrecompile(env vm.PrecompileEnvironment, input []byte, gas uint64) ([]byte, uint64, error) {
  // ...
  if err != nil {
    return nil, gas - gasCost, err // pattern susceptible to bugs; should it be `nil, gas, err` ?
  }
  // ...
  return output, gas - gasCost, nil  
}

func newPrecompile(env vm.PrecompileEnvironment, input []byte) ([]byte, error) {
  // The original `gas` argument is still available as `env.Gas()`
  // ...
  if !env.UseGas(gasCost) { // an explicit point at which gas is consumed
    return nil, vm.ErrOutOfGas
  }
  // ...
  if err != nil {
    return nil, err
  }
  // ...
  return output, nil
}
```

## How this was tested

Existing unit test modified to use the `legacy` adaptor.