### PR TITLE
chore: remove module retractions in lieu of bumping minor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,6 @@ module github.com/ava-labs/libevm
 
 go 1.20
 
-retract (
-	// Bad semver formats resulting in incorrect precedence
-	v1.13.14-0.1.0-rc.1
-	v1.13.14-0.1.0.rc-2
-)
-
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0
 	github.com/Microsoft/go-winio v0.6.1


### PR DESCRIPTION
## Why this should be merged

Both #141 and #81 attempted to fix my lack of planning with release versioning however Go modules [require a higher-precedence version for retract statements to be honoured](https://go.dev/ref/mod#go-mod-file-retract:~:text=The%20new%20version%20must%20be%20higher%20than%20other%20release%20or%20pre%2Drelease%20versions%3B%20that%20is%2C%20the%20%40latest%20version%20query%20should%20resolve%20to%20the%20new%20version%20before%20retractions%20are%20considered.). The only way we can get that with our [versioning rules](https://github.com/ava-labs/libevm/blob/32e7dafe1c176ec1ef447119a2d996210b877864/params/version.libevm.go#L30) is to bump the minor version. This will negate the need for explicit retraction so I'm removing it as a cleanup.

## How this works

n/a

## How this was tested

[Effect of bumping minor](https://semvercompare.azurewebsites.net/?version=1.13.14-0.1.0.rc.3&version=1.13.14-0.1.0.rc-2&version=1.13.14-0.1.0-rc.1&version=1.13.14-0.2.0.rc.1):

![image](https://github.com/user-attachments/assets/d8eb3508-9c62-4864-b0ba-19b8f5f218f1)
