### PR TITLE
refactor(metrics): `New*` constructors use `GetOrRegister*` functions

### DIFF
--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -52,12 +52,7 @@ func NewCounterForced() Counter {
 
 // NewRegisteredCounter constructs and registers a new StandardCounter.
 func NewRegisteredCounter(name string, r Registry) Counter {
-	c := NewCounter()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterCounter(name, r)
 }
 
 // NewRegisteredCounterForced constructs and registers a new StandardCounter
@@ -65,12 +60,7 @@ func NewRegisteredCounter(name string, r Registry) Counter {
 // Be sure to unregister the counter from the registry once it is of no use to
 // allow for garbage collection.
 func NewRegisteredCounterForced(name string, r Registry) Counter {
-	c := NewCounterForced()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterCounterForced(name, r)
 }
 
 // counterSnapshot is a read-only copy of another Counter.

--- a/metrics/counter.libevm.go
+++ b/metrics/counter.libevm.go
@@ -1,4 +1,4 @@
-// Copyright 2026 the libevm authors.
+// Copyright 2025 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License

--- a/metrics/counter.libevm.go
+++ b/metrics/counter.libevm.go
@@ -1,0 +1,38 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package metrics
+
+// GetOrRegisterOrOverrideCounter searches for a metric already registered
+// with the `name` given. If a metric is found and it is a [Counter], this one
+// is returned. If a metric is found and it is not a [Counter], it is unregistered
+// and replaced with a new registered [Counter]. If no metric is found, a new
+// [Counter] is constructed and registered.
+// This is especially useful for a metric defined in this project with a different
+// type than a metric defined in a consumer of this project, for the same name.
+func GetOrRegisterOrOverrideCounter(name string, r Registry) Counter {
+	if r == nil {
+		r = DefaultRegistry
+	}
+	counter, ok := r.GetOrRegister(name, NewCounter).(Counter)
+	if ok {
+		return counter
+	}
+	r.Unregister(name)
+	counter = NewCounter()
+	_ = r.Register(name, counter)
+	return counter
+}

--- a/metrics/counter_float64.go
+++ b/metrics/counter_float64.go
@@ -53,12 +53,7 @@ func NewCounterFloat64Forced() CounterFloat64 {
 
 // NewRegisteredCounterFloat64 constructs and registers a new StandardCounterFloat64.
 func NewRegisteredCounterFloat64(name string, r Registry) CounterFloat64 {
-	c := NewCounterFloat64()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterCounterFloat64(name, r)
 }
 
 // NewRegisteredCounterFloat64Forced constructs and registers a new StandardCounterFloat64
@@ -66,12 +61,7 @@ func NewRegisteredCounterFloat64(name string, r Registry) CounterFloat64 {
 // Be sure to unregister the counter from the registry once it is of no use to
 // allow for garbage collection.
 func NewRegisteredCounterFloat64Forced(name string, r Registry) CounterFloat64 {
-	c := NewCounterFloat64Forced()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterCounterFloat64Forced(name, r)
 }
 
 // counterFloat64Snapshot is a read-only copy of another CounterFloat64.

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -35,12 +35,7 @@ func NewGauge() Gauge {
 
 // NewRegisteredGauge constructs and registers a new StandardGauge.
 func NewRegisteredGauge(name string, r Registry) Gauge {
-	c := NewGauge()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterGauge(name, r)
 }
 
 // gaugeSnapshot is a read-only copy of another Gauge.

--- a/metrics/gauge_float64.go
+++ b/metrics/gauge_float64.go
@@ -34,12 +34,7 @@ func NewGaugeFloat64() GaugeFloat64 {
 
 // NewRegisteredGaugeFloat64 constructs and registers a new StandardGaugeFloat64.
 func NewRegisteredGaugeFloat64(name string, r Registry) GaugeFloat64 {
-	c := NewGaugeFloat64()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterGaugeFloat64(name, r)
 }
 
 // gaugeFloat64Snapshot is a read-only copy of another GaugeFloat64.

--- a/metrics/gauge_info.go
+++ b/metrics/gauge_info.go
@@ -44,12 +44,7 @@ func NewGaugeInfo() GaugeInfo {
 
 // NewRegisteredGaugeInfo constructs and registers a new StandardGaugeInfo.
 func NewRegisteredGaugeInfo(name string, r Registry) GaugeInfo {
-	c := NewGaugeInfo()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterGaugeInfo(name, r)
 }
 
 // gaugeInfoSnapshot is a read-only copy of another GaugeInfo.

--- a/metrics/histogram.go
+++ b/metrics/histogram.go
@@ -40,12 +40,7 @@ func NewHistogram(s Sample) Histogram {
 // NewRegisteredHistogram constructs and registers a new StandardHistogram from
 // a Sample.
 func NewRegisteredHistogram(name string, r Registry, s Sample) Histogram {
-	c := NewHistogram(s)
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterHistogram(name, r, s)
 }
 
 // NilHistogram is a no-op Histogram.

--- a/metrics/resetting_timer.go
+++ b/metrics/resetting_timer.go
@@ -35,12 +35,7 @@ func GetOrRegisterResettingTimer(name string, r Registry) ResettingTimer {
 
 // NewRegisteredResettingTimer constructs and registers a new StandardResettingTimer.
 func NewRegisteredResettingTimer(name string, r Registry) ResettingTimer {
-	c := NewResettingTimer()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterResettingTimer(name, r)
 }
 
 // NewResettingTimer constructs a new StandardResettingTimer

--- a/metrics/testdata/opentsb.want
+++ b/metrics/testdata/opentsb.want
@@ -20,4 +20,4 @@ put pre.second.one-minute 978307200 0.00 host=hal9000
 put pre.second.five-minute 978307200 0.00 host=hal9000
 put pre.second.fifteen-minute 978307200 0.00 host=hal9000
 put pre.second.mean-rate 978307200 0.00 host=hal9000
-put pre.tau.count 978307200 1.570000 host=hal9000
+put pre.tau.count 978307200 4.710000 host=hal9000

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -46,12 +46,7 @@ func NewCustomTimer(h Histogram, m Meter) Timer {
 // Be sure to unregister the meter from the registry once it is of no use to
 // allow for garbage collection.
 func NewRegisteredTimer(name string, r Registry) Timer {
-	c := NewTimer()
-	if nil == r {
-		r = DefaultRegistry
-	}
-	r.Register(name, c)
-	return c
+	return GetOrRegisterTimer(name, r)
 }
 
 // NewTimer constructs a new StandardTimer using an exponentially-decaying


### PR DESCRIPTION
## Why this should be merged

- Avoid conflicts for metrics used both in consumers of libevm and in libevm
- See https://github.com/ava-labs/coreth/pull/848

The alternative would be to change all occurrences of `metrics.New*` by `metrics.GetOrRegister*` in both the consumer code and in the libevm code (because it's unpredictable which one would register first), but that produces a lot more diffs.

Just for historical purposes, I did try to have a custom registry on a consumer (coreth) for all metrics but:

- if the same metric is used in both the consumer and libevm (I think there are a few, given CI fails quite a bit), we would lose metrics from the libevm side because it uses another registry (and not sure we can merge both metrics from 2 different registries)
- it introduces a few hundred lines of diffs which is undesirable on the consumer side (coreth) at this time

## How this works

- Change all `metrics.New*` function implementations to use `metrics.GetOrRegister*` functions.
- Add `GetOrRegisterOrOverrideCounter` because counter metrics in consumers are defined as timer metrics in libevm, so consumers need to use this function when this happens.

## How this was tested

- [ ] CI passing
- [ ] `GetOrRegisterOrOverrideCounter` needs test