### PR TITLE
feat(params): export `newTimestampCompatError` with alias `NewTimestampCompatError`

### DIFF
--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -219,8 +219,7 @@ func (r *Rules) extraPayload() *pseudo.Type {
 
 // NewTimestampCompatError returns a new config-compatibility error indicating an incompatible timestamp.
 func NewTimestampCompatError(what string, storedTime, newTime *uint64) *ConfigCompatError {
-    // If this breaks when merging a new version of `geth`, the wrapping function's signature MUST be
-    // changed to match as it exists only to export the function.
-    return newTimestampCompatError(what, storedTime, newTime)
+	// If this breaks when merging a new version of `geth`, the wrapping function's signature MUST be
+	// changed to match as it exists only to export the function.
+	return newTimestampCompatError(what, storedTime, newTime)
 }
-

--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -217,4 +217,10 @@ func (r *Rules) extraPayload() *pseudo.Type {
 	return r.extra
 }
 
-var NewTimestampCompatError = newTimestampCompatError
+// NewTimestampCompatError returns a new config-compatibility error indicating an incompatible timestamp.
+func NewTimestampCompatError(what string, storedTime, newTime *uint64) *ConfigCompatError {
+    // If this breaks when merging a new version of `geth`, the wrapping function's signature MUST be
+    // changed to match as it exists only to export the function.
+    return newTimestampCompatError(what, storedTime, newTime)
+}
+

--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -216,3 +216,5 @@ func (r *Rules) extraPayload() *pseudo.Type {
 	}
 	return r.extra
 }
+
+var NewTimestampCompatError = newTimestampCompatError


### PR DESCRIPTION
## Why this should be merged

To resolve [this TODO comment](https://github.com/ava-labs/coreth/pull/820#discussion_r2010136784) and import it in consumers.

## How this works

Use an exported variable assigned to the unexported function.

## How this was tested
