### PR TITLE
chore(ci): use the Go version found in `go.mod`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.4
+          go-version: 1.20
       - name: Run flaky tests sequentially
         run:
           | # Upstream flakes are race conditions exacerbated by concurrent tests
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.4
+          go-version: 1.20
 
       - name: Run `go generate`
         run: go list ./... | grep -Pv "${EXCLUDE_REGEX}" | xargs go generate;

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version-file: "go.mod"
       - name: Run flaky tests sequentially
         run:
           | # Upstream flakes are race conditions exacerbated by concurrent tests
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version-file: "go.mod"
 
       - name: Run `go generate`
         run: go list ./... | grep -Pv "${EXCLUDE_REGEX}" | xargs go generate;

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version-file: "go.mod"
       - name: goheader
         # The goheader linter is only enabled in the CI so that it runs only on modified or new files
         # (see only-new-issues: true). It is disabled in .golangci.yml because

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: 1.20
       - name: goheader
         # The goheader linter is only enabled in the CI so that it runs only on modified or new files
         # (see only-new-issues: true). It is disabled in .golangci.yml because

--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version-file: "go.mod"
 
       - name: Smoke tests
         # `go list` shows us the module name and grep will non-zero exit on mismatch
@@ -75,18 +75,3 @@ jobs:
           commit_message: "[AUTO] rename Go module + update internal import paths\n\nWorkflow: ${{ steps.vars.outputs.WORKFLOW_HASH }} on branch ${{ github.ref_name }}"
           repo: ${{ github.repository }}
           branch: ${{ steps.vars.outputs.DEST_BRANCH }}
-
-      - name: Update .github yml files "go-version" properties
-        shell: bash
-        run: |
-          gomodver=$(sed -n 's/^go \([0-9.]*\)/\1/p' go.mod)
-          sed -i '' -E "s/go-version: 1\.[0-9]\+/go-version: \$gomodver/g" .github/workflows/*.yml
-
-      - name: Signed commit to branch
-        uses: planetscale/ghcommit-action@d4176bfacef926cc2db351eab20398dfc2f593b5 # v0.2.0
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          commit_message: "[AUTO] update .github workflows go-version properties"
-          repo: ${{ github.repository }}
-          branch: ${{ needs.rename-module.outputs.vars.DEST_BRANCH }}

--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -75,3 +75,18 @@ jobs:
           commit_message: "[AUTO] rename Go module + update internal import paths\n\nWorkflow: ${{ steps.vars.outputs.WORKFLOW_HASH }} on branch ${{ github.ref_name }}"
           repo: ${{ github.repository }}
           branch: ${{ steps.vars.outputs.DEST_BRANCH }}
+
+      - name: Update .github yml files "go-version" properties
+        shell: bash
+        run: |
+          gomodver=$(sed -n 's/^go \([0-9.]*\)/\1/p' go.mod)
+          sed -i '' -E "s/go-version: 1\.[0-9]\+/go-version: \$gomodver/g" .github/workflows/*.yml
+
+      - name: Signed commit to branch
+        uses: planetscale/ghcommit-action@d4176bfacef926cc2db351eab20398dfc2f593b5 # v0.2.0
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          commit_message: "[AUTO] update .github workflows go-version properties"
+          repo: ${{ github.repository }}
+          branch: ${{ needs.rename-module.outputs.vars.DEST_BRANCH }}

--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.4
+          go-version: 1.20
 
       - name: Smoke tests
         # `go list` shows us the module name and grep will non-zero exit on mismatch


### PR DESCRIPTION
## Why this should be merged

To prevent disparity between the codebase Go version and the go version used in the CI

## How this works

CI uses the Go version specified in go.mod

## How this was tested

CI passing