### PR TITLE
test: lock in `types.Header` RLP encoding

### DIFF
--- a/core/types/rlp_backwards_compat.libevm_test.go
+++ b/core/types/rlp_backwards_compat.libevm_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package types_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/libevm/ethtest"
+	"github.com/ava-labs/libevm/rlp"
+)
+
+func TestHeaderRLPBackwardsCompatibility(t *testing.T) {
+	// This is a deliberate change-detector test that locks in backwards
+	// compatibility of RLP encoding.
+	rng := ethtest.NewPseudoRand(42)
+
+	const numExtraBytes = 16
+	hdr := &Header{
+		ParentHash:  rng.Hash(),
+		UncleHash:   rng.Hash(),
+		Coinbase:    rng.Address(),
+		Root:        rng.Hash(),
+		TxHash:      rng.Hash(),
+		ReceiptHash: rng.Hash(),
+		// Bloom populated below
+		Difficulty: rng.Uint256().ToBig(),
+		Number:     rng.BigUint64(),
+		GasLimit:   rng.Uint64(),
+		GasUsed:    rng.Uint64(),
+		Time:       rng.Uint64(),
+		Extra:      make([]byte, numExtraBytes), // populated below
+		MixDigest:  rng.Hash(),
+		// Nonce populated below
+
+		BaseFee:          rng.BigUint64(),
+		WithdrawalsHash:  rng.HashPtr(),
+		BlobGasUsed:      rng.Uint64Ptr(),
+		ExcessBlobGas:    rng.Uint64Ptr(),
+		ParentBeaconRoot: rng.HashPtr(),
+	}
+	require.Equal(t, BloomByteLength, rng.Read(hdr.Bloom[:]))
+	require.Equal(t, len(BlockNonce{}), rng.Read(hdr.Nonce[:]))
+	require.Equal(t, numExtraBytes, rng.Read(hdr.Extra))
+	t.Logf("%T:\n%+v", hdr, hdr)
+
+	// WARNING: changing this hex might break backwards compatibility of RLP
+	// encoding (i.e. block hashes might change)!
+	const wantHex = `f9029aa01a571e7e4d774caf46053201cfe0001b3c355ffcc93f510e671e8809741f0eeda0756095410506ec72a2c287fe83ebf68efb0be177e61acec1c985277e90e52087941bfc3bc193012ba58912c01fb35a3454831a8971a00bc9f064144eb5965c5e5d1020f9f90392e7e06ded9225966abc7c754b410e61a0d942eab201424f4320ec1e1ffa9390baf941629b9349977b5d48e0502dbb9386a035d9d550a9c113f78689b4c161c4605609bb57b83061914c42ad244daa7fc38eb90100718d155798390a6c6782181d1bac1dd64cd956332b008412ddc735f2994e297c8a088c6bb4c637542295ba3cbc3cd399c8127076f4d834d74d5b11a36b6d02e2fe3a583216aa4ccef052df9a96e7a454256bebabdfc38c429079f25913e0f1d7416b2f056c4a115fc757012b1757d2d69f0e5fb87c08605098d9031fa37cd0df6942c5a2da12a4424b978febf5479896165caf573cf82fb3aa10f6ebf6b62bef8ed36b8ea3d4b1ddb80c99afafa37cb8f3393eb6d802f5bc6c8cd6bcd168a7e0061a718218b848d945135b6dff228a4e66bade4717e6f4d318ac98fca12a053af6f98805a764fb5d523cb6f69029522cab9ced907cc75718f7e2c79154ef3fc7a04b31d39ae246d689f23176d679a62ff328f530407cbafd0146f45b2ed635282e88b36f6a5752feff5b881fc7fa9ef217f81d889f073433138e6ba58857515405d28f2a8e904bcda3066d382675f37dd1a18507b5fba02812f2701021506f27190adb52a1313f6d28c77d66ae1aa3d3d6757a762476f488294c7768cddd9ccf881b5da1b6a47970a3a0c8a2b7b2c44161190c82d5e1c8b55e05c7354f1e5f6512924c941fb3d93667dc889bc9df25654e163c88859405c51041475fa03a8c304a732153e20300c3482832d07b65f97958360da414cb438ce252aec6c2`
+	want, err := hex.DecodeString(wantHex)
+	require.NoError(t, err, "hex.DecodeString()")
+
+	got, err := rlp.EncodeToBytes(hdr)
+	require.NoErrorf(t, err, "rlp.EncodeToBytes(%T)", hdr)
+	assert.Equalf(t, want, got, "rlp.EncodeToBytes(%T)", hdr)
+}

--- a/core/types/rlp_backwards_compat.libevm_test.go
+++ b/core/types/rlp_backwards_compat.libevm_test.go
@@ -41,15 +41,15 @@ func TestHeaderRLPBackwardsCompatibility(t *testing.T) {
 		Root:        rng.Hash(),
 		TxHash:      rng.Hash(),
 		ReceiptHash: rng.Hash(),
-		// Bloom populated below
-		Difficulty: rng.Uint256().ToBig(),
-		Number:     rng.BigUint64(),
-		GasLimit:   rng.Uint64(),
-		GasUsed:    rng.Uint64(),
-		Time:       rng.Uint64(),
-		Extra:      make([]byte, numExtraBytes), // populated below
-		MixDigest:  rng.Hash(),
-		// Nonce populated below
+		Bloom:       rng.Bloom(),
+		Difficulty:  rng.Uint256().ToBig(),
+		Number:      rng.BigUint64(),
+		GasLimit:    rng.Uint64(),
+		GasUsed:     rng.Uint64(),
+		Time:        rng.Uint64(),
+		Extra:       rng.Bytes(numExtraBytes),
+		MixDigest:   rng.Hash(),
+		Nonce:       rng.BlockNonce(),
 
 		BaseFee:          rng.BigUint64(),
 		WithdrawalsHash:  rng.HashPtr(),
@@ -57,14 +57,11 @@ func TestHeaderRLPBackwardsCompatibility(t *testing.T) {
 		ExcessBlobGas:    rng.Uint64Ptr(),
 		ParentBeaconRoot: rng.HashPtr(),
 	}
-	require.Equal(t, BloomByteLength, rng.Read(hdr.Bloom[:]))
-	require.Equal(t, len(BlockNonce{}), rng.Read(hdr.Nonce[:]))
-	require.Equal(t, numExtraBytes, rng.Read(hdr.Extra))
 	t.Logf("%T:\n%+v", hdr, hdr)
 
 	// WARNING: changing this hex might break backwards compatibility of RLP
 	// encoding (i.e. block hashes might change)!
-	const wantHex = `f9029aa01a571e7e4d774caf46053201cfe0001b3c355ffcc93f510e671e8809741f0eeda0756095410506ec72a2c287fe83ebf68efb0be177e61acec1c985277e90e52087941bfc3bc193012ba58912c01fb35a3454831a8971a00bc9f064144eb5965c5e5d1020f9f90392e7e06ded9225966abc7c754b410e61a0d942eab201424f4320ec1e1ffa9390baf941629b9349977b5d48e0502dbb9386a035d9d550a9c113f78689b4c161c4605609bb57b83061914c42ad244daa7fc38eb90100718d155798390a6c6782181d1bac1dd64cd956332b008412ddc735f2994e297c8a088c6bb4c637542295ba3cbc3cd399c8127076f4d834d74d5b11a36b6d02e2fe3a583216aa4ccef052df9a96e7a454256bebabdfc38c429079f25913e0f1d7416b2f056c4a115fc757012b1757d2d69f0e5fb87c08605098d9031fa37cd0df6942c5a2da12a4424b978febf5479896165caf573cf82fb3aa10f6ebf6b62bef8ed36b8ea3d4b1ddb80c99afafa37cb8f3393eb6d802f5bc6c8cd6bcd168a7e0061a718218b848d945135b6dff228a4e66bade4717e6f4d318ac98fca12a053af6f98805a764fb5d523cb6f69029522cab9ced907cc75718f7e2c79154ef3fc7a04b31d39ae246d689f23176d679a62ff328f530407cbafd0146f45b2ed635282e88b36f6a5752feff5b881fc7fa9ef217f81d889f073433138e6ba58857515405d28f2a8e904bcda3066d382675f37dd1a18507b5fba02812f2701021506f27190adb52a1313f6d28c77d66ae1aa3d3d6757a762476f488294c7768cddd9ccf881b5da1b6a47970a3a0c8a2b7b2c44161190c82d5e1c8b55e05c7354f1e5f6512924c941fb3d93667dc889bc9df25654e163c88859405c51041475fa03a8c304a732153e20300c3482832d07b65f97958360da414cb438ce252aec6c2`
+	const wantHex = `f9029aa01a571e7e4d774caf46053201cfe0001b3c355ffcc93f510e671e8809741f0eeda0756095410506ec72a2c287fe83ebf68efb0be177e61acec1c985277e90e52087941bfc3bc193012ba58912c01fb35a3454831a8971a00bc9f064144eb5965c5e5d1020f9f90392e7e06ded9225966abc7c754b410e61a0d942eab201424f4320ec1e1ffa9390baf941629b9349977b5d48e0502dbb9386a035d9d550a9c113f78689b4c161c4605609bb57b83061914c42ad244daa7fc38eb901004b31d39ae246d689f23176d679a62ff328f530407cbafd0146f45b2ed635282e2812f2705bfffe52576a6fb31df817f29efac71fa56b8e133334079f8e2a8fd2055451571021506f27190adb52a1313f6d28c77d66ae1aa3d3d6757a762476f4c8a2b7b2a37079a4b6a15d1bc44161190c82d5e1c8b55e05c7354f1e5f6512924c941fb3d93667dc3a8c304a3c164e6525dfc99b5f474110c5059485732153e20300c3482832d07b65f97958360da414cb438ce252aec6c2718d155798390a6c6782181d1bac1dd64cd956332b008412ddc735f2994e297c8a088c6bb4c637542295ba3cbc3cd399c8127076f4d834d74d5b11a36b6d02e2fe3a583216aa4ccea0f052df9a96e7a454256bebabdfc38c429079f25913e0f1d7416b2f056c4a115f88b85f0e9fd6d25717881f03d9985060087c88a2c54269dfd07ca388eb8f974b42a412da90c757012bf5479896165caf573cf82fb3a0aa10f6ebf6b62bef8ed36b8ea3d4b1ddb80c99afafa37cb8f3393eb6d802f5bc886c8cd6bcd168a7e0886d5b1345d948b818a0061a7182ff228a4e66bade4717e6f4d318ac98fca12a053af6f98805a764fb5d8890ed9cab2c5229908891c7e2f71857c77ca0523cb6f654ef3fc7294c7768cddd9ccf4bcda3066d382675f37dd1a18507b5fb`
 	want, err := hex.DecodeString(wantHex)
 	require.NoError(t, err, "hex.DecodeString()")
 

--- a/libevm/ethtest/rand.go
+++ b/libevm/ethtest/rand.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/exp/rand"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
 )
 
 // PseudoRand extends [rand.Rand] (*not* crypto/rand).
@@ -87,4 +88,16 @@ func (r *PseudoRand) Uint64Ptr() *uint64 {
 // Uint256 returns a random 256-bit unsigned int.
 func (r *PseudoRand) Uint256() *uint256.Int {
 	return new(uint256.Int).SetBytes(r.Bytes(32))
+}
+
+// Bloom returns a pseudorandom Bloom.
+func (r *PseudoRand) Bloom() (b types.Bloom) {
+	r.Read(b[:])
+	return b
+}
+
+// BlockNonce returns a pseudorandom BlockNonce.
+func (r *PseudoRand) BlockNonce() (n types.BlockNonce) {
+	r.Read(n[:])
+	return n
 }


### PR DESCRIPTION
## Why this should be merged

We're making changes to very sensitive code that, if broken, can result in block hashes being different.

## How this works

Change-detector test.

## How this was tested

A randomly filled `types.Header` with expected RLP locked as a constant in the test.