### PR TITLE
feat!: `types.ExtraPayloads` supports `SlimAccount`

### DIFF
--- a/core/state/state.libevm.go
+++ b/core/state/state.libevm.go
@@ -27,7 +27,7 @@ import (
 func GetExtra[SA any](s *StateDB, p types.ExtraPayloads[SA], addr common.Address) SA {
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
-		return p.FromStateAccount(&stateObject.data)
+		return p.FromPayloadCarrier(&stateObject.data)
 	}
 	var zero SA
 	return zero
@@ -45,9 +45,9 @@ func setExtraOnObject[SA any](s *stateObject, p types.ExtraPayloads[SA], addr co
 	s.db.journal.append(extraChange[SA]{
 		payloads: p,
 		account:  &addr,
-		prev:     p.FromStateAccount(&s.data),
+		prev:     p.FromPayloadCarrier(&s.data),
 	})
-	p.SetOnStateAccount(&s.data, extra)
+	p.SetOnPayloadCarrier(&s.data, extra)
 }
 
 // extraChange is a [journalEntry] for [SetExtra] / [setExtraOnObject].
@@ -60,5 +60,5 @@ type extraChange[SA any] struct {
 func (e extraChange[SA]) dirtied() *common.Address { return e.account }
 
 func (e extraChange[SA]) revert(s *StateDB) {
-	e.payloads.SetOnStateAccount(&s.getStateObject(*e.account).data, e.prev)
+	e.payloads.SetOnPayloadCarrier(&s.getStateObject(*e.account).data, e.prev)
 }

--- a/core/state/state.libevm_test.go
+++ b/core/state/state.libevm_test.go
@@ -87,7 +87,7 @@ func TestGetSetExtra(t *testing.T) {
 				Root:     types.EmptyRootHash,
 				CodeHash: types.EmptyCodeHash[:],
 			}
-			payloads.SetOnStateAccount(want, extra)
+			payloads.SetOnPayloadCarrier(want, extra)
 
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("types.FullAccount(%T.Account()) diff (-want +got):\n%s", iter, diff)

--- a/core/state/state_object.libevm_test.go
+++ b/core/state/state_object.libevm_test.go
@@ -46,7 +46,7 @@ func TestStateObjectEmpty(t *testing.T) {
 		{
 			name: "explicit false bool",
 			registerAndSet: func(acc *types.StateAccount) {
-				types.RegisterExtras[bool]().SetOnStateAccount(acc, false)
+				types.RegisterExtras[bool]().SetOnPayloadCarrier(acc, false)
 			},
 			wantEmpty: true,
 		},
@@ -60,7 +60,7 @@ func TestStateObjectEmpty(t *testing.T) {
 		{
 			name: "true bool",
 			registerAndSet: func(acc *types.StateAccount) {
-				types.RegisterExtras[bool]().SetOnStateAccount(acc, true)
+				types.RegisterExtras[bool]().SetOnPayloadCarrier(acc, true)
 			},
 			wantEmpty: false,
 		},

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -35,7 +35,7 @@ type StateAccount struct {
 	Root     common.Hash // merkle root of the storage trie
 	CodeHash []byte
 
-	Extra *StateAccountExtra
+	Extra *StateAccountExtra // only access via [ExtraPayloads] instances
 }
 
 // NewEmptyStateAccount constructs an empty state account.
@@ -71,7 +71,7 @@ type SlimAccount struct {
 	Root     []byte // Nil if root equals to types.EmptyRootHash
 	CodeHash []byte // Nil if hash equals to types.EmptyCodeHash
 
-	Extra *StateAccountExtra
+	Extra *StateAccountExtra // only access via [ExtraPayloads] instances
 }
 
 // SlimAccountRLP encodes the state account in 'slim RLP' format.

--- a/core/types/state_account_storage.libevm_test.go
+++ b/core/types/state_account_storage.libevm_test.go
@@ -71,12 +71,12 @@ func TestStateAccountExtraViaTrieStorage(t *testing.T) {
 		{
 			name: "true-boolean payload",
 			registerAndSetExtra: func(a *types.StateAccount) *types.StateAccount {
-				types.RegisterExtras[bool]().SetOnStateAccount(a, true)
+				types.RegisterExtras[bool]().SetOnPayloadCarrier(a, true)
 				return a
 			},
 			assertExtra: func(t *testing.T, sa *types.StateAccount) {
 				t.Helper()
-				assert.Truef(t, types.ExtraPayloads[bool]{}.FromStateAccount(sa), "")
+				assert.Truef(t, types.ExtraPayloads[bool]{}.FromPayloadCarrier(sa), "")
 			},
 			wantTrieHash: trueBool,
 		},
@@ -84,12 +84,12 @@ func TestStateAccountExtraViaTrieStorage(t *testing.T) {
 			name: "explicit false-boolean payload",
 			registerAndSetExtra: func(a *types.StateAccount) *types.StateAccount {
 				p := types.RegisterExtras[bool]()
-				p.SetOnStateAccount(a, false) // the explicit part
+				p.SetOnPayloadCarrier(a, false) // the explicit part
 				return a
 			},
 			assertExtra: func(t *testing.T, sa *types.StateAccount) {
 				t.Helper()
-				assert.Falsef(t, types.ExtraPayloads[bool]{}.FromStateAccount(sa), "")
+				assert.Falsef(t, types.ExtraPayloads[bool]{}.FromPayloadCarrier(sa), "")
 			},
 			wantTrieHash: falseBool,
 		},
@@ -102,7 +102,7 @@ func TestStateAccountExtraViaTrieStorage(t *testing.T) {
 			},
 			assertExtra: func(t *testing.T, sa *types.StateAccount) {
 				t.Helper()
-				assert.Falsef(t, types.ExtraPayloads[bool]{}.FromStateAccount(sa), "")
+				assert.Falsef(t, types.ExtraPayloads[bool]{}.FromPayloadCarrier(sa), "")
 			},
 			wantTrieHash: falseBool,
 		},
@@ -110,12 +110,12 @@ func TestStateAccountExtraViaTrieStorage(t *testing.T) {
 			name: "arbitrary payload",
 			registerAndSetExtra: func(a *types.StateAccount) *types.StateAccount {
 				p := arbitraryPayload{arbitraryData}
-				types.RegisterExtras[arbitraryPayload]().SetOnStateAccount(a, p)
+				types.RegisterExtras[arbitraryPayload]().SetOnPayloadCarrier(a, p)
 				return a
 			},
 			assertExtra: func(t *testing.T, sa *types.StateAccount) {
 				t.Helper()
-				got := types.ExtraPayloads[arbitraryPayload]{}.FromStateAccount(sa)
+				got := types.ExtraPayloads[arbitraryPayload]{}.FromPayloadCarrier(sa)
 				assert.Equalf(t, arbitraryPayload{arbitraryData}, got, "")
 			},
 			wantTrieHash: arbitrary,


### PR DESCRIPTION
## Why this should be merged

Provides access to extra payloads registered on `types.SlimAccount`, not just on regular `types.StateAccount`. This is a breaking syntax change to have the method reflect the behaviour.

## How this works

Modify existing method to accept the `ExtraPayloadCarrier` interface instead of `*StateAccount`. The interface is implemented by both `*StateAccount` and `*SlimAccount`.

## How this was tested

Covered by existing testing.