### PR TITLE
refactor: test error semantics

### DIFF
--- a/internal/libevm/errs/errs.go
+++ b/internal/libevm/errs/errs.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
-//
+
 // Package errs provides a mechanism for [testing error semantics] through
 // unique identifiers, instead of depending on error messages that may result in
 // change-detector tests.

--- a/internal/libevm/errs/errs.go
+++ b/internal/libevm/errs/errs.go
@@ -1,0 +1,89 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+//
+// Package errs provides a mechanism for [testing error semantics] through
+// unique identifiers, instead of depending on error messages that may result in
+// change-detector tests.
+//
+// [testing error semantics]: https://google.github.io/styleguide/go/decisions#test-error-semantics
+package errs
+
+import (
+	"errors"
+	"fmt"
+)
+
+// An ID is a distinct numeric identifier for an error. It has no effect on the
+// error message and can only be accessed with this package.
+type ID int
+
+// Error returns a new error with the ID.
+func (id ID) Error(msg string) error {
+	return noWrap{errors.New(msg), id}
+}
+
+type noWrap struct {
+	error
+	id ID
+}
+
+// Errorf is the formatted equivalent of [ID.Error], supporting the same
+// wrapping semantics as [fmt.Errorf].
+func (id ID) Errorf(format string, a ...any) error {
+	switch err := fmt.Errorf(format, a...).(type) {
+	case singleWrapper:
+		return single{err, id}
+	case multiWrapper:
+		return multi{err, id}
+	default:
+		return noWrap{err, id}
+	}
+}
+
+type singleWrapper interface {
+	error
+	Unwrap() error
+}
+
+type single struct {
+	singleWrapper
+	id ID
+}
+
+type multiWrapper interface {
+	error
+	Unwrap() []error
+}
+
+type multi struct {
+	multiWrapper
+	id ID
+}
+
+// IDOf returns the ID of the error, if one exists, and a flag to indicate as
+// such. IDOf does not unwrap errors.
+func IDOf(err error) (ID, bool) {
+	switch err := err.(type) {
+	case noWrap:
+		return err.id, true
+	case single:
+		return err.id, true
+	case multi:
+		return err.id, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/libevm/errs/errs_test.go
+++ b/internal/libevm/errs/errs_test.go
@@ -51,7 +51,7 @@ func TestIs(t *testing.T) {
 			}
 
 			for _, target := range unidentified {
-				assert.Falsef(t, errors.Is(err, target), "errors.Is(%v [ID %d], %v)", err, id, target)
+				assert.NotErrorIsf(t, err, target, "error ID %d", id)
 			}
 		}
 	}

--- a/internal/libevm/errs/errs_test.go
+++ b/internal/libevm/errs/errs_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package errs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIDOf(t *testing.T) {
+	tests := []struct {
+		err    error
+		wantID ID
+		wantOK bool
+	}{
+		{
+			err: errors.New("x"),
+		},
+		{
+			err: fmt.Errorf("x"),
+		},
+		{
+			err:    ID(3).Error("x"),
+			wantID: 3,
+			wantOK: true,
+		},
+		{
+			err:    ID(42).Errorf("x"),
+			wantID: 42,
+			wantOK: true,
+		},
+		{
+			err:    ID(99).Errorf("%w", errors.New("x")),
+			wantID: 99,
+			wantOK: true,
+		},
+		{
+			err:    ID(0).Errorf("%w %w", errors.New("x"), errors.New("y")),
+			wantID: 0,
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		got, ok := IDOf(tt.err)
+		assert.Equalf(t, tt.wantID, got, "IDOf(%T)", tt.err)
+		assert.Equalf(t, tt.wantOK, ok, "IDOf(%T)", tt.err)
+	}
+}

--- a/params/json.libevm.go
+++ b/params/json.libevm.go
@@ -60,7 +60,7 @@ const (
 // [RegisterExtras]. The `extra` argument MUST NOT be nil.
 func UnmarshalChainConfigJSON[C any](data []byte, config *ChainConfig, extra *C, reuseJSONRoot bool) (err error) {
 	if extra == nil {
-		return errIDNilExtra.Errorf("%T argument is nil; use %T.UnmarshalJSON() directly", extra, config)
+		return errs.WithIDf(errIDNilExtra, "%T argument is nil; use %T.UnmarshalJSON() directly", extra, config)
 	}
 
 	if reuseJSONRoot {
@@ -68,7 +68,7 @@ func UnmarshalChainConfigJSON[C any](data []byte, config *ChainConfig, extra *C,
 			return fmt.Errorf("decoding JSON into %T: %s", config, err)
 		}
 		if err := json.Unmarshal(data, extra); err != nil {
-			return errIDDecodeJSONIntoExtra.Errorf("decoding JSON into %T: %s", extra, err)
+			return errs.WithIDf(errIDDecodeJSONIntoExtra, "decoding JSON into %T: %s", extra, err)
 		}
 		return nil
 	}
@@ -81,7 +81,7 @@ func UnmarshalChainConfigJSON[C any](data []byte, config *ChainConfig, extra *C,
 		extra,
 	}
 	if err := json.Unmarshal(data, &combined); err != nil {
-		return errIDDecodeJSONIntoCombination.Errorf(`decoding JSON into combination of %T and %T (as "extra" key): %s`, config, extra, err)
+		return errs.WithIDf(errIDDecodeJSONIntoCombination, `decoding JSON into combination of %T and %T (as "extra" key): %s`, config, extra, err)
 	}
 	return nil
 }
@@ -112,7 +112,7 @@ func MarshalChainConfigJSON[C any](config ChainConfig, extra C, reuseJSONRoot bo
 		}
 		data, err = json.Marshal(jsonExtra)
 		if err != nil {
-			return nil, errIDEncodeJSONCombination.Errorf(`encoding combination of %T and %T (as "extra" key) to JSON: %s`, config, extra, err)
+			return nil, errs.WithIDf(errIDEncodeJSONCombination, `encoding combination of %T and %T (as "extra" key) to JSON: %s`, config, extra, err)
 		}
 		return data, nil
 	}
@@ -128,13 +128,13 @@ func MarshalChainConfigJSON[C any](config ChainConfig, extra C, reuseJSONRoot bo
 	}
 	extraJSONRaw, err := toJSONRawMessages(extra)
 	if err != nil {
-		return nil, errIDEncodeExtraToRawJSON.Errorf("converting extra config to JSON raw messages: %s", err)
+		return nil, errs.WithIDf(errIDEncodeExtraToRawJSON, "converting extra config to JSON raw messages: %s", err)
 	}
 
 	for k, v := range extraJSONRaw {
 		_, ok := configJSONRaw[k]
 		if ok {
-			return nil, errIDEncodeDuplicateJSONKey.Errorf("duplicate JSON key %q in ChainConfig and extra %T", k, extra)
+			return nil, errs.WithIDf(errIDEncodeDuplicateJSONKey, "duplicate JSON key %q in ChainConfig and extra %T", k, extra)
 		}
 		configJSONRaw[k] = v
 	}

--- a/params/json.libevm_test.go
+++ b/params/json.libevm_test.go
@@ -197,9 +197,7 @@ func TestUnmarshalChainConfigJSON_Errors(t *testing.T) {
 			data := []byte(testCase.jsonData)
 			config := ChainConfig{}
 			err := UnmarshalChainConfigJSON(data, &config, testCase.extra, testCase.reuseJSONRoot)
-			got, ok := errs.IDOf(err)
-			require.True(t, ok, "errs.IDOf(UnmarshalChainConfigJSON())")
-			assert.Equalf(t, testCase.wantErrID, got, "UnmarshalChainConfigJSON() got error %v", err)
+			assert.ErrorIs(t, err, errs.WithID(testCase.wantErrID, ""))
 		})
 	}
 }
@@ -243,9 +241,7 @@ func TestMarshalChainConfigJSON_Errors(t *testing.T) {
 
 			config := ChainConfig{}
 			_, err := MarshalChainConfigJSON(config, testCase.extra, testCase.reuseJSONRoot)
-			got, ok := errs.IDOf(err)
-			require.True(t, ok, "errs.IDOf(MarshalChainConfigJSON())")
-			assert.Equalf(t, testCase.wantErrID, got, "MarshalChainConfigJSON() got error %v", err)
+			assert.ErrorIs(t, err, errs.WithID(testCase.wantErrID, ""))
 		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Testing errors by matching their strings results in change-detector tests that can result in false positives due to nothing more than changing the message intended for humans. Changing an implementation and a test at the same time adds uncertainty to the correctness of the change, but change-detector tests force this to be done.

See also: [Test error semantics](https://google.github.io/styleguide/go/decisions#test-error-semantics)

## How this works

The `errs` package is introduced to allow tagging of errors with distinct identifiers that are intended to be immutable (i.e. no change-detector tests) even when messages change. The IDs can only be extracted via the `errs` package, which is in `internal` to stop leakage of the errors via the API such that users can depend on them as per Hyrum's Law:

> With a sufficient number of users of an API,
> it does not matter what you promise in the contract:
> all observable behaviors of your system
> will be depended on by somebody.

## How this was tested

Unit test for ID extraction + usage in `params` tests.