### PR TITLE
feat(core/state): async trie prefetching

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -175,13 +175,13 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the
 // state trie concurrently while the state is mutated so that when we reach the
 // commit phase, most of the needed data is already hot.
-func (s *StateDB) StartPrefetcher(namespace string) {
+func (s *StateDB) StartPrefetcher(namespace string, opts ...PrefetcherOption) {
 	if s.prefetcher != nil {
 		s.prefetcher.close()
 		s.prefetcher = nil
 	}
 	if s.snap != nil {
-		s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, namespace)
+		s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, namespace, opts...)
 	}
 }
 

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -355,9 +355,9 @@ func (sf *subfetcher) loop() {
 						sf.dups++
 					} else {
 						if len(task) == common.AddressLength {
-							sf.GetAccount(common.BytesToAddress(task))
+							sf.pool.GetAccount(common.BytesToAddress(task))
 						} else {
-							sf.GetStorage(sf.addr, task)
+							sf.pool.GetStorage(sf.addr, task)
 						}
 						sf.seen[string(task)] = struct{}{}
 					}

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -79,7 +79,7 @@ func newTriePrefetcher(db Database, root common.Hash, namespace string, opts ...
 // close iterates over all the subfetchers, aborts any that were left spinning
 // and reports the stats to the metrics subsystem.
 func (p *triePrefetcher) close() {
-	p.abortFetchersConcurrently()
+	p.abortFetchersAndReleaseWorkerPools()
 	for _, fetcher := range p.fetchers {
 		fetcher.abort() // safe to do multiple times
 

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -79,7 +79,6 @@ func newTriePrefetcher(db Database, root common.Hash, namespace string, opts ...
 // close iterates over all the subfetchers, aborts any that were left spinning
 // and reports the stats to the metrics subsystem.
 func (p *triePrefetcher) close() {
-	p.abortFetchersAndReleaseWorkerPools()
 	for _, fetcher := range p.fetchers {
 		fetcher.abort() // safe to do multiple times
 
@@ -105,6 +104,7 @@ func (p *triePrefetcher) close() {
 			}
 		}
 	}
+	p.releaseWorkerPools()
 	// Clear out all fetchers (will crash on a second call, deliberate)
 	p.fetchers = nil
 }

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -339,14 +339,14 @@ func (sf *subfetcher) loop() {
 			sf.lock.Unlock()
 
 			// Prefetch any tasks until the loop is interrupted
-			for i, task := range tasks {
+			for _, task := range tasks {
 				select {
-				case <-sf.stop:
-					// If termination is requested, add any leftover back and return
-					sf.lock.Lock()
-					sf.tasks = append(sf.tasks, tasks[i:]...)
-					sf.lock.Unlock()
-					return
+				//libevm:start
+				//
+				// The <-sf.stop case has been removed, in keeping with the equivalent change below. Future geth
+				// versions also remove it so our modification here can be undone when merging upstream.
+				//
+				//libevm:end
 
 				case ch := <-sf.copy:
 					// Somebody wants a copy of the current trie, grant them

--- a/core/state/trie_prefetcher.libevm.go
+++ b/core/state/trie_prefetcher.libevm.go
@@ -51,9 +51,9 @@ type subfetcherPool struct {
 	tries   sync.Pool
 }
 
-// apply configures the [subfetcher] to use a [WorkerPool] if one was provided
+// applyTo configures the [subfetcher] to use a [WorkerPool] if one was provided
 // with a [PrefetcherOption].
-func (c *prefetcherConfig) apply(sf *subfetcher) {
+func (c *prefetcherConfig) applyTo(sf *subfetcher) {
 	sf.pool = &subfetcherPool{
 		tries: sync.Pool{
 			// Although the workers may be shared between all subfetchers, each
@@ -68,10 +68,11 @@ func (c *prefetcherConfig) apply(sf *subfetcher) {
 	}
 }
 
-func (sf *subfetcher) wait() {
-	if w := sf.pool.workers; w != nil {
-		w.Wait()
+func (p *subfetcherPool) wait() {
+	if p == nil || p.workers == nil {
+		return
 	}
+	p.workers.Wait()
 }
 
 // execute runs the provided function with a copy of the subfetcher's Trie.

--- a/core/state/trie_prefetcher.libevm.go
+++ b/core/state/trie_prefetcher.libevm.go
@@ -79,20 +79,20 @@ func (p *subfetcherPool) wait() {
 // Copies are stored in a [sync.Pool] to reduce creation overhead. If sf was
 // configured with a [WorkerPool] then it is used for function execution,
 // otherwise `fn` is just called directly.
-func (sf *subfetcher) execute(fn func(Trie)) {
-	trie := sf.pool.tries.Get().(Trie)
-	if w := sf.pool.workers; w != nil {
+func (p *subfetcherPool) execute(fn func(Trie)) {
+	trie := p.tries.Get().(Trie)
+	if w := p.workers; w != nil {
 		w.Execute(func() { fn(trie) })
 	} else {
 		fn(trie)
 	}
-	sf.pool.tries.Put(trie)
+	p.tries.Put(trie)
 }
 
 // GetAccount optimistically pre-fetches an account, dropping the returned value
 // and logging errors. See [subfetcher.execute] re worker pools.
-func (sf *subfetcher) GetAccount(addr common.Address) {
-	sf.execute(func(t Trie) {
+func (p *subfetcherPool) GetAccount(addr common.Address) {
+	p.execute(func(t Trie) {
 		if _, err := t.GetAccount(addr); err != nil {
 			log.Error("account prefetching failed", "address", addr, "err", err)
 		}
@@ -100,8 +100,8 @@ func (sf *subfetcher) GetAccount(addr common.Address) {
 }
 
 // GetStorage is the storage equivalent of [subfetcher.GetAccount].
-func (sf *subfetcher) GetStorage(addr common.Address, key []byte) {
-	sf.execute(func(t Trie) {
+func (p *subfetcherPool) GetStorage(addr common.Address, key []byte) {
+	p.execute(func(t Trie) {
 		if _, err := t.GetStorage(addr, key); err != nil {
 			log.Error("storage prefetching failed", "address", addr, "key", key, "err", err)
 		}

--- a/core/state/trie_prefetcher.libevm.go
+++ b/core/state/trie_prefetcher.libevm.go
@@ -1,0 +1,108 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"sync"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/libevm/options"
+	"github.com/ava-labs/libevm/log"
+)
+
+// A PrefetcherOption configures behaviour of trie prefetching.
+type PrefetcherOption = options.Option[prefetcherConfig]
+
+type prefetcherConfig struct {
+	newWorkers func() WorkerPool
+}
+
+// A WorkerPool is responsible for executing functions, possibly asynchronously.
+type WorkerPool interface {
+	Execute(func())
+	Wait()
+}
+
+// WithWorkerPools configures trie prefetching to execute asynchronously. The
+// provided constructor is called once for each trie being fetched and it MAY
+// return the same pool.
+func WithWorkerPools(ctor func() WorkerPool) PrefetcherOption {
+	return options.Func[prefetcherConfig](func(c *prefetcherConfig) {
+		c.newWorkers = ctor
+	})
+}
+
+type subfetcherPool struct {
+	workers WorkerPool
+	tries   sync.Pool
+}
+
+// apply configures the [subfetcher] to use a [WorkerPool] if one was provided
+// with a [PrefetcherOption].
+func (c *prefetcherConfig) apply(sf *subfetcher) {
+	sf.pool = &subfetcherPool{
+		tries: sync.Pool{
+			// Although the workers may be shared between all subfetchers, each
+			// MUST have its own Trie pool.
+			New: func() any {
+				return sf.db.CopyTrie(sf.trie)
+			},
+		},
+	}
+	if c.newWorkers != nil {
+		sf.pool.workers = c.newWorkers()
+	}
+}
+
+func (sf *subfetcher) wait() {
+	if w := sf.pool.workers; w != nil {
+		w.Wait()
+	}
+}
+
+// execute runs the provided function with a copy of the subfetcher's Trie.
+// Copies are stored in a [sync.Pool] to reduce creation overhead. If sf was
+// configured with a [WorkerPool] then it is used for function execution,
+// otherwise `fn` is just called directly.
+func (sf *subfetcher) execute(fn func(Trie)) {
+	trie := sf.pool.tries.Get().(Trie)
+	if w := sf.pool.workers; w != nil {
+		w.Execute(func() { fn(trie) })
+	} else {
+		fn(trie)
+	}
+	sf.pool.tries.Put(trie)
+}
+
+// GetAccount optimistically pre-fetches an account, dropping the returned value
+// and logging errors. See [subfetcher.execute] re worker pools.
+func (sf *subfetcher) GetAccount(addr common.Address) {
+	sf.execute(func(t Trie) {
+		if _, err := t.GetAccount(addr); err != nil {
+			log.Error("account prefetching failed", "address", addr, "err", err)
+		}
+	})
+}
+
+// GetStorage is the storage equivalent of [subfetcher.GetAccount].
+func (sf *subfetcher) GetStorage(addr common.Address, key []byte) {
+	sf.execute(func(t Trie) {
+		if _, err := t.GetStorage(addr, key); err != nil {
+			log.Error("storage prefetching failed", "address", addr, "key", key, "err", err)
+		}
+	})
+}

--- a/core/state/trie_prefetcher.libevm_test.go
+++ b/core/state/trie_prefetcher.libevm_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/libevm/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ava-labs/libevm/common"
 )
 
 type synchronisingWorkerPool struct {
@@ -73,7 +74,7 @@ func TestStopPrefetcherWaitsOnWorkers(t *testing.T) {
 
 	<-pool.executed
 	db.StopPrefetcher()
-	// If this happens then either Execute() hadn't returned or Done() wasn't
+	// If this errors then either Execute() hadn't returned or Done() wasn't
 	// called.
 	assert.Equalf(t, 2, pool.preconditionsToStopPrefetcher, "%T.StopPrefetcher() returned early", db)
 }

--- a/core/state/trie_prefetcher.libevm_test.go
+++ b/core/state/trie_prefetcher.libevm_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ava-labs/libevm/common"
+)
+
+type synchronisingWorkerPool struct {
+	executed, unblock chan struct{}
+}
+
+var _ WorkerPool = (*synchronisingWorkerPool)(nil)
+
+func (p *synchronisingWorkerPool) Execute(func()) {
+	select {
+	case <-p.executed:
+	default:
+		close(p.executed)
+	}
+}
+
+func (p *synchronisingWorkerPool) Wait() {
+	<-p.unblock
+}
+
+func TestStopPrefetcherWaitsOnWorkers(t *testing.T) {
+	pool := &synchronisingWorkerPool{
+		executed: make(chan struct{}),
+		unblock:  make(chan struct{}),
+	}
+	opt := WithWorkerPools(func() WorkerPool { return pool })
+
+	db := filledStateDB()
+	db.prefetcher = newTriePrefetcher(db.db, db.originalRoot, "", opt)
+	db.prefetcher.prefetch(common.Hash{}, common.Hash{}, common.Address{}, [][]byte{{}})
+
+	go func() {
+		<-pool.executed
+		// Sleep otherwise there is a small chance that we close pool.unblock
+		// between db.StopPrefetcher() returning and the select receiving on the
+		// channel.
+		time.Sleep(time.Second)
+		close(pool.unblock)
+	}()
+
+	<-pool.executed
+	db.StopPrefetcher()
+	select {
+	case <-pool.unblock:
+		// The channel was closed, therefore pool.Wait() unblocked. This is a
+		// necessary pre-condition for db.StopPrefetcher() unblocking, and the
+		// purpose of this test.
+	default:
+		t.Errorf("%T.StopPrefetcher() returned before %T.Wait() unblocked", db, pool)
+	}
+}

--- a/libevm/sync/sync.go
+++ b/libevm/sync/sync.go
@@ -1,0 +1,52 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+// Package sync extends the standard library's sync package.
+package sync
+
+import "sync"
+
+// Aliases of stdlib sync's types to avoid having to import it alongside this
+// package.
+type (
+	Cond      = sync.Cond
+	Locker    = sync.Locker
+	Map       = sync.Map
+	Mutex     = sync.Mutex
+	Once      = sync.Once
+	RWMutex   = sync.RWMutex
+	WaitGroup = sync.WaitGroup
+)
+
+// A Pool is a type-safe wrapper around [sync.Pool].
+type Pool[T any] struct {
+	New  func() T
+	pool sync.Pool
+	once Once
+}
+
+// Get is equivalent to [sync.Pool.Get].
+func (p *Pool[T]) Get() T {
+	p.once.Do(func() { // Do() guarantees at least once, not just only once
+		p.pool.New = func() any { return p.New() }
+	})
+	return p.pool.Get().(T) //nolint:forcetypeassert
+}
+
+// Put is equivalent to [sync.Pool.Put].
+func (p *Pool[T]) Put(t T) {
+	p.pool.Put(t)
+}


### PR DESCRIPTION
## Why this should be merged

Performs trie prefetching concurrently, required for equivalent performance with `coreth` / `subnet-evm` implementations.

## How this works

`StateDB.StartPrefetcher()` accepts variadic options (for backwards compatibility of function signatures). An option to specify a `WorkerPool` is provided which, if present, is used to call `Trie.Get{Account,Storage}()`; the pool is responsible for concurrency but does not need to be able to wait on the work as that is handled by this change.

## How this was tested

Unit test demonstrating hand-off of work to a `WorkerPool` as well as API-guaranteed ordering of events.