### PR TITLE
chore: retract `v1.13.14-0.1.0.rc-2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ava-labs/libevm
 go 1.20
 
 retract (
-	// Vad semver formats resulting in incorrect precedence
+	// Bad semver formats resulting in incorrect precedence
 	v1.13.14-0.1.0-rc.1
 	v1.13.14-0.1.0.rc-2
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,11 @@ module github.com/ava-labs/libevm
 
 go 1.20
 
-retract v1.13.14-0.1.0-rc.1 // bad semver format ("0-rc" grouping) considered > .rc-2
+retract (
+	// Vad semver formats resulting in incorrect precedence
+	v1.13.14-0.1.0-rc.1
+	v1.13.14-0.1.0.rc-2
+)
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0


### PR DESCRIPTION
## Why this should be merged

Our initial release tags weren't well-formed for our needs. Although the format was locked in in #81, I still stuffed up rc2. With the upcoming rc3 release, we want to ensure that Go tooling picks it up as the latest, which requires retracting rc2 as its format means it will take higher precedence.

## How this works

`go.mod` `retract`

## How this was tested

n/a
