### PR TITLE
chore(ci): `goheader` linting only runs in CI on changed or new files

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,10 @@ on:
   workflow_dispatch:
 
 permissions:
+  # Required: allow read access to the content for analysis.
   contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
 
 jobs:
   golangci:
@@ -23,3 +26,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           version: v1.60
           only-new-issues: true
+          args: --enable goheader

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - gci
     - gocheckcompilerdirectives
     - gofmt
-    - goheader
     - goimports
     - gomodguard
     - gosec

--- a/.libevm-header
+++ b/.libevm-header
@@ -1,4 +1,4 @@
-Copyright {{ MOD-YEAR }} the libevm authors.
+Copyright {{ MOD-YEAR-RANGE }} the libevm authors.
 
 The libevm additions to go-ethereum are free software: you can redistribute
 them and/or modify them under the terms of the GNU Lesser General Public License


### PR DESCRIPTION
## Why this should be merged

Unblock the CI and update the copyright

## How this works

Bumped the year

## How this was tested

Lint job passing
