### PR TITLE
chore(core/types): add Test_Body_hasOptionalFields to enforce `hasLaterOptionalField` is up to date

### DIFF
--- a/core/types/block.internal.libevm_test.go
+++ b/core/types/block.internal.libevm_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Body_hasAnyOptionalFieldSet(t *testing.T) {
+func TestBody_hasAnyOptionalFieldSet(t *testing.T) {
 	t.Parallel()
 
 	var body Body

--- a/core/types/block.internal.libevm_test.go
+++ b/core/types/block.internal.libevm_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Body_hasOptionalFields(t *testing.T) {
+func Test_Body_hasAnyOptionalFieldSet(t *testing.T) {
 	t.Parallel()
 
 	var body Body
 
-	assert.False(t, body.hasOptionalFields(), "body has no optional field set")
+	assert.False(t, body.hasAnyOptionalFieldSet(), "body has no optional field set")
 
 	v := reflect.ValueOf(&body).Elem()
 	typ := reflect.TypeOf(body)
@@ -35,7 +35,7 @@ func Test_Body_hasOptionalFields(t *testing.T) {
 			t.Errorf("unexpected field kind %q for field %q", field.Kind(), fieldType.Name)
 		}
 
-		assert.Truef(t, body.hasOptionalFields(), "body has the optional field %q set", fieldType.Name)
+		assert.Truef(t, body.hasAnyOptionalFieldSet(), "body has the optional field %q set", fieldType.Name)
 		field.Set(reflect.ValueOf(before)) // reset the field
 	}
 }

--- a/core/types/block.internal.libevm_test.go
+++ b/core/types/block.internal.libevm_test.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Body_hasOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	var body Body
+
+	assert.False(t, body.hasOptionalFields(), "body has no optional field set")
+
+	v := reflect.ValueOf(&body).Elem()
+	typ := reflect.TypeOf(body)
+	for i := 0; i < v.NumField(); i++ {
+		fieldType := typ.Field(i)
+		rlpTag := fieldType.Tag.Get("rlp")
+		rlpTagFields := strings.Split(rlpTag, ",")
+		if !slices.Contains(rlpTagFields, "optional") {
+			continue
+		}
+
+		field := v.Field(i)
+		before := field.Interface()
+		switch field.Kind() {
+		case reflect.Slice:
+			slice := reflect.MakeSlice(field.Type(), 1, 1)
+			field.Set(slice)
+		default:
+			t.Errorf("unexpected field kind %q for field %q", field.Kind(), fieldType.Name)
+		}
+
+		assert.Truef(t, body.hasOptionalFields(), "body has the optional field %q set", fieldType.Name)
+		field.Set(reflect.ValueOf(before)) // reset the field
+	}
+}

--- a/core/types/block.internal.libevm_test.go
+++ b/core/types/block.internal.libevm_test.go
@@ -17,9 +17,8 @@ func TestBody_hasAnyOptionalFieldSet(t *testing.T) {
 	assert.False(t, body.hasAnyOptionalFieldSet(), "body has no optional field set")
 
 	v := reflect.ValueOf(&body).Elem()
-	typ := reflect.TypeOf(body)
 	for i := 0; i < v.NumField(); i++ {
-		fieldType := typ.Field(i)
+		fieldType := v.Type().Field(i)
 		tag := fieldType.Tag.Get("rlp")
 		if !slices.Contains(strings.Split(tag, ","), "optional") {
 			continue

--- a/core/types/block.internal.libevm_test.go
+++ b/core/types/block.internal.libevm_test.go
@@ -20,9 +20,8 @@ func Test_Body_hasOptionalFields(t *testing.T) {
 	typ := reflect.TypeOf(body)
 	for i := 0; i < v.NumField(); i++ {
 		fieldType := typ.Field(i)
-		rlpTag := fieldType.Tag.Get("rlp")
-		rlpTagFields := strings.Split(rlpTag, ",")
-		if !slices.Contains(rlpTagFields, "optional") {
+		tag := fieldType.Tag.Get("rlp")
+		if !slices.Contains(strings.Split(tag, ","), "optional") {
 			continue
 		}
 

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -137,7 +137,7 @@ func (b *Body) EncodeRLP(dst io.Writer) error {
 			return err
 		}
 
-		hasLaterOptionalField := b.Withdrawals != nil
+		hasLaterOptionalField := b.hasOptionalFields()
 		if err := b.hooks().AppendRLPFields(w, hasLaterOptionalField); err != nil {
 			return err
 		}
@@ -146,6 +146,10 @@ func (b *Body) EncodeRLP(dst io.Writer) error {
 		}
 		return rlp.EncodeListToBuffer(w, b.Withdrawals)
 	})
+}
+
+func (b *Body) hasOptionalFields() bool {
+	return b.Withdrawals != nil
 }
 
 // DecodeRLP implements the [rlp.Decoder] interface.

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -137,7 +137,7 @@ func (b *Body) EncodeRLP(dst io.Writer) error {
 			return err
 		}
 
-		hasLaterOptionalField := b.hasOptionalFields()
+		hasLaterOptionalField := b.hasAnyOptionalFieldSet()
 		if err := b.hooks().AppendRLPFields(w, hasLaterOptionalField); err != nil {
 			return err
 		}
@@ -148,7 +148,7 @@ func (b *Body) EncodeRLP(dst io.Writer) error {
 	})
 }
 
-func (b *Body) hasOptionalFields() bool {
+func (b *Body) hasAnyOptionalFieldSet() bool {
 	return b.Withdrawals != nil
 }
 


### PR DESCRIPTION
## Why this should be merged

To enforce updating the `hasLaterOptionalField` field if more optional fields are added to `Body`

## How this works

Use some reflect magic in a unit test

## How this was tested
