### PR TITLE
feat(core/types): `Header` hook `PostCopy`

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -277,7 +277,9 @@ func NewBlockWithWithdrawals(header *Header, txs []*Transaction, uncles []*Heade
 	return b.WithWithdrawals(withdrawals)
 }
 
-func copyHeader(h *Header) *Header {
+// CopyEthHeader creates a deep copy of an Ethereum block header.
+// Use [CopyHeader] instead if your header has any registered extra.
+func CopyEthHeader(h *Header) *Header {
 	cpy := *h
 	if cpy.Difficulty = new(big.Int); h.Difficulty != nil {
 		cpy.Difficulty.Set(h.Difficulty)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -309,7 +309,7 @@ func CopyHeader(h *Header) *Header {
 		cpy.ParentBeaconRoot = new(common.Hash)
 		*cpy.ParentBeaconRoot = *h.ParentBeaconRoot
 	}
-	h.hooks().PostCopy(&cpy, h)
+	h.hooks().PostCopy(&cpy)
 	return &cpy
 }
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -277,8 +277,7 @@ func NewBlockWithWithdrawals(header *Header, txs []*Transaction, uncles []*Heade
 	return b.WithWithdrawals(withdrawals)
 }
 
-// CopyHeader creates a deep copy of a block header.
-func CopyHeader(h *Header) *Header {
+func copyHeader(h *Header) *Header {
 	cpy := *h
 	if cpy.Difficulty = new(big.Int); h.Difficulty != nil {
 		cpy.Difficulty.Set(h.Difficulty)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -277,9 +277,8 @@ func NewBlockWithWithdrawals(header *Header, txs []*Transaction, uncles []*Heade
 	return b.WithWithdrawals(withdrawals)
 }
 
-// CopyEthHeader creates a deep copy of an Ethereum block header.
-// Use [CopyHeader] instead if your header has any registered extra.
-func CopyEthHeader(h *Header) *Header {
+// CopyHeader creates a deep copy of a block header.
+func CopyHeader(h *Header) *Header {
 	cpy := *h
 	if cpy.Difficulty = new(big.Int); h.Difficulty != nil {
 		cpy.Difficulty.Set(h.Difficulty)
@@ -310,6 +309,7 @@ func CopyEthHeader(h *Header) *Header {
 		cpy.ParentBeaconRoot = new(common.Hash)
 		*cpy.ParentBeaconRoot = *h.ParentBeaconRoot
 	}
+	h.hooks().PostCopy(&cpy, h)
 	return &cpy
 }
 

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -32,6 +32,7 @@ type HeaderHooks interface {
 	UnmarshalJSON(*Header, []byte) error //nolint:govet
 	EncodeRLP(*Header, io.Writer) error
 	DecodeRLP(*Header, *rlp.Stream) error
+	Copy(*Header) *Header
 }
 
 // hooks returns the Header's registered HeaderHooks, if any, otherwise a
@@ -107,4 +108,13 @@ func (*NOOPHeaderHooks) EncodeRLP(h *Header, w io.Writer) error {
 func (*NOOPHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 	type withoutMethods Header
 	return s.Decode((*withoutMethods)(h))
+}
+
+func (n *NOOPHeaderHooks) Copy(h *Header) *Header {
+	return copyHeader(h)
+}
+
+// CopyHeader creates a deep copy of a block header.
+func CopyHeader(h *Header) *Header {
+	return h.hooks().Copy(h)
 }

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -32,7 +32,7 @@ type HeaderHooks interface {
 	UnmarshalJSON(*Header, []byte) error //nolint:govet
 	EncodeRLP(*Header, io.Writer) error
 	DecodeRLP(*Header, *rlp.Stream) error
-	Copy(*Header) *Header
+	PostCopy(dst, src *Header)
 }
 
 // hooks returns the Header's registered HeaderHooks, if any, otherwise a
@@ -110,11 +110,4 @@ func (*NOOPHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 	return s.Decode((*withoutMethods)(h))
 }
 
-func (n *NOOPHeaderHooks) Copy(h *Header) *Header {
-	return CopyEthHeader(h)
-}
-
-// CopyHeader creates a deep copy of a block header.
-func CopyHeader(h *Header) *Header {
-	return h.hooks().Copy(h)
-}
+func (n *NOOPHeaderHooks) PostCopy(dst, src *Header) {}

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -32,7 +32,7 @@ type HeaderHooks interface {
 	UnmarshalJSON(*Header, []byte) error //nolint:govet
 	EncodeRLP(*Header, io.Writer) error
 	DecodeRLP(*Header, *rlp.Stream) error
-	PostCopy(dst, src *Header)
+	PostCopy(dst *Header)
 }
 
 // hooks returns the Header's registered HeaderHooks, if any, otherwise a
@@ -110,4 +110,4 @@ func (*NOOPHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 	return s.Decode((*withoutMethods)(h))
 }
 
-func (n *NOOPHeaderHooks) PostCopy(dst, src *Header) {}
+func (n *NOOPHeaderHooks) PostCopy(dst *Header) {}

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -111,7 +111,7 @@ func (*NOOPHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 }
 
 func (n *NOOPHeaderHooks) Copy(h *Header) *Header {
-	return copyHeader(h)
+	return CopyEthHeader(h)
 }
 
 // CopyHeader creates a deep copy of a block header.

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -146,16 +146,14 @@ func TestHeaderHooks(t *testing.T) {
 		hdr := new(Header)
 		stub := &stubHeaderHooks{
 			accessor: extras.Header,
-			copied: &stubHeaderHooks{
+			toCopy: &stubHeaderHooks{
 				suffix: []byte("copied"),
 			},
 		}
 		extras.Header.Set(hdr, stub)
-		cpy := CopyHeader(hdr)
 
-		copiedStub := extras.Header.Get(cpy)
-
-		assert.Equal(t, stub.copied, copiedStub)
+		got := extras.Header.Get(CopyHeader(hdr))
+		assert.Equal(t, stub.toCopy, got)
 	})
 
 	t.Run("error_propagation", func(t *testing.T) {

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -75,6 +75,10 @@ func (hh *stubHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 	return hh.errDecode
 }
 
+func (hh *stubHeaderHooks) Copy(h *Header) *Header {
+	return h
+}
+
 func TestHeaderHooks(t *testing.T) {
 	TestOnlyClearRegisteredExtras()
 	defer TestOnlyClearRegisteredExtras()

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -75,9 +75,7 @@ func (hh *stubHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 	return hh.errDecode
 }
 
-func (hh *stubHeaderHooks) Copy(h *Header) *Header {
-	return h
-}
+func (hh *stubHeaderHooks) PostCopy(dst, src *Header) {}
 
 func TestHeaderHooks(t *testing.T) {
 	TestOnlyClearRegisteredExtras()

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -38,7 +38,7 @@ type stubHeaderHooks struct {
 	gotRawJSONToUnmarshal, gotRawRLPToDecode []byte
 	setHeaderToOnUnmarshalOrDecode           Header
 	accessor                                 pseudo.Accessor[*Header, *stubHeaderHooks]
-	copied                                   *stubHeaderHooks
+	toCopy                                   *stubHeaderHooks
 
 	errMarshal, errUnmarshal, errEncode, errDecode error
 }
@@ -79,7 +79,7 @@ func (hh *stubHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 }
 
 func (hh *stubHeaderHooks) PostCopy(dst *Header) {
-	hh.accessor.Set(dst, hh.copied)
+	hh.accessor.Set(dst, hh.toCopy)
 }
 
 func TestHeaderHooks(t *testing.T) {

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -75,7 +75,7 @@ func (hh *stubHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 	return hh.errDecode
 }
 
-func (hh *stubHeaderHooks) PostCopy(dst, src *Header) {}
+func (hh *stubHeaderHooks) PostCopy(dst *Header) {}
 
 func TestHeaderHooks(t *testing.T) {
 	TestOnlyClearRegisteredExtras()


### PR DESCRIPTION
## Why this should be merged

Introduce header copy hooks to get rid of core/types.CopyHeader in coreth and subnet-evm

## How this works

Header copy hooks 🎉 

## How this was tested

- [x] Tested in https://github.com/ava-labs/coreth/pull/759
- [x] Needs to be unit tested