### PR TITLE
chore(ci): add `merge_group` trigger to required workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, "release/**"]
   pull_request:
     branches: [main, "release/**"]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/libevm-delta.yml
+++ b/.github/workflows/libevm-delta.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, "release/**"]
   pull_request:
     branches: [main, "release/**"]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, "release/**"]
   pull_request:
     branches: [main, "release/**"]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why this should be merged

Allows ruleset-required workflows to be triggered by a merge queue, not just the PR for the merge. Although `main` isn't a particularly "busy" branch, a merge queue will ensure that CI passes on the exact version of code that is about to be merged; i.e. (from the [docs]):

> The merge queue provides the same benefits as the **Require branches to be up to date before merging** branch protection, but does not require a pull request author to update their pull request branch and wait for status checks to finish before trying to merge.

[docs]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#about-merge-queues

## How this works

Adds `merge_group` workflow trigger with [recommended type](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group).

## How this was tested

N/A (worst-case it has to be reverted and another PR is temporarily blocked).