### PR TITLE
chore: mark upstream `triedb/pathdb` test flaky

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   go_test_short:
     env:
-      FLAKY_REGEX: 'ava-labs/libevm/(eth|eth/tracers/js|eth/tracers/logger|accounts/abi/bind|accounts/keystore|eth/downloader|miner|ethclient|ethclient/gethclient|eth/catalyst)$'
+      FLAKY_REGEX: 'ava-labs/libevm/(triedb/pathdb|eth|eth/tracers/js|eth/tracers/logger|accounts/abi/bind|accounts/keystore|eth/downloader|miner|ethclient|ethclient/gethclient|eth/catalyst)$'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why this should be merged

Reduce false-positive CI failures. The flaky block also runs first so fails early and allows quicker re-runs.

## How this works

Runs upstream `triedb/pathdb` test sequentially.

## How this was tested

[Inspection of CI](https://github.com/ava-labs/libevm/actions/runs/12049469376/job/33596276893?pr=78#step:4:17)