### PR TITLE
chore: add label "Priority: With next Geth sync"

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -46,6 +46,8 @@
   color: "03adfc"
 - name: "Priority: 📌 Before next release"
   color: "03adfc"
+- name: "Priority: ⛓️ With next Geth sync"
+  color: "03adfc"
   description: "Has to be done before the next release"
 - name: "Status: 🔒 After next release"
   color: "03adfc"


### PR DESCRIPTION
## Why this should be merged

#110 introduces changes that we want to revert as part of the next Geth sync. This label will be applied to issues that track similar tasks.

## How this works

Magic 🧙 

## How this was tested

Inspecting [CI dry run, which creates the new label](https://github.com/ava-labs/libevm/actions/runs/13261362433/job/37018526246?pr=129#step:3:99).
