### PR TITLE
fix(ci): module-renaming workflow includes `.go.tpl` and `.proto`

### DIFF
--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -9,10 +9,6 @@ on:
         type: string
         default: "2bd6bd01d2e8561dd7fc21b631f4a34ac16627a1"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   rename-module:
     runs-on: ubuntu-latest

--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -41,7 +41,8 @@ jobs:
           find . \
             -iname '*.go' \
             -o -iname '*.txt' \
-            -o -iname '*.go.tpl' | xargs \
+            -o -iname '*.go.tpl' \
+            -o -iname '*.proto' | xargs \
             sed -i -E 's|(["`]github\.com/)ethereum/go-ethereum|\1ava-labs/libevm|g';
 
       - name: Remnant references

--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -28,6 +28,12 @@ jobs:
           echo "DEST_BRANCH=auto-rename-module_source-${{ inputs.source_commit }}_workflow-${WORKFLOW_HASH}-${{ github.ref_name }}" \
             >> "$GITHUB_OUTPUT";
 
+      - name: Fetch tags from ethereum/go-ethereum
+        run: git fetch --tags https://github.com/ethereum/go-ethereum.git
+
+      - name: Tags pointing to source commit
+        run: git tag --points-at  ${{ inputs.source_commit }}
+
       - name: Check out source commit
         run: git checkout ${{ inputs.source_commit }}
 

--- a/.github/workflows/rename-module.yml
+++ b/.github/workflows/rename-module.yml
@@ -38,8 +38,11 @@ jobs:
       - name: Globally update module name
         run: |
           go mod edit -module github.com/ava-labs/libevm;
-          find . -iname '*.go' -o -iname '*.txt' | xargs sed -i -E \
-            's|(["`]github\.com/)ethereum/go-ethereum|\1ava-labs/libevm|g';
+          find . \
+            -iname '*.go' \
+            -o -iname '*.txt' \
+            -o -iname '*.go.tpl' | xargs \
+            sed -i -E 's|(["`]github\.com/)ethereum/go-ethereum|\1ava-labs/libevm|g';
 
       - name: Remnant references
         run: |


### PR DESCRIPTION
## Why this should be merged

Introduction of breaking upstream changes (inclusion of `.go.tpl` files) since the workflow was written. Resulted in [failed smoke tests](https://github.com/ava-labs/libevm/actions/runs/13198798601) due to ABI-binding templates not being updated.

## How this works

Only (1) is necessary for the fix but the others were added for convenience as relevant to this PR:

1. Replace module name in `*.go.tpl` files;
2. As above for `*.proto` files (`go_package` option);
3. Remove concurrency limitations as they're unnecessary with a manually triggered workflow; and
4. Display all tags that point to the source commit as they're useful for inspection of version.

## How this was tested

[Successful workflow run](https://github.com/ava-labs/libevm/actions/runs/13199663099/job/36848609786) at upstream v1.15.0.

For the modifications, respectively:

1. Smoke tests pass and no `.go.tpl` files in [Remnant references](https://github.com/ava-labs/libevm/actions/runs/13199663099/job/36848609786#step:9:1);
2. As above re remnant references;
3. N/A; and
4. Inspection of [step output](https://github.com/ava-labs/libevm/actions/runs/13199663099/job/36848609786#step:6:5).
