### PR TITLE
fix(ci): only create local `main` branch if non-existent

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "./libevm/tooling/go.mod"
-      - run: git branch main origin/main
+      - name: Create local `main` if non-existent
+        run: git show-ref --quiet --verify refs/heads/main || git branch main origin/main
       - run: go test -v ./... --target_branch="${{ env.TARGET_BRANCH }}"
 
   go_generate:


### PR DESCRIPTION
## Why this should be merged

The CI job in #145 requires a local (to the runner) `main` branch and since `actions/checkout` doesn't check it out, the workflow creates the branch off `origin/main`. However, after merge of a PR to `main`, the workflow is run on `main` itself and that step [fails because the branch already exists](https://github.com/ava-labs/libevm/actions/runs/13908218530/job/38916101218).

## How this works

Only call `git branch main origin/main` if `main` doesn't exist.

## How this was tested

We'll see once it's merged 🤷 
