### PR TITLE
chore: migrate instead of delete old labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -61,7 +61,6 @@
   color: "ff9efc"
 - name: "Complexity: 🟦 Easy to do"
   color: "ff9efc"
-  from_name: "good first issue"
 
 # Closing reason
 - name: "Closed: 👥 Duplicate"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -30,8 +30,6 @@
 - name: "Category: Label missing ❗"
   description: "Use this if it feels a label should be added to label this issue"
   color: "ffc7ea"
-- name: "Category: Question / Help wanted ❓"
-  from_name: "question"
 
 # Status
 - name: "Status: 🗯️ Waiting for feedback"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -12,7 +12,6 @@
 - name: "Category: Documentation ✒️"
   description: "A problem with the readme or a code comment."
   color: "ffc7ea"
-  from_name: "documentation"
 - name: "Category: Bug 🐛"
   color: "ffc7ea"
   from_name: "bug"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -72,6 +72,6 @@
   color: "959a9c"
   description: "No answer was received for weeks"
 - name: "Closed: 🙅 Won't fix"
-  from_name: "wontfix"
+  color: "959a9c"
 - name: "Closed: 🧺 Invalid"
-  from_name: "invalid"
+  color: "959a9c"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -12,6 +12,7 @@
 - name: "Category: Documentation ✒️"
   description: "A problem with the readme or a code comment."
   color: "ffc7ea"
+  from_name: "documentation"
 - name: "Category: Bug 🐛"
   color: "ffc7ea"
   from_name: "bug"
@@ -30,6 +31,8 @@
 - name: "Category: Label missing ❗"
   description: "Use this if it feels a label should be added to label this issue"
   color: "ffc7ea"
+- name: "Category: Question / Help wanted ❓"
+  from_name: "question"
 
 # Status
 - name: "Status: 🗯️ Waiting for feedback"
@@ -58,11 +61,17 @@
   color: "ff9efc"
 - name: "Complexity: 🟦 Easy to do"
   color: "ff9efc"
+  from_name: "good first issue"
 
 # Closing reason
 - name: "Closed: 👥 Duplicate"
   color: "959a9c"
   description: "Issue duplicates an existing issue"
+  from_name: "duplicate"
 - name: "Closed: ⚰️ Inactive"
   color: "959a9c"
   description: "No answer was received for weeks"
+- name: "Closed: 🙅 Won't fix"
+  from_name: "wontfix"
+- name: "Closed: 🧺 Invalid"
+  from_name: "invalid"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -67,7 +67,6 @@
 - name: "Closed: 👥 Duplicate"
   color: "959a9c"
   description: "Issue duplicates an existing issue"
-  from_name: "duplicate"
 - name: "Closed: ⚰️ Inactive"
   color: "959a9c"
   description: "No answer was received for weeks"


### PR DESCRIPTION
Easier than PR suggestions. I noticed that some useful labels were being deleted either entirely or to be replaced with effectively the same thing.