### PR TITLE
refactor: abstract `options` package

### DIFF
--- a/core/vm/options.libevm.go
+++ b/core/vm/options.libevm.go
@@ -16,10 +16,14 @@
 
 package vm
 
-// A CallOption modifies the default behaviour of a contract call.
-type CallOption interface {
-	libevmCallOption() // noop to only allow internally defined options
+import "github.com/ava-labs/libevm/libevm/options"
+
+type callConfig struct {
+	unsafeCallerAddressProxying bool
 }
+
+// A CallOption modifies the default behaviour of a contract call.
+type CallOption = options.Option[callConfig]
 
 // WithUNSAFECallerAddressProxying results in precompiles making contract calls
 // specifying their own caller's address as the caller. This is NOT SAFE for
@@ -29,10 +33,7 @@ type CallOption interface {
 // Deprecated: this option MUST NOT be used other than to allow migration to
 // libevm when backwards compatibility is required.
 func WithUNSAFECallerAddressProxying() CallOption {
-	return callOptUNSAFECallerAddressProxy{}
+	return options.Func[callConfig](func(c *callConfig) {
+		c.unsafeCallerAddressProxying = true
+	})
 }
-
-// Deprecated: see [WithUNSAFECallerAddressProxying].
-type callOptUNSAFECallerAddressProxy struct{}
-
-func (callOptUNSAFECallerAddressProxy) libevmCallOption() {}

--- a/libevm/options/options.go
+++ b/libevm/options/options.go
@@ -1,0 +1,42 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+// Package options provides a generic mechanism for defining configuration of
+// arbitrary types.
+package options
+
+// An Option configures values of arbitrary type.
+type Option[T any] interface {
+	Configure(*T)
+}
+
+// As applies Options to a zero-value T, which it then returns.
+func As[T any](opts ...Option[T]) *T {
+	var t T
+	for _, o := range opts {
+		o.Configure(&t)
+	}
+	return &t
+}
+
+// A Func converts a function into an [Option], using itself as the Configure
+// method.
+type Func[T any] func(*T)
+
+var _ Option[struct{}] = Func[struct{}](nil)
+
+// Configure implements the [Option] interface.
+func (f Func[T]) Configure(t *T) { f(t) }


### PR DESCRIPTION
## Why this should be merged

Simplifies the creation and application of variadic options; this is also applicable to many of my other WIP branches (e.g. `snapshot`).

## How this works

See `libevm/options/options.go`, which is very simple.

## How this was tested

Existing tests of `vm.PrecompileEnvironment.Call()`, which itself uses refactored options.