### PR TITLE
refactor!(core/types): `Block` method `WithBody(Body)` signature

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -254,7 +254,7 @@ func ExecutableDataToBlock(params ExecutableData, versionedHashes []common.Hash,
 		BlobGasUsed:      params.BlobGasUsed,
 		ParentBeaconRoot: beaconRoot,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */).WithWithdrawals(params.Withdrawals)
+	block := types.NewBlockWithHeader(header).WithBody(&types.Body{Transactions: txs}).WithWithdrawals(params.Withdrawals)
 	if block.Hash() != params.BlockHash {
 		return nil, fmt.Errorf("blockhash mismatch, want %x, got %x", params.BlockHash, block.Hash())
 	}

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -255,7 +255,7 @@ func ExecutableDataToBlock(params ExecutableData, versionedHashes []common.Hash,
 		ParentBeaconRoot: beaconRoot,
 	}
 	block := types.NewBlockWithHeader(header).
-		WithBody(types.Body{Transactions: txs, Uncles: nil}).WithWithdrawals(params.Withdrawals)
+		WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: params.Withdrawals})
 	if block.Hash() != params.BlockHash {
 		return nil, fmt.Errorf("blockhash mismatch, want %x, got %x", params.BlockHash, block.Hash())
 	}

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -254,7 +254,8 @@ func ExecutableDataToBlock(params ExecutableData, versionedHashes []common.Hash,
 		BlobGasUsed:      params.BlobGasUsed,
 		ParentBeaconRoot: beaconRoot,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(&types.Body{Transactions: txs}).WithWithdrawals(params.Withdrawals)
+	block := types.NewBlockWithHeader(header).
+		WithBody(types.Body{Transactions: txs, Uncles: nil}).WithWithdrawals(params.Withdrawals)
 	if block.Hash() != params.BlockHash {
 		return nil, fmt.Errorf("blockhash mismatch, want %x, got %x", params.BlockHash, block.Hash())
 	}

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -255,7 +255,7 @@ func ExecutableDataToBlock(params ExecutableData, versionedHashes []common.Hash,
 		ParentBeaconRoot: beaconRoot,
 	}
 	block := types.NewBlockWithHeader(header).
-		WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: params.Withdrawals})
+		WithBody(types.Body{Transactions: txs, Uncles: nil}).WithWithdrawals(params.Withdrawals)
 	if block.Hash() != params.BlockHash {
 		return nil, fmt.Errorf("blockhash mismatch, want %x, got %x", params.BlockHash, block.Hash())
 	}

--- a/cmd/evm/internal/t8ntool/block.go
+++ b/cmd/evm/internal/t8ntool/block.go
@@ -160,7 +160,7 @@ func (i *bbInput) ToBlock() *types.Block {
 	if i.Header.Difficulty != nil {
 		header.Difficulty = i.Header.Difficulty
 	}
-	return types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: i.Txs, Uncles: i.Ommers}).WithWithdrawals(i.Withdrawals)
+	return types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: i.Txs, Uncles: i.Ommers, Withdrawals: i.Withdrawals})
 }
 
 // SealBlock seals the given block using the configured engine.

--- a/cmd/evm/internal/t8ntool/block.go
+++ b/cmd/evm/internal/t8ntool/block.go
@@ -160,8 +160,7 @@ func (i *bbInput) ToBlock() *types.Block {
 	if i.Header.Difficulty != nil {
 		header.Difficulty = i.Header.Difficulty
 	}
-	body := &types.Body{Transactions: i.Txs, Uncles: i.Ommers}
-	return types.NewBlockWithHeader(header).WithBody(body).WithWithdrawals(i.Withdrawals)
+	return types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: i.Txs, Uncles: i.Ommers}).WithWithdrawals(i.Withdrawals)
 }
 
 // SealBlock seals the given block using the configured engine.

--- a/cmd/evm/internal/t8ntool/block.go
+++ b/cmd/evm/internal/t8ntool/block.go
@@ -160,7 +160,7 @@ func (i *bbInput) ToBlock() *types.Block {
 	if i.Header.Difficulty != nil {
 		header.Difficulty = i.Header.Difficulty
 	}
-	return types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: i.Txs, Uncles: i.Ommers, Withdrawals: i.Withdrawals})
+	return types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: i.Txs, Uncles: i.Ommers}).WithWithdrawals(i.Withdrawals)
 }
 
 // SealBlock seals the given block using the configured engine.

--- a/cmd/evm/internal/t8ntool/block.go
+++ b/cmd/evm/internal/t8ntool/block.go
@@ -160,7 +160,8 @@ func (i *bbInput) ToBlock() *types.Block {
 	if i.Header.Difficulty != nil {
 		header.Difficulty = i.Header.Difficulty
 	}
-	return types.NewBlockWithHeader(header).WithBody(i.Txs, i.Ommers).WithWithdrawals(i.Withdrawals)
+	body := &types.Body{Transactions: i.Txs, Uncles: i.Ommers}
+	return types.NewBlockWithHeader(header).WithBody(body).WithWithdrawals(i.Withdrawals)
 }
 
 // SealBlock seals the given block using the configured engine.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -753,7 +753,7 @@ func ReadBlock(db ethdb.Reader, hash common.Hash, number uint64) *types.Block {
 	if body == nil {
 		return nil
 	}
-	return types.NewBlockWithHeader(header).WithBody(body.Transactions, body.Uncles).WithWithdrawals(body.Withdrawals)
+	return types.NewBlockWithHeader(header).WithBody(body).WithWithdrawals(body.Withdrawals)
 }
 
 // WriteBlock serializes a block into the database, header and body separately.
@@ -843,7 +843,7 @@ func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
 	}
 	for _, bad := range badBlocks {
 		if bad.Header.Hash() == hash {
-			return types.NewBlockWithHeader(bad.Header).WithBody(bad.Body.Transactions, bad.Body.Uncles).WithWithdrawals(bad.Body.Withdrawals)
+			return types.NewBlockWithHeader(bad.Header).WithBody(bad.Body).WithWithdrawals(bad.Body.Withdrawals)
 		}
 	}
 	return nil
@@ -862,7 +862,7 @@ func ReadAllBadBlocks(db ethdb.Reader) []*types.Block {
 	}
 	var blocks []*types.Block
 	for _, bad := range badBlocks {
-		blocks = append(blocks, types.NewBlockWithHeader(bad.Header).WithBody(bad.Body.Transactions, bad.Body.Uncles).WithWithdrawals(bad.Body.Withdrawals))
+		blocks = append(blocks, types.NewBlockWithHeader(bad.Header).WithBody(bad.Body).WithWithdrawals(bad.Body.Withdrawals))
 	}
 	return blocks
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -753,7 +753,7 @@ func ReadBlock(db ethdb.Reader, hash common.Hash, number uint64) *types.Block {
 	if body == nil {
 		return nil
 	}
-	return types.NewBlockWithHeader(header).WithBody(*body).WithWithdrawals(body.Withdrawals)
+	return types.NewBlockWithHeader(header).WithBody(*body)
 }
 
 // WriteBlock serializes a block into the database, header and body separately.
@@ -846,7 +846,6 @@ func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
 			block := types.NewBlockWithHeader(bad.Header)
 			if bad.Body != nil {
 				block = block.WithBody(*bad.Body)
-				block = block.WithWithdrawals(bad.Body.Withdrawals)
 			}
 			return block
 		}
@@ -870,7 +869,6 @@ func ReadAllBadBlocks(db ethdb.Reader) []*types.Block {
 		block := types.NewBlockWithHeader(bad.Header)
 		if bad.Body != nil {
 			block = block.WithBody(*bad.Body)
-			block = block.WithWithdrawals(bad.Body.Withdrawals)
 		}
 		blocks = append(blocks, block)
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -753,7 +753,7 @@ func ReadBlock(db ethdb.Reader, hash common.Hash, number uint64) *types.Block {
 	if body == nil {
 		return nil
 	}
-	return types.NewBlockWithHeader(header).WithBody(*body)
+	return types.NewBlockWithHeader(header).WithBody(*body).WithWithdrawals(body.Withdrawals)
 }
 
 // WriteBlock serializes a block into the database, header and body separately.
@@ -846,6 +846,7 @@ func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
 			block := types.NewBlockWithHeader(bad.Header)
 			if bad.Body != nil {
 				block = block.WithBody(*bad.Body)
+				block = block.WithWithdrawals(bad.Body.Withdrawals)
 			}
 			return block
 		}
@@ -869,6 +870,7 @@ func ReadAllBadBlocks(db ethdb.Reader) []*types.Block {
 		block := types.NewBlockWithHeader(bad.Header)
 		if bad.Body != nil {
 			block = block.WithBody(*bad.Body)
+			block = block.WithWithdrawals(bad.Body.Withdrawals)
 		}
 		blocks = append(blocks, block)
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -753,7 +753,7 @@ func ReadBlock(db ethdb.Reader, hash common.Hash, number uint64) *types.Block {
 	if body == nil {
 		return nil
 	}
-	return types.NewBlockWithHeader(header).WithBody(body).WithWithdrawals(body.Withdrawals)
+	return types.NewBlockWithHeader(header).WithBody(*body).WithWithdrawals(body.Withdrawals)
 }
 
 // WriteBlock serializes a block into the database, header and body separately.
@@ -843,7 +843,12 @@ func ReadBadBlock(db ethdb.Reader, hash common.Hash) *types.Block {
 	}
 	for _, bad := range badBlocks {
 		if bad.Header.Hash() == hash {
-			return types.NewBlockWithHeader(bad.Header).WithBody(bad.Body).WithWithdrawals(bad.Body.Withdrawals)
+			block := types.NewBlockWithHeader(bad.Header)
+			if bad.Body != nil {
+				block = block.WithBody(*bad.Body)
+				block = block.WithWithdrawals(bad.Body.Withdrawals)
+			}
+			return block
 		}
 	}
 	return nil
@@ -862,7 +867,12 @@ func ReadAllBadBlocks(db ethdb.Reader) []*types.Block {
 	}
 	var blocks []*types.Block
 	for _, bad := range badBlocks {
-		blocks = append(blocks, types.NewBlockWithHeader(bad.Header).WithBody(bad.Body).WithWithdrawals(bad.Body.Withdrawals))
+		block := types.NewBlockWithHeader(bad.Header)
+		if bad.Body != nil {
+			block = block.WithBody(*bad.Body)
+			block = block.WithWithdrawals(bad.Body.Withdrawals)
+		}
+		blocks = append(blocks, block)
 	}
 	return blocks
 }

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -640,7 +640,7 @@ func makeTestBlocks(nblock int, txsPerBlock int) []*types.Block {
 			Number: big.NewInt(int64(i)),
 			Extra:  []byte("test block"),
 		}
-		blocks[i] = types.NewBlockWithHeader(header).WithBody(txs, nil)
+		blocks[i] = types.NewBlockWithHeader(header).WithBody(&types.Body{Transactions: txs})
 		blocks[i].Hash() // pre-cache the block hash
 	}
 	return blocks

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -640,7 +640,7 @@ func makeTestBlocks(nblock int, txsPerBlock int) []*types.Block {
 			Number: big.NewInt(int64(i)),
 			Extra:  []byte("test block"),
 		}
-		blocks[i] = types.NewBlockWithHeader(header).WithBody(&types.Body{Transactions: txs})
+		blocks[i] = types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs})
 		blocks[i].Hash() // pre-cache the block hash
 	}
 	return blocks

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -460,7 +460,7 @@ func (b *Block) WithSeal(header *Header) *Block {
 }
 
 // WithBody returns a copy of the block with the given transaction and uncle contents.
-func (b *Block) WithBody(body *Body) *Block {
+func (b *Block) WithBody(body Body) *Block {
 	block := &Block{
 		header:       b.header,
 		transactions: make([]*Transaction, len(body.Transactions)),

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"math/big"
 	"reflect"
-	"slices"
 	"sync/atomic"
 	"time"
 
@@ -466,7 +465,7 @@ func (b *Block) WithBody(body Body) *Block {
 		header:       b.header,
 		transactions: make([]*Transaction, len(body.Transactions)),
 		uncles:       make([]*Header, len(body.Uncles)),
-		withdrawals:  slices.Clone(body.Withdrawals),
+		withdrawals:  b.withdrawals,
 	}
 	copy(block.transactions, body.Transactions)
 	for i := range body.Uncles {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/big"
 	"reflect"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -465,7 +466,7 @@ func (b *Block) WithBody(body Body) *Block {
 		header:       b.header,
 		transactions: make([]*Transaction, len(body.Transactions)),
 		uncles:       make([]*Header, len(body.Uncles)),
-		withdrawals:  b.withdrawals,
+		withdrawals:  slices.Clone(body.Withdrawals),
 	}
 	copy(block.transactions, body.Transactions)
 	for i := range body.Uncles {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -460,16 +460,16 @@ func (b *Block) WithSeal(header *Header) *Block {
 }
 
 // WithBody returns a copy of the block with the given transaction and uncle contents.
-func (b *Block) WithBody(transactions []*Transaction, uncles []*Header) *Block {
+func (b *Block) WithBody(body *Body) *Block {
 	block := &Block{
 		header:       b.header,
-		transactions: make([]*Transaction, len(transactions)),
-		uncles:       make([]*Header, len(uncles)),
+		transactions: make([]*Transaction, len(body.Transactions)),
+		uncles:       make([]*Header, len(body.Uncles)),
 		withdrawals:  b.withdrawals,
 	}
-	copy(block.transactions, transactions)
-	for i := range uncles {
-		block.uncles[i] = CopyHeader(uncles[i])
+	copy(block.transactions, body.Transactions)
+	for i := range body.Uncles {
+		block.uncles[i] = CopyHeader(body.Uncles[i])
 	}
 	return block
 }

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -778,7 +778,7 @@ func setBlockhash(data *engine.ExecutableData) *engine.ExecutableData {
 		Extra:       data.ExtraData,
 		MixDigest:   data.Random,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */)
+	block := types.NewBlockWithHeader(header).WithBody(&types.Body{Transactions: txs})
 	data.BlockHash = block.Hash()
 	return data
 }
@@ -935,7 +935,7 @@ func TestNewPayloadOnInvalidTerminalBlock(t *testing.T) {
 		Extra:       data.ExtraData,
 		MixDigest:   data.Random,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */)
+	block := types.NewBlockWithHeader(header).WithBody(&types.Body{Transactions: txs})
 	data.BlockHash = block.Hash()
 	// Send the new payload
 	resp2, err := api.NewPayloadV1(data)

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -778,7 +778,7 @@ func setBlockhash(data *engine.ExecutableData) *engine.ExecutableData {
 		Extra:       data.ExtraData,
 		MixDigest:   data.Random,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(&types.Body{Transactions: txs})
+	block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs})
 	data.BlockHash = block.Hash()
 	return data
 }
@@ -935,7 +935,7 @@ func TestNewPayloadOnInvalidTerminalBlock(t *testing.T) {
 		Extra:       data.ExtraData,
 		MixDigest:   data.Random,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(&types.Body{Transactions: txs})
+	block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: txs})
 	data.BlockHash = block.Hash()
 	// Send the new payload
 	resp2, err := api.NewPayloadV1(data)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1500,8 +1500,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	)
 	blocks := make([]*types.Block, len(results))
 	for i, result := range results {
-		body := &types.Body{Transactions: result.Transactions, Uncles: result.Uncles}
-		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(body).WithWithdrawals(result.Withdrawals)
+		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
 	}
 	// Downloaded blocks are always regarded as trusted after the
 	// transition. Because the downloaded chain is guided by the
@@ -1719,8 +1718,7 @@ func (d *Downloader) commitSnapSyncData(results []*fetchResult, stateSync *state
 	blocks := make([]*types.Block, len(results))
 	receipts := make([]types.Receipts, len(results))
 	for i, result := range results {
-		body := &types.Body{Transactions: result.Transactions, Uncles: result.Uncles}
-		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(body).WithWithdrawals(result.Withdrawals)
+		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
 		receipts[i] = result.Receipts
 	}
 	if index, err := d.blockchain.InsertReceiptChain(blocks, receipts, d.ancientLimit); err != nil {
@@ -1731,8 +1729,7 @@ func (d *Downloader) commitSnapSyncData(results []*fetchResult, stateSync *state
 }
 
 func (d *Downloader) commitPivotBlock(result *fetchResult) error {
-	body := &types.Body{Transactions: result.Transactions, Uncles: result.Uncles}
-	block := types.NewBlockWithHeader(result.Header).WithBody(body).WithWithdrawals(result.Withdrawals)
+	block := types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
 	log.Debug("Committing snap sync pivot as new head", "number", block.Number(), "hash", block.Hash())
 
 	// Commit the pivot block as the new head, will require full sync from here on

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -25,7 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ava-labs/libevm"
+	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/state/snapshot"
@@ -1500,7 +1500,8 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	)
 	blocks := make([]*types.Block, len(results))
 	for i, result := range results {
-		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles).WithWithdrawals(result.Withdrawals)
+		body := &types.Body{Transactions: result.Transactions, Uncles: result.Uncles}
+		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(body).WithWithdrawals(result.Withdrawals)
 	}
 	// Downloaded blocks are always regarded as trusted after the
 	// transition. Because the downloaded chain is guided by the
@@ -1718,7 +1719,8 @@ func (d *Downloader) commitSnapSyncData(results []*fetchResult, stateSync *state
 	blocks := make([]*types.Block, len(results))
 	receipts := make([]types.Receipts, len(results))
 	for i, result := range results {
-		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles).WithWithdrawals(result.Withdrawals)
+		body := &types.Body{Transactions: result.Transactions, Uncles: result.Uncles}
+		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(body).WithWithdrawals(result.Withdrawals)
 		receipts[i] = result.Receipts
 	}
 	if index, err := d.blockchain.InsertReceiptChain(blocks, receipts, d.ancientLimit); err != nil {
@@ -1729,7 +1731,8 @@ func (d *Downloader) commitSnapSyncData(results []*fetchResult, stateSync *state
 }
 
 func (d *Downloader) commitPivotBlock(result *fetchResult) error {
-	block := types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles).WithWithdrawals(result.Withdrawals)
+	body := &types.Body{Transactions: result.Transactions, Uncles: result.Uncles}
+	block := types.NewBlockWithHeader(result.Header).WithBody(body).WithWithdrawals(result.Withdrawals)
 	log.Debug("Committing snap sync pivot as new head", "number", block.Number(), "hash", block.Hash())
 
 	// Commit the pivot block as the new head, will require full sync from here on

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -25,7 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	ethereum "github.com/ava-labs/libevm"
+	"github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/state/snapshot"

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1500,7 +1500,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	)
 	blocks := make([]*types.Block, len(results))
 	for i, result := range results {
-		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body())
+		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
 	}
 	// Downloaded blocks are always regarded as trusted after the
 	// transition. Because the downloaded chain is guided by the
@@ -1718,7 +1718,7 @@ func (d *Downloader) commitSnapSyncData(results []*fetchResult, stateSync *state
 	blocks := make([]*types.Block, len(results))
 	receipts := make([]types.Receipts, len(results))
 	for i, result := range results {
-		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body())
+		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
 		receipts[i] = result.Receipts
 	}
 	if index, err := d.blockchain.InsertReceiptChain(blocks, receipts, d.ancientLimit); err != nil {
@@ -1729,7 +1729,7 @@ func (d *Downloader) commitSnapSyncData(results []*fetchResult, stateSync *state
 }
 
 func (d *Downloader) commitPivotBlock(result *fetchResult) error {
-	block := types.NewBlockWithHeader(result.Header).WithBody(result.body())
+	block := types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
 	log.Debug("Committing snap sync pivot as new head", "number", block.Number(), "hash", block.Hash())
 
 	// Commit the pivot block as the new head, will require full sync from here on

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1500,7 +1500,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	)
 	blocks := make([]*types.Block, len(results))
 	for i, result := range results {
-		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
+		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body())
 	}
 	// Downloaded blocks are always regarded as trusted after the
 	// transition. Because the downloaded chain is guided by the
@@ -1718,7 +1718,7 @@ func (d *Downloader) commitSnapSyncData(results []*fetchResult, stateSync *state
 	blocks := make([]*types.Block, len(results))
 	receipts := make([]types.Receipts, len(results))
 	for i, result := range results {
-		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
+		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body())
 		receipts[i] = result.Receipts
 	}
 	if index, err := d.blockchain.InsertReceiptChain(blocks, receipts, d.ancientLimit); err != nil {
@@ -1729,7 +1729,7 @@ func (d *Downloader) commitSnapSyncData(results []*fetchResult, stateSync *state
 }
 
 func (d *Downloader) commitPivotBlock(result *fetchResult) error {
-	block := types.NewBlockWithHeader(result.Header).WithBody(result.body()).WithWithdrawals(result.Withdrawals)
+	block := types.NewBlockWithHeader(result.Header).WithBody(result.body())
 	log.Debug("Committing snap sync pivot as new head", "number", block.Number(), "hash", block.Hash())
 
 	// Commit the pivot block as the new head, will require full sync from here on

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -87,6 +87,15 @@ func newFetchResult(header *types.Header, fastSync bool) *fetchResult {
 	return item
 }
 
+// body returns a representation of the fetch result as a types.Body object.
+func (f *fetchResult) body() types.Body {
+	return types.Body{
+		Transactions: f.Transactions,
+		Uncles:       f.Uncles,
+		Withdrawals:  f.Withdrawals,
+	}
+}
+
 // SetBodyDone flags the body as finished.
 func (f *fetchResult) SetBodyDone() {
 	if v := f.pending.Load(); (v & (1 << bodyType)) != 0 {

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -686,7 +686,8 @@ func (f *BlockFetcher) loop() {
 						// Mark the body matched, reassemble if still unknown
 						matched = true
 						if f.getBlock(hash) == nil {
-							block := types.NewBlockWithHeader(announce.header).WithBody(task.transactions[i], task.uncles[i])
+							body := &types.Body{Transactions: task.transactions[i], Uncles: task.uncles[i]}
+							block := types.NewBlockWithHeader(announce.header).WithBody(body)
 							block.ReceivedAt = task.time
 							blocks = append(blocks, block)
 						} else {

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -687,7 +687,7 @@ func (f *BlockFetcher) loop() {
 						matched = true
 						if f.getBlock(hash) == nil {
 							body := &types.Body{Transactions: task.transactions[i], Uncles: task.uncles[i]}
-							block := types.NewBlockWithHeader(announce.header).WithBody(body)
+							block := types.NewBlockWithHeader(announce.header).WithBody(*body)
 							block.ReceivedAt = task.time
 							blocks = append(blocks, block)
 						} else {

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -686,8 +686,8 @@ func (f *BlockFetcher) loop() {
 						// Mark the body matched, reassemble if still unknown
 						matched = true
 						if f.getBlock(hash) == nil {
-							body := &types.Body{Transactions: task.transactions[i], Uncles: task.uncles[i]}
-							block := types.NewBlockWithHeader(announce.header).WithBody(*body)
+							body := types.Body{Transactions: task.transactions[i], Uncles: task.uncles[i]}
+							block := types.NewBlockWithHeader(announce.header).WithBody(body)
 							block.ReceivedAt = task.time
 							blocks = append(blocks, block)
 						} else {

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -586,7 +586,7 @@ func testBroadcastMalformedBlock(t *testing.T, protocol uint) {
 
 	// Try to broadcast all malformations and ensure they all get discarded
 	for _, header := range []*types.Header{malformedUncles, malformedTransactions, malformedEverything} {
-		block := types.NewBlockWithHeader(header).WithBody(block.Transactions(), block.Uncles())
+		block := types.NewBlockWithHeader(header).WithBody(block.Body())
 		if err := src.SendNewBlock(block, big.NewInt(131136)); err != nil {
 			t.Fatalf("failed to broadcast block: %v", err)
 		}

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -586,7 +586,7 @@ func testBroadcastMalformedBlock(t *testing.T, protocol uint) {
 
 	// Try to broadcast all malformations and ensure they all get discarded
 	for _, header := range []*types.Header{malformedUncles, malformedTransactions, malformedEverything} {
-		block := types.NewBlockWithHeader(header).WithBody(block.Body())
+		block := types.NewBlockWithHeader(header).WithBody(*block.Body())
 		if err := src.SendNewBlock(block, big.NewInt(131136)); err != nil {
 			t.Fatalf("failed to broadcast block: %v", err)
 		}

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ava-labs/libevm"
+	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/core/types"
@@ -191,7 +191,8 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 		}
 		txs[i] = tx.tx
 	}
-	return types.NewBlockWithHeader(head).WithBody(txs, uncles).WithWithdrawals(body.Withdrawals), nil
+	blockBody := &types.Body{Transactions: txs, Uncles: uncles}
+	return types.NewBlockWithHeader(head).WithBody(blockBody).WithWithdrawals(body.Withdrawals), nil
 }
 
 // HeaderByHash returns the block header with the given hash.

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"math/big"
 
-	ethereum "github.com/ava-labs/libevm"
+	"github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/core/types"

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -191,8 +191,11 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 		}
 		txs[i] = tx.tx
 	}
-	blockBody := &types.Body{Transactions: txs, Uncles: uncles}
-	return types.NewBlockWithHeader(head).WithBody(blockBody).WithWithdrawals(body.Withdrawals), nil
+	return types.NewBlockWithHeader(head).WithBody(
+		types.Body{
+			Transactions: txs,
+			Uncles:       uncles,
+		}).WithWithdrawals(body.Withdrawals), nil
 }
 
 // HeaderByHash returns the block header with the given hash.

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -195,8 +195,7 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 		types.Body{
 			Transactions: txs,
 			Uncles:       uncles,
-			Withdrawals:  body.Withdrawals,
-		}), nil
+		}).WithWithdrawals(body.Withdrawals), nil
 }
 
 // HeaderByHash returns the block header with the given hash.

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -195,7 +195,8 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 		types.Body{
 			Transactions: txs,
 			Uncles:       uncles,
-		}).WithWithdrawals(body.Withdrawals), nil
+			Withdrawals:  body.Withdrawals,
+		}), nil
 }
 
 // HeaderByHash returns the block header with the given hash.

--- a/internal/era/era.go
+++ b/internal/era/era.go
@@ -150,7 +150,7 @@ func (e *Era) GetBlockByNumber(num uint64) (*types.Block, error) {
 	if err := rlp.Decode(r, &body); err != nil {
 		return nil, err
 	}
-	return types.NewBlockWithHeader(&header).WithBody(body.Transactions, body.Uncles), nil
+	return types.NewBlockWithHeader(&header).WithBody(&body), nil
 }
 
 // Accumulator reads the accumulator entry in the Era1 file.

--- a/internal/era/era.go
+++ b/internal/era/era.go
@@ -150,7 +150,7 @@ func (e *Era) GetBlockByNumber(num uint64) (*types.Block, error) {
 	if err := rlp.Decode(r, &body); err != nil {
 		return nil, err
 	}
-	return types.NewBlockWithHeader(&header).WithBody(&body), nil
+	return types.NewBlockWithHeader(&header).WithBody(body), nil
 }
 
 // Accumulator reads the accumulator entry in the Era1 file.

--- a/internal/era/iterator.go
+++ b/internal/era/iterator.go
@@ -73,7 +73,7 @@ func (it *Iterator) Block() (*types.Block, error) {
 	if err := rlp.Decode(it.inner.Body, &body); err != nil {
 		return nil, err
 	}
-	return types.NewBlockWithHeader(&header).WithBody(body.Transactions, body.Uncles), nil
+	return types.NewBlockWithHeader(&header).WithBody(&body), nil
 }
 
 // Receipts returns the receipts for the iterator's current position.

--- a/internal/era/iterator.go
+++ b/internal/era/iterator.go
@@ -73,7 +73,7 @@ func (it *Iterator) Block() (*types.Block, error) {
 	if err := rlp.Decode(it.inner.Body, &body); err != nil {
 		return nil, err
 	}
-	return types.NewBlockWithHeader(&header).WithBody(&body), nil
+	return types.NewBlockWithHeader(&header).WithBody(body), nil
 }
 
 // Receipts returns the receipts for the iterator's current position.


### PR DESCRIPTION
Breaking change refactoring `core/types.Block.WithBody()` method from signature

```go
WithBody(transactions []*Transaction, uncles []*Header) *Block
```

to signature

```go
WithBody(body Body) *Block
```

such that block and body extras can be used within `WithBody`.

> [!NOTE]
> `geth` made the same change in method signature so the deltas introduced in this PR will disappear once we sync.