### PR TITLE
feat(core/types): `Block` RLP overriding

### DIFF
--- a/core/state/state.libevm_test.go
+++ b/core/state/state.libevm_test.go
@@ -47,7 +47,7 @@ func TestGetSetExtra(t *testing.T) {
 	// test deep copying.
 	payloads := types.RegisterExtras[
 		types.NOOPHeaderHooks, *types.NOOPHeaderHooks,
-		types.NOOPBodyHooks, *types.NOOPBodyHooks,
+		types.NOOPBlockBodyHooks, *types.NOOPBlockBodyHooks,
 		*accountExtra,
 	]().StateAccount
 

--- a/core/state/state_object.libevm_test.go
+++ b/core/state/state_object.libevm_test.go
@@ -48,7 +48,7 @@ func TestStateObjectEmpty(t *testing.T) {
 			registerAndSet: func(acc *types.StateAccount) {
 				types.RegisterExtras[
 					types.NOOPHeaderHooks, *types.NOOPHeaderHooks,
-					types.NOOPBodyHooks, *types.NOOPBodyHooks,
+					types.NOOPBlockBodyHooks, *types.NOOPBlockBodyHooks,
 					bool,
 				]().StateAccount.Set(acc, false)
 			},
@@ -59,7 +59,7 @@ func TestStateObjectEmpty(t *testing.T) {
 			registerAndSet: func(*types.StateAccount) {
 				types.RegisterExtras[
 					types.NOOPHeaderHooks, *types.NOOPHeaderHooks,
-					types.NOOPBodyHooks, *types.NOOPBodyHooks,
+					types.NOOPBlockBodyHooks, *types.NOOPBlockBodyHooks,
 					bool,
 				]()
 			},
@@ -70,7 +70,7 @@ func TestStateObjectEmpty(t *testing.T) {
 			registerAndSet: func(acc *types.StateAccount) {
 				types.RegisterExtras[
 					types.NOOPHeaderHooks, *types.NOOPHeaderHooks,
-					types.NOOPBodyHooks, *types.NOOPBodyHooks,
+					types.NOOPBlockBodyHooks, *types.NOOPBlockBodyHooks,
 					bool,
 				]().StateAccount.Set(acc, true)
 			},

--- a/core/types/backwards_compat.libevm_test.go
+++ b/core/types/backwards_compat.libevm_test.go
@@ -200,6 +200,8 @@ type cChainBodyExtras struct {
 
 var _ BlockBodyHooks = (*cChainBodyExtras)(nil)
 
+func (e *cChainBodyExtras) DeepCopy() *cChainBodyExtras { return e }
+
 func (e *cChainBodyExtras) BodyRLPFieldsForEncoding(b *Body) *rlp.Fields {
 	// The Avalanche C-Chain uses all of the geth required fields (but none of
 	// the optional ones) so there's no need to explicitly list them. This

--- a/core/types/backwards_compat.libevm_test.go
+++ b/core/types/backwards_compat.libevm_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newTx(nonce uint64) *Transaction    { return NewTx(&LegacyTx{Nonce: nonce}) }
-func newHdr(hashLow byte) *Header        { return &Header{ParentHash: common.Hash{hashLow}} }
+func newHdr(parentHashHigh byte) *Header { return &Header{ParentHash: common.Hash{parentHashHigh}} }
 func newWithdraw(idx uint64) *Withdrawal { return &Withdrawal{Index: idx} }
 
 func blockBodyRLPTestInputs() []*Body {

--- a/core/types/backwards_compat.libevm_test.go
+++ b/core/types/backwards_compat.libevm_test.go
@@ -193,6 +193,10 @@ func TestBlockRLPBackwardsCompatibility(t *testing.T) {
 // cChainBodyExtras carries the same additional fields as the Avalanche C-Chain
 // (ava-labs/coreth) [Body] and implements [BlockBodyHooks] to achieve
 // equivalent RLP {en,de}coding.
+//
+// It is not intended as a full test of ava-labs/coreth existing functionality,
+// which should be implemented when that module consumes libevm, but as proof of
+// equivalence of the [rlp.Fields] approach.
 type cChainBodyExtras struct {
 	Version uint32
 	ExtData *[]byte

--- a/core/types/backwards_compat.libevm_test.go
+++ b/core/types/backwards_compat.libevm_test.go
@@ -204,8 +204,6 @@ type cChainBodyExtras struct {
 
 var _ BlockBodyHooks = (*cChainBodyExtras)(nil)
 
-func (e *cChainBodyExtras) Copy() *cChainBodyExtras { return e }
-
 func (e *cChainBodyExtras) BodyRLPFieldsForEncoding(b *Body) *rlp.Fields {
 	// The Avalanche C-Chain uses all of the geth required fields (but none of
 	// the optional ones) so there's no need to explicitly list them. This
@@ -233,6 +231,12 @@ func (e *cChainBodyExtras) BodyRLPFieldPointersForDecoding(b *Body) *rlp.Fields 
 			rlp.Nillable(&e.ExtData), // equivalent to `rlp:"nil"`
 		},
 	}
+}
+
+// See [cChainBodyExtras] intent.
+
+func (e *cChainBodyExtras) Copy() *cChainBodyExtras {
+	panic("unimplemented")
 }
 
 func (e *cChainBodyExtras) BlockRLPFieldsForEncoding(b *BlockRLPProxy) *rlp.Fields {

--- a/core/types/backwards_compat.libevm_test.go
+++ b/core/types/backwards_compat.libevm_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/ava-labs/libevm/rlp"
 )
 
-func TestBodyRLPBackwardsCompatibility(t *testing.T) {
-	newTx := func(nonce uint64) *Transaction { return NewTx(&LegacyTx{Nonce: nonce}) }
-	newHdr := func(hashLow byte) *Header { return &Header{ParentHash: common.Hash{hashLow}} }
-	newWithdraw := func(idx uint64) *Withdrawal { return &Withdrawal{Index: idx} }
+func newTx(nonce uint64) *Transaction    { return NewTx(&LegacyTx{Nonce: nonce}) }
+func newHdr(hashLow byte) *Header        { return &Header{ParentHash: common.Hash{hashLow}} }
+func newWithdraw(idx uint64) *Withdrawal { return &Withdrawal{Index: idx} }
 
+func blockBodyRLPTestInputs() []*Body {
 	// We build up test-case [Body] instances from the Cartesian product of each
 	// of these components.
 	txMatrix := [][]*Transaction{
@@ -61,8 +61,11 @@ func TestBodyRLPBackwardsCompatibility(t *testing.T) {
 			}
 		}
 	}
+	return bodies
+}
 
-	for _, body := range bodies {
+func TestBodyRLPBackwardsCompatibility(t *testing.T) {
+	for _, body := range blockBodyRLPTestInputs() {
 		t.Run("", func(t *testing.T) {
 			t.Cleanup(func() {
 				if t.Failed() {
@@ -114,17 +117,90 @@ func TestBodyRLPBackwardsCompatibility(t *testing.T) {
 	}
 }
 
+func TestBlockRLPBackwardsCompatibility(t *testing.T) {
+	TestOnlyClearRegisteredExtras()
+	t.Cleanup(TestOnlyClearRegisteredExtras)
+
+	RegisterExtras[
+		NOOPHeaderHooks, *NOOPHeaderHooks,
+		NOOPBlockBodyHooks, *NOOPBlockBodyHooks, // types under test
+		struct{},
+	]()
+
+	// Note that there are also a number of tests in `block_test.go` that ensure
+	// backwards compatibility as [NOOPBlockBodyHooks] are used by default when
+	// nothing is registered (the above registration is only for completeness).
+
+	for _, body := range blockBodyRLPTestInputs() {
+		t.Run("", func(t *testing.T) {
+			// [Block] doesn't export most of its fields so uses [extblock] as a
+			// proxy for RLP encoding, which is what we therefore use as the
+			// backwards-compatible gold standard.
+			hdr := newHdr(99)
+			block := extblock{
+				Header:      hdr,
+				Txs:         body.Transactions,
+				Uncles:      body.Uncles,
+				Withdrawals: body.Withdrawals,
+			}
+
+			// We've added [extblock.EncodeRLP] and [extblock.DecodeRLP] for our
+			// hooks.
+			type withoutMethods extblock
+
+			wantRLP, err := rlp.EncodeToBytes(withoutMethods(block))
+			require.NoErrorf(t, err, "rlp.EncodeToBytes([%T with methods stripped])", block)
+
+			// Our input to RLP might not be the canonical RLP output.
+			var wantBlock extblock
+			err = rlp.DecodeBytes(wantRLP, (*withoutMethods)(&wantBlock))
+			require.NoErrorf(t, err, "rlp.DecodeBytes(..., [%T with methods stripped])", &wantBlock)
+
+			t.Run("Encode", func(t *testing.T) {
+				b := NewBlockWithHeader(hdr).WithBody(*body).WithWithdrawals(body.Withdrawals)
+				got, err := rlp.EncodeToBytes(b)
+				require.NoErrorf(t, err, "rlp.EncodeToBytes(%T)", b)
+
+				assert.Equalf(t, wantRLP, got, "expect %T RLP identical to that from %T struct stripped of methods", got, extblock{})
+			})
+
+			t.Run("Decode", func(t *testing.T) {
+				var gotBlock Block
+				err := rlp.DecodeBytes(wantRLP, &gotBlock)
+				require.NoErrorf(t, err, "rlp.DecodeBytes(..., %T)", &gotBlock)
+
+				got := extblock{
+					gotBlock.Header(),
+					gotBlock.Transactions(),
+					gotBlock.Uncles(),
+					gotBlock.Withdrawals(),
+					nil, // unexported libevm hooks
+				}
+
+				opts := cmp.Options{
+					cmp.Comparer((*Header).equalHash),
+					cmp.Comparer((*Transaction).equalHash),
+					cmpopts.IgnoreUnexported(extblock{}),
+				}
+				if diff := cmp.Diff(wantBlock, got, opts); diff != "" {
+					t.Errorf("rlp.DecodeBytes([RLP from %T stripped of methods], ...) diff (-want +got):\n%s", extblock{}, diff)
+				}
+			})
+		})
+	}
+}
+
 // cChainBodyExtras carries the same additional fields as the Avalanche C-Chain
-// (ava-labs/coreth) [Body] and implements [BodyHooks] to achieve equivalent RLP
-// {en,de}coding.
+// (ava-labs/coreth) [Body] and implements [BlockBodyHooks] to achieve
+// equivalent RLP {en,de}coding.
 type cChainBodyExtras struct {
 	Version uint32
 	ExtData *[]byte
 }
 
-var _ BodyHooks = (*cChainBodyExtras)(nil)
+var _ BlockBodyHooks = (*cChainBodyExtras)(nil)
 
-func (e *cChainBodyExtras) RLPFieldsForEncoding(b *Body) *rlp.Fields {
+func (e *cChainBodyExtras) BodyRLPFieldsForEncoding(b *Body) *rlp.Fields {
 	// The Avalanche C-Chain uses all of the geth required fields (but none of
 	// the optional ones) so there's no need to explicitly list them. This
 	// pattern might not be ideal for readability but is used here for
@@ -134,13 +210,13 @@ func (e *cChainBodyExtras) RLPFieldsForEncoding(b *Body) *rlp.Fields {
 	// compatibility so this is safe to do, but only for the required fields.
 	return &rlp.Fields{
 		Required: append(
-			NOOPBodyHooks{}.RLPFieldsForEncoding(b).Required,
+			NOOPBlockBodyHooks{}.BodyRLPFieldsForEncoding(b).Required,
 			e.Version, e.ExtData,
 		),
 	}
 }
 
-func (e *cChainBodyExtras) RLPFieldPointersForDecoding(b *Body) *rlp.Fields {
+func (e *cChainBodyExtras) BodyRLPFieldPointersForDecoding(b *Body) *rlp.Fields {
 	// An alternative to the pattern used above is to explicitly list all
 	// fields for better introspection.
 	return &rlp.Fields{
@@ -151,6 +227,14 @@ func (e *cChainBodyExtras) RLPFieldPointersForDecoding(b *Body) *rlp.Fields {
 			rlp.Nillable(&e.ExtData), // equivalent to `rlp:"nil"`
 		},
 	}
+}
+
+func (e *cChainBodyExtras) BlockRLPFieldsForEncoding(b *BlockRLPProxy) *rlp.Fields {
+	panic("unimplemented")
+}
+
+func (e *cChainBodyExtras) BlockRLPFieldPointersForDecoding(b *BlockRLPProxy) *rlp.Fields {
+	panic("unimplemented")
 }
 
 func TestBodyRLPCChainCompat(t *testing.T) {

--- a/core/types/backwards_compat.libevm_test.go
+++ b/core/types/backwards_compat.libevm_test.go
@@ -200,7 +200,7 @@ type cChainBodyExtras struct {
 
 var _ BlockBodyHooks = (*cChainBodyExtras)(nil)
 
-func (e *cChainBodyExtras) DeepCopy() *cChainBodyExtras { return e }
+func (e *cChainBodyExtras) Copy() *cChainBodyExtras { return e }
 
 func (e *cChainBodyExtras) BodyRLPFieldsForEncoding(b *Body) *rlp.Fields {
 	// The Avalanche C-Chain uses all of the geth required fields (but none of

--- a/core/types/backwards_compat.libevm_test.go
+++ b/core/types/backwards_compat.libevm_test.go
@@ -86,8 +86,10 @@ func TestBodyRLPBackwardsCompatibility(t *testing.T) {
 			t.Run("Decode", func(t *testing.T) {
 				got := new(Body)
 				err := rlp.DecodeBytes(wantRLP, got)
-				require.NoErrorf(t, err, "rlp.DecodeBytes(rlp.EncodeToBytes(%T), %T) resulted in %s",
-					(*withoutMethods)(body), got, pretty.Sprint(got))
+				require.NoErrorf(
+					t, err, "rlp.DecodeBytes(rlp.EncodeToBytes(%T), %T) resulted in %s",
+					(*withoutMethods)(body), got, pretty.Sprint(got),
+				)
 
 				want := body
 				// Regular RLP decoding will never leave these non-optional

--- a/core/types/backwards_compat_diffpkg.libevm_test.go
+++ b/core/types/backwards_compat_diffpkg.libevm_test.go
@@ -42,7 +42,7 @@ func TestHeaderRLPBackwardsCompatibility(t *testing.T) {
 			register: func() {
 				RegisterExtras[
 					NOOPHeaderHooks, *NOOPHeaderHooks,
-					NOOPBodyHooks, *NOOPBodyHooks,
+					NOOPBlockBodyHooks, *NOOPBlockBodyHooks,
 					struct{},
 				]()
 			},

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -212,7 +212,7 @@ type Block struct {
 	ReceivedAt   time.Time
 	ReceivedFrom interface{}
 
-	extra *pseudo.Type // See RegisterExtras()
+	extra *pseudo.Type // See [RegisterExtras]
 }
 
 // "external" block encoding. used for eth protocol, etc.

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -464,6 +464,7 @@ func (b *Block) WithSeal(header *Header) *Block {
 		transactions: b.transactions,
 		uncles:       b.uncles,
 		withdrawals:  b.withdrawals,
+		extra:        b.cloneExtra(),
 	}
 }
 
@@ -489,6 +490,7 @@ func (b *Block) WithWithdrawals(withdrawals []*Withdrawal) *Block {
 		header:       b.header,
 		transactions: b.transactions,
 		uncles:       b.uncles,
+		extra:        b.cloneExtra(),
 	}
 	if withdrawals != nil {
 		block.withdrawals = make([]*Withdrawal, len(withdrawals))

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -211,6 +211,8 @@ type Block struct {
 	// inter-peer block relay.
 	ReceivedAt   time.Time
 	ReceivedFrom interface{}
+
+	extra *pseudo.Type // See RegisterExtras()
 }
 
 // "external" block encoding. used for eth protocol, etc.
@@ -219,6 +221,8 @@ type extblock struct {
 	Txs         []*Transaction
 	Uncles      []*Header
 	Withdrawals []*Withdrawal `rlp:"optional"`
+
+	hooks BlockBodyHooks // libevm: MUST be unexported + populated from [Block.hooks]
 }
 
 // NewBlock creates a new block. The input data is copied, changes to header and to the
@@ -318,6 +322,7 @@ func CopyHeader(h *Header) *Header {
 // DecodeRLP decodes a block from RLP.
 func (b *Block) DecodeRLP(s *rlp.Stream) error {
 	var eb extblock
+	eb.hooks = b.hooks()
 	_, size, _ := s.Kind()
 	if err := s.Decode(&eb); err != nil {
 		return err
@@ -334,13 +339,14 @@ func (b *Block) EncodeRLP(w io.Writer) error {
 		Txs:         b.transactions,
 		Uncles:      b.uncles,
 		Withdrawals: b.withdrawals,
+		hooks:       b.hooks(),
 	})
 }
 
 // Body returns the non-header content of the block.
 // Note the returned data is not an independent copy.
 func (b *Block) Body() *Body {
-	return &Body{b.transactions, b.uncles, b.withdrawals, nil /* unexported extras field */}
+	return &Body{b.transactions, b.uncles, b.withdrawals, b.cloneExtra()}
 }
 
 // Accessors for body data. These do not return a copy because the content
@@ -468,6 +474,7 @@ func (b *Block) WithBody(body Body) *Block {
 		transactions: make([]*Transaction, len(body.Transactions)),
 		uncles:       make([]*Header, len(body.Uncles)),
 		withdrawals:  b.withdrawals,
+		extra:        body.cloneExtra(),
 	}
 	copy(block.transactions, body.Transactions)
 	for i := range body.Uncles {

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -86,11 +86,17 @@ func (*NOOPHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 func (*NOOPHeaderHooks) PostCopy(dst *Header) {}
 
 func (b *Body) cloneExtra() *pseudo.Type {
-	return b.extra // TODO(arr4n) implement this // DO NOT MERGE
+	if r := registeredExtras; r.Registered() {
+		return r.Get().hooks.cloneBodyPayload(b)
+	}
+	return nil
 }
 
 func (b *Block) cloneExtra() *pseudo.Type {
-	return b.extra // TODO(arr4n) implement this // DO NOT MERGE
+	if r := registeredExtras; r.Registered() {
+		return r.Get().hooks.cloneBlockPayload(b)
+	}
+	return nil
 }
 
 var _ = []interface {
@@ -137,6 +143,10 @@ type BlockBodyHooks interface {
 // NOOPBlockBodyHooks implements [BlockBodyHooks] such that they are equivalent
 // to no type having been registered.
 type NOOPBlockBodyHooks struct{}
+
+var _ BlockBodyPayload[*NOOPBlockBodyHooks] = NOOPBlockBodyHooks{}
+
+func (NOOPBlockBodyHooks) DeepCopy() *NOOPBlockBodyHooks { return &NOOPBlockBodyHooks{} }
 
 // The RLP-related methods of [NOOPBlockBodyHooks] make assumptions about the
 // struct fields and their order, which we lock in here as a change detector. If

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -146,7 +146,7 @@ type NOOPBlockBodyHooks struct{}
 
 var _ BlockBodyPayload[*NOOPBlockBodyHooks] = NOOPBlockBodyHooks{}
 
-func (NOOPBlockBodyHooks) DeepCopy() *NOOPBlockBodyHooks { return &NOOPBlockBodyHooks{} }
+func (NOOPBlockBodyHooks) Copy() *NOOPBlockBodyHooks { return &NOOPBlockBodyHooks{} }
 
 // The RLP-related methods of [NOOPBlockBodyHooks] make assumptions about the
 // struct fields and their order, which we lock in here as a change detector. If

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -85,20 +85,6 @@ func (*NOOPHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 }
 func (*NOOPHeaderHooks) PostCopy(dst *Header) {}
 
-func (b *Body) cloneExtra() *pseudo.Type {
-	if r := registeredExtras; r.Registered() {
-		return r.Get().hooks.cloneBodyPayload(b)
-	}
-	return nil
-}
-
-func (b *Block) cloneExtra() *pseudo.Type {
-	if r := registeredExtras; r.Registered() {
-		return r.Get().hooks.cloneBlockPayload(b)
-	}
-	return nil
-}
-
 var _ = []interface {
 	rlp.Encoder
 	rlp.Decoder

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -205,12 +205,10 @@ func TestHeaderHooks(t *testing.T) {
 
 type blockPayload struct {
 	NOOPBlockBodyHooks
-	x      int
-	copied bool
+	x int
 }
 
 func (p *blockPayload) Copy() *blockPayload {
-	p.copied = true
 	return &blockPayload{x: p.x}
 }
 

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -88,7 +88,7 @@ func TestHeaderHooks(t *testing.T) {
 
 	extras := RegisterExtras[
 		stubHeaderHooks, *stubHeaderHooks,
-		NOOPBodyHooks, *NOOPBodyHooks,
+		NOOPBlockBodyHooks, *NOOPBlockBodyHooks,
 		struct{},
 	]()
 	rng := ethtest.NewPseudoRand(13579)

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -258,7 +258,7 @@ func TestBlockWithX(t *testing.T) {
 			// This specifically uses `require` instead of `assert` because a
 			// failure here invalidates the next test, which demonstrates a deep
 			// copy.
-			require.Equalf(t, initialPayload+1, extras.Block.Get(block).x, "%T payload %T after modification via pointer")
+			require.Equalf(t, initialPayload+1, extras.Block.Get(block).x, "%T payload %T after modification via pointer", block, payload)
 
 			switch got := extras.Block.Get(newBlock); got.x {
 			case initialPayload: // expected

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -209,7 +209,7 @@ type blockPayload struct {
 	copied bool
 }
 
-func (p *blockPayload) DeepCopy() *blockPayload {
+func (p *blockPayload) Copy() *blockPayload {
 	p.copied = true
 	return &blockPayload{x: p.x}
 }

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -249,7 +249,7 @@ func TestBlockWithX(t *testing.T) {
 			case "WithWithdrawals":
 				newBlock = block.WithWithdrawals(nil)
 			default:
-				t.Fatal("method call not implemented")
+				t.Fatalf("method call not implemented: %s", method)
 			}
 
 			payload.x++

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -206,7 +206,7 @@ func (ExtraPayloads[HPtr, BPtr, SA]) cloneStateAccount(s *StateAccountExtra) *St
 // blockOrBody is an interface for use as a method argument as they can't
 // introduce new generic type parameters.
 type blockOrBody interface {
-	isBlockOrBody() // noop purely for tagging
+	isBlockOrBody() // noop to restrict type as [Header.extraPayload] otherwise matches
 	extraPayload() *pseudo.Type
 }
 

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -203,6 +203,16 @@ func (ExtraPayloads[HPtr, BPtr, SA]) cloneStateAccount(s *StateAccountExtra) *St
 	}
 }
 
+// blockOrBody is an interface for use as a method argument as they can't
+// introduce new generic type parameters.
+type blockOrBody interface {
+	isBlockOrBody() // noop purely for tagging
+	extraPayload() *pseudo.Type
+}
+
+func (*Block) isBlockOrBody() {}
+func (*Body) isBlockOrBody()  {}
+
 func (e ExtraPayloads[HPtr, BPtr, SA]) cloneBodyPayload(b *Body) *pseudo.Type {
 	return e.cloneBlockOrBodyPayload(b)
 }
@@ -229,16 +239,6 @@ func (b *Block) cloneExtra() *pseudo.Type {
 	}
 	return nil
 }
-
-// blockOrBody is an interface for use as a method argument as they can't
-// introduce new generic type parameters.
-type blockOrBody interface {
-	isBlockOrBody() // noop purely for tagging
-	extraPayload() *pseudo.Type
-}
-
-func (*Block) isBlockOrBody() {}
-func (*Body) isBlockOrBody()  {}
 
 // StateOrSlimAccount is implemented by both [StateAccount] and [SlimAccount],
 // allowing for their [StateAccountExtra] payloads to be accessed in a type-safe

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -89,10 +89,10 @@ func RegisterExtras[
 
 // A BlockBodyPayload is an implementation of [BlockBodyHooks] that is also able
 // to clone itself. Both [Block.Body] and [Block.WithBody] require this
-// functionality to clone the payload between the types.
+// functionality to copy the payload between the types.
 type BlockBodyPayload[BPtr any] interface {
 	BlockBodyHooks
-	DeepCopy() BPtr
+	Copy() BPtr
 }
 
 // TestOnlyClearRegisteredExtras clears the [Extras] previously passed to
@@ -221,7 +221,7 @@ func cloneBlockBodyPayload[
 	BPtr BlockBodyPayload[BPtr],
 ](b T) *pseudo.Type {
 	v := pseudo.MustNewValue[BPtr](b.extraPayload())
-	return pseudo.From(v.Get().DeepCopy()).Type
+	return pseudo.From(v.Get().Copy()).Type
 }
 
 // StateOrSlimAccount is implemented by both [StateAccount] and [SlimAccount],

--- a/core/types/state_account.libevm_test.go
+++ b/core/types/state_account.libevm_test.go
@@ -48,7 +48,7 @@ func TestStateAccountRLP(t *testing.T) {
 		register: func() {
 			RegisterExtras[
 				NOOPHeaderHooks, *NOOPHeaderHooks,
-				NOOPBodyHooks, *NOOPBodyHooks,
+				NOOPBlockBodyHooks, *NOOPBlockBodyHooks,
 				bool,
 			]()
 		},
@@ -82,7 +82,7 @@ func TestStateAccountRLP(t *testing.T) {
 			register: func() {
 				RegisterExtras[
 					NOOPHeaderHooks, *NOOPHeaderHooks,
-					NOOPBodyHooks, *NOOPBodyHooks,
+					NOOPBlockBodyHooks, *NOOPBlockBodyHooks,
 					bool,
 				]()
 			},

--- a/core/types/state_account_storage.libevm_test.go
+++ b/core/types/state_account_storage.libevm_test.go
@@ -75,7 +75,7 @@ func TestStateAccountExtraViaTrieStorage(t *testing.T) {
 			registerAndSetExtra: func(a *types.StateAccount) (*types.StateAccount, assertion) {
 				e := types.RegisterExtras[
 					types.NOOPHeaderHooks, *types.NOOPHeaderHooks,
-					types.NOOPBodyHooks, *types.NOOPBodyHooks,
+					types.NOOPBlockBodyHooks, *types.NOOPBlockBodyHooks,
 					bool,
 				]()
 				e.StateAccount.Set(a, true)
@@ -90,7 +90,7 @@ func TestStateAccountExtraViaTrieStorage(t *testing.T) {
 			registerAndSetExtra: func(a *types.StateAccount) (*types.StateAccount, assertion) {
 				e := types.RegisterExtras[
 					types.NOOPHeaderHooks, *types.NOOPHeaderHooks,
-					types.NOOPBodyHooks, *types.NOOPBodyHooks,
+					types.NOOPBlockBodyHooks, *types.NOOPBlockBodyHooks,
 					bool,
 				]()
 				e.StateAccount.Set(a, false) // the explicit part
@@ -106,7 +106,7 @@ func TestStateAccountExtraViaTrieStorage(t *testing.T) {
 			registerAndSetExtra: func(a *types.StateAccount) (*types.StateAccount, assertion) {
 				e := types.RegisterExtras[
 					types.NOOPHeaderHooks, *types.NOOPHeaderHooks,
-					types.NOOPBodyHooks, *types.NOOPBodyHooks,
+					types.NOOPBlockBodyHooks, *types.NOOPBlockBodyHooks,
 					bool,
 				]()
 				// Note that `a` is reflected, unchanged (the implicit part).
@@ -121,7 +121,7 @@ func TestStateAccountExtraViaTrieStorage(t *testing.T) {
 			registerAndSetExtra: func(a *types.StateAccount) (*types.StateAccount, assertion) {
 				e := types.RegisterExtras[
 					types.NOOPHeaderHooks, *types.NOOPHeaderHooks,
-					types.NOOPBodyHooks, *types.NOOPBodyHooks,
+					types.NOOPBlockBodyHooks, *types.NOOPBlockBodyHooks,
 					arbitraryPayload,
 				]()
 				p := arbitraryPayload{arbitraryData}


### PR DESCRIPTION
## Why this should be merged

Support for configurable `core/types.Block` with RLP encoding, including interplay with `Body`.

## How this works

`Block` doesn't export most of its fields so relies on an internal type, `extblock`, for RLP encoding. This type is modified to implement the `rlp.Encoder` and `Decoder` methods as a point to inject hooks using `rlp.Fields` (as in #120 for `Body`).

`Block` shares the same registered extra type as `Body`. Unlike `Header`, which has its own field in a `Block`, the fields in `Body` are promoted to be carried directly. This suggests that (at least for pure data payloads) the modifications might be equivalent (and `ava-labs/coreth` evidences this). Should different payloads be absolutely required in the future, we can split the types—the `RegisterExtras` signature is already too verbose though 😢.

## How this was tested

Explicit inclusion of a backwards-compatibility test for `NOOPBlockBodyHooks` + implicit testing via the multiple upstream tests in `block_test.go`. Re implicit testing: default behaviour is now to use the noop hooks even when no registration is performed, but if we change this then the tests in `block_test.go` can still be called as subtests from a test that explicitly registers noops.
