### PR TITLE
chore!(triedb): remove config argument for `DBConstructor`

### DIFF
--- a/triedb/database.libevm.go
+++ b/triedb/database.libevm.go
@@ -42,7 +42,7 @@ type ReaderProvider interface {
 }
 
 // A DBConstructor constructs alternative backend-database implementations.
-type DBConstructor func(ethdb.Database, *Config) DBOverride
+type DBConstructor func(ethdb.Database) DBOverride
 
 // A DBOverride is an arbitrary implementation of a [Database] backend. It MUST
 // be either a [HashDB] or a [PathDB].
@@ -59,7 +59,7 @@ func (db *Database) overrideBackend(diskdb ethdb.Database, config *Config) bool 
 		log.Crit("Database override provided when 'hash' or 'path' mode are configured")
 	}
 
-	db.backend = config.DBOverride(diskdb, config)
+	db.backend = config.DBOverride(diskdb)
 	switch db.backend.(type) {
 	case HashDB:
 	case PathDB:

--- a/triedb/database.libevm_test.go
+++ b/triedb/database.libevm_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestDBOverride(t *testing.T) {
 	config := &Config{
-		DBOverride: func(d ethdb.Database, c *Config) DBOverride {
+		DBOverride: func(d ethdb.Database) DBOverride {
 			return override{}
 		},
 	}


### PR DESCRIPTION
## Why this should be merged

The config argument is not used by consumers anymore, see https://github.com/ava-labs/coreth/pull/862/commits/b94c67629c0a6ff239834d0a4cbf91b8018a2b19 and conversation https://github.com/ava-labs/coreth/pull/820#discussion_r2010986603

## How this works

Removes config argument from DBConstructor

## How this was tested

Existing CI passing
