### PR TITLE
feat: `rawdb.InspectDatabaseOption`

### DIFF
--- a/core/rawdb/database.libevm.go
+++ b/core/rawdb/database.libevm.go
@@ -79,10 +79,11 @@ func WithDatabaseMetadataKeys(isMetadata func(key []byte) bool) InspectDatabaseO
 	})
 }
 
-// WithDatabaseStatsTransformer returns an option that causes all statistics to
+// WithDatabaseStatsTransformer returns an option that causes all statistics rows to
 // be passed to the provided function, with its return value being printed
 // instead of the original values.
-func WithDatabaseStatsTransformer(transform func([][]string) [][]string) InspectDatabaseOption {
+// Each row contains 4 columns: database, category, size and count.
+func WithDatabaseStatsTransformer(transform func(rows [][]string) [][]string) InspectDatabaseOption {
 	return newInspectOpt(func(c *inspectDatabaseConfig) {
 		c.statsTransformer = transform
 	})

--- a/core/rawdb/database.libevm.go
+++ b/core/rawdb/database.libevm.go
@@ -1,0 +1,89 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/libevm/options"
+)
+
+// An InspectDatabaseOption configures the behaviour of [InspectDatabase]. For
+// each type of option, only one instance can be used in the same call to
+// InspectDatabase().
+type InspectDatabaseOption = options.Option[inspectDatabaseConfig]
+
+type inspectDatabaseConfig struct {
+	statRecorder     func([]byte, common.StorageSize) bool
+	isMeta           func([]byte) bool
+	statsTransformer func([][]string) [][]string
+}
+
+func (c inspectDatabaseConfig) recordStat(key []byte, size common.StorageSize) bool {
+	if r := c.statRecorder; r != nil {
+		return r(key, size)
+	}
+	return false
+}
+
+func (c inspectDatabaseConfig) isMetadata(key []byte) bool {
+	if m := c.isMeta; m != nil {
+		return m(key)
+	}
+	return false
+}
+
+func (c inspectDatabaseConfig) transformStats(stats [][]string) [][]string {
+	if f := c.statsTransformer; f != nil {
+		return f(stats)
+	}
+	return stats
+}
+
+func newInspectOpt(fn func(*inspectDatabaseConfig)) InspectDatabaseOption {
+	return options.Func[inspectDatabaseConfig](fn)
+}
+
+// WithDatabaseStatRecorder returns an option that results in `rec` being called
+// for every `key` not otherwise matched by the [InspectDatabase] iterator loop.
+// The returned boolean signals whether the recorder matches the key, thus
+// stopping further matches.
+func WithDatabaseStatRecorder(rec func(key []byte, _ common.StorageSize) bool) InspectDatabaseOption {
+	return newInspectOpt(func(c *inspectDatabaseConfig) {
+		c.statRecorder = rec
+	})
+}
+
+// A DatabaseStat stores total size and counts for a parameter measured by
+// [InspectDatabase]. It is exported for use with [WithDatabaseStatRecorder].
+type DatabaseStat = stat
+
+// WithDatabaseMetadataKeys returns an option that results in the `key` size
+// being counted with the metadata statistic i.f.f. the function returns true.
+func WithDatabaseMetadataKeys(isMetadata func(key []byte) bool) InspectDatabaseOption {
+	return newInspectOpt(func(c *inspectDatabaseConfig) {
+		c.isMeta = isMetadata
+	})
+}
+
+// WithDatabaseStatsTransformer returns an option that causes all statistics to
+// be passed to the provided function, with its return value being printed
+// instead of the original values.
+func WithDatabaseStatsTransformer(transform func([][]string) [][]string) InspectDatabaseOption {
+	return newInspectOpt(func(c *inspectDatabaseConfig) {
+		c.statsTransformer = transform
+	})
+}

--- a/core/rawdb/database.libevm.go
+++ b/core/rawdb/database.libevm.go
@@ -61,7 +61,7 @@ func newInspectOpt(fn func(*inspectDatabaseConfig)) InspectDatabaseOption {
 // for every `key` not otherwise matched by the [InspectDatabase] iterator loop.
 // The returned boolean signals whether the recorder matches the key, thus
 // stopping further matches.
-func WithDatabaseStatRecorder(rec func(key []byte, _ common.StorageSize) bool) InspectDatabaseOption {
+func WithDatabaseStatRecorder(rec func(key []byte, size common.StorageSize) bool) InspectDatabaseOption {
 	return newInspectOpt(func(c *inspectDatabaseConfig) {
 		c.statRecorder = rec
 	})

--- a/core/rawdb/database.libevm_test.go
+++ b/core/rawdb/database.libevm_test.go
@@ -32,17 +32,15 @@ import (
 func ExampleDatabaseStat() {
 	var stat rawdb.DatabaseStat
 
-	stat.Add(common.StorageSize(0)) // only to demonstrate param type
-	stat.Add(1)
+	stat.Add(common.StorageSize(1)) // only to demonstrate param type
 	stat.Add(2)
-	stat.Add(4)
 
 	fmt.Println("Sum:", stat.Size())    // sum of all values passed to Add()
 	fmt.Println("Count:", stat.Count()) // number of calls to Add()
 
 	// Output:
-	// Sum: 7.00 B
-	// Count: 4
+	// Sum: 3.00 B
+	// Count: 2
 }
 
 func ExampleInspectDatabase() {
@@ -155,7 +153,7 @@ func (s *stubDatabase) Get(key []byte) ([]byte, error) {
 	return nil, nil
 }
 
-func (s *stubDatabase) ReadAncients(fn func(ethdb.AncientReaderOp) error) (err error) {
+func (s *stubDatabase) ReadAncients(fn func(ethdb.AncientReaderOp) error) error {
 	return nil
 }
 
@@ -178,8 +176,7 @@ func (s *stubIterator) pos() int {
 
 func (s *stubIterator) Next() bool {
 	s.i++
-	available := s.pos() < len(s.kvs)
-	return available
+	return s.pos() < len(s.kvs)
 }
 
 func (s *stubIterator) Release() {}

--- a/core/rawdb/database.libevm_test.go
+++ b/core/rawdb/database.libevm_test.go
@@ -17,6 +17,8 @@
 package rawdb_test
 
 import (
+	"fmt"
+
 	"github.com/ava-labs/libevm/common"
 	// To ensure that all methods are available to importing packages, this test
 	// is defined in package `rawdb_test` instead of `rawdb`.
@@ -26,15 +28,17 @@ import (
 // ExampleDatabaseStat demonstrates the method signatures of DatabaseStat, which
 // exposes an otherwise unexported type that won't have its methods documented.
 func ExampleDatabaseStat() {
-	var (
-		stat rawdb.DatabaseStat
-		size common.StorageSize
-	)
+	var stat rawdb.DatabaseStat
 
-	stat.Add(size)
+	stat.Add(common.StorageSize(0)) // only to demonstrate param type
+	stat.Add(1)
+	stat.Add(2)
+	stat.Add(4)
 
-	var (
-		_ string = stat.Size()  // sum of all values passed to Add()
-		_ string = stat.Count() // number of calls to Add()
-	)
+	fmt.Println("Sum:", stat.Size())    // sum of all values passed to Add()
+	fmt.Println("Count:", stat.Count()) // number of calls to Add()
+
+	// Output:
+	// Sum: 7.00 B
+	// Count: 4
 }

--- a/core/rawdb/database.libevm_test.go
+++ b/core/rawdb/database.libevm_test.go
@@ -1,0 +1,40 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package rawdb_test
+
+import (
+	"github.com/ava-labs/libevm/common"
+	// To ensure that all methods are available to importing packages, this test
+	// is defined in package `rawdb_test` instead of `rawdb`.
+	"github.com/ava-labs/libevm/core/rawdb"
+)
+
+// ExampleDatabaseStat demonstrates the method signatures of DatabaseStat, which
+// exposes an otherwise unexported type that won't have its methods documented.
+func ExampleDatabaseStat() {
+	var (
+		stat rawdb.DatabaseStat
+		size common.StorageSize
+	)
+
+	stat.Add(size)
+
+	var (
+		_ string = stat.Size()  // sum of all values passed to Add()
+		_ string = stat.Count() // number of calls to Add()
+	)
+}


### PR DESCRIPTION
## Why this should be merged

Allows for `ava-labs/coreth` equivalent modifications of `rawdb.InspectDatabase()` through external logic injection.

## How this works

Variadic options to:

1. Record a database statistic;
2. Mark a database statistic as metadata;
3. Filter statistics for printing.

## How this was tested

Testable example acting as a unit test.