### PR TITLE
chore: enable metrics by default

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,11 +18,11 @@ import (
 )
 
 // Enabled is checked by the constructor functions for all of the
-// standard metrics. If it is true, the metric returned is a stub.
+// standard metrics. If it is false, the metric returned is a stub.
 //
 // This global kill-switch helps quantify the observer effect and makes
 // for less cluttered pprof profiles.
-var Enabled = false
+var Enabled = true
 
 // EnabledExpensive is a soft-flag meant for external packages to check if costly
 // metrics gathering is allowed or not. The goal is to separate standard metrics


### PR DESCRIPTION
## Why this should be merged

The `metrics.Enabled` global is misleadingly named and disables _constructors_, not individual metrics when they're used. This resulted in all `ava-labs/coreth` metrics being no-ops because it was only set to `true` after they were all constructed. As the majority of metrics are globals, they're created during package initialisation so simply setting `metrics.Enabled = true` somewhere in `coreth` isn't a guarantee of ordering. The old `coreth/metrics` package simply set the global to `true` by default.

## How this works

`metrics.Enabled = true` at the point of declaration.

## How this was tested

Local inspection of metrics on a running binary.