### PR TITLE
chore(ci): pin goheader golangci-lint action to v6.2.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,7 @@ jobs:
         # (see only-new-issues: true). It is disabled in .golangci.yml because
         # golangci-lint running locally is not aware of new/modified files compared to the base
         # commit of a pull request, and we want to avoid reporting invalid goheader errors.
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0 since v6.3.1 does not handle `only-new-issues` correctly
         with:
           version: v1.60
           only-new-issues: true


### PR DESCRIPTION
## Why this should be merged

The action is currently misbehaving on the main branch, linting all files instead of just the files from the current commit.

## How this works

Pins the action to use v6.2

## How this was tested

Will be tested on main branch once this is merged.