### PR TITLE
chore(lint): use `new-from-rev` field

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for new-from-rev option to work
       - uses: actions/setup-go@v5
         with:
           go-version: stable

--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -75,3 +75,29 @@ jobs:
           commit_message: "[AUTO] rename Go module + update internal import paths\n\nWorkflow: ${{ steps.vars.outputs.WORKFLOW_HASH }} on branch ${{ github.ref_name }}"
           repo: ${{ github.repository }}
           branch: ${{ steps.vars.outputs.DEST_BRANCH }}
+
+  update-golangci:
+    runs-on: ubuntu-latest
+    needs: rename-module
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.rename-module.outputs.vars.DEST_BRANCH }}
+          depth: 1
+
+      - name: Update .golangci.yml new-from-rev
+        uses: fjogeleit/yaml-update-action@main
+        with:
+          valueFile: ".golangci.yml"
+          propertyPath: "issues.new-from-rev"
+          value: $(git rev-parse HEAD)
+          commitChange: false
+
+      - name: Signed commit to branch
+        uses: planetscale/ghcommit-action@d4176bfacef926cc2db351eab20398dfc2f593b5 # v0.2.0
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          commit_message: "[AUTO] update .golangci.yml new-from-rev"
+          repo: ${{ github.repository }}
+          branch: ${{ needs.rename-module.outputs.vars.DEST_BRANCH }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,38 +78,8 @@ linters-settings:
         disabled: true
 
 issues:
+  new-from-rev: 0b56af5a01b8a0c6fc9d60247bb79ffd03d1bcfd
   exclude-dirs-use-default: false
-  exclude-rules:
-    - path-except: libevm
-      linters:
-        # If any issue is flagged in a non-libevm file, add the linter here
-        # because the problem isn't under our control.
-        - containedctx
-        - forcetypeassert
-        - errcheck
-        - gci
-        - gofmt
-        - goheader
-        - goimports
-        - gosec
-        - gosimple
-        - govet
-        - nakedret
-        - nestif
-        - nilerr
-        - nolintlint
-        - revive
-        - staticcheck
-        - tagliatelle
-        - testableexamples
-        - testifylint
-        - thelper
-        - tparallel
-        - typecheck
-        - usestdlibvars
-        - varnamelen
-        - wastedassign
-        - whitespace
   include:
     # Many of the default exclusions are because, verbatim "Annoying issue",
     # which defeats the point of a linter.


### PR DESCRIPTION
## Why this should be merged

Only lint changes made after the last base libevm commit (includes line modifications in non-libevm code)

## How this works

- [`new-from-rev`](https://golangci-lint.run/usage/configuration/#issues-configuration) set to the current libevm base commit hash. Remove `path-except` linting rules which should no longer be needed.
- New rename-module workflow job "update-golangci" which updates the `new-from-rev` commit hash to the new rename module commit hash

## How this was tested

- [x] `golangci-lint run` working as expected on new changes only
- [x] Linting CI passing
- [ ] We should try by dispatching the rename-module workflow, but I wanted to check what we think on this first.