### PR TITLE
chore(ci): disable lint goheader step on non-pull-request events

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: lint
 
 on:
+  push:
+    branches: [main, "release/**"]
   pull_request:
     branches: [main, "release/**"]
   workflow_dispatch:
@@ -32,6 +34,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: goheader
+        if: ${{ github.event_name == 'pull_request' }}
         # The goheader linter is only enabled in the CI so that it runs only on modified or new files
         # (see only-new-issues: true). It is disabled in .golangci.yml because
         # golangci-lint running locally is not aware of new/modified files compared to the base

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
         with:
-          scandir: "./libevm"
+          scandir: './libevm'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
         # (see only-new-issues: true). It is disabled in .golangci.yml because
         # golangci-lint running locally is not aware of new/modified files compared to the base
         # commit of a pull request, and we want to avoid reporting invalid goheader errors.
-        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0 since v6.3.1 does not handle `only-new-issues` correctly
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60
           only-new-issues: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: lint
 
 on:
-  push:
-    branches: [main, "release/**"]
   pull_request:
     branches: [main, "release/**"]
   workflow_dispatch:
@@ -61,4 +59,4 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
         with:
-          scandir: './libevm'
+          scandir: "./libevm"


### PR DESCRIPTION
This notably addresses the goheader step misbehaving and linting all files on pushes