### PR TITLE
fix(core/vm): defensive treatment of `ErrOutOfGas` in stateful precompiles

### DIFF
--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -97,7 +98,11 @@ func (args *evmCallArgs) run(p PrecompiledContract, input []byte) (ret []byte, e
 	case statefulPrecompile:
 		env := args.env()
 		ret, err := p(env, input)
-		args.gasRemaining = env.Gas()
+		if errors.Is(err, ErrOutOfGas) {
+			args.gasRemaining = 0
+		} else {
+			args.gasRemaining = env.Gas()
+		}
 		return ret, err
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Paranoia.

It's possible for a stateful precompile to return `ErrOutOfGas` without actually depleting the underlying `vm.Contract` gas tank. In fact, this is quite likely given the way `UseGas()` bails early with `false` if there's insufficient gas.

## How this works

Implementation of `vm.evmCallArgs.run(PrecompiledContract, ...)` conditionally sets gas remaining based on the error.

## How this was tested
