### PR TITLE
docs(libevm/tooling/release): add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ with `geth`.
 
 We are immensely grateful for the hard work of the `geth` authors, and hope that our contribution can be of value to others too. Thank you!
 
+If you want to create a release, please refer to [libevm/tooling/release](libevm/tooling/release)
+
 ## Go Ethereum
 
 Golang execution layer implementation of the Ethereum protocol.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with `geth`.
 
 We are immensely grateful for the hard work of the `geth` authors, and hope that our contribution can be of value to others too. Thank you!
 
-If you want to create a release, please refer to [libevm/tooling/release](libevm/tooling/release)
+To create a release, please refer to [libevm/tooling/release](libevm/tooling/release).
 
 ## Go Ethereum
 

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -10,7 +10,6 @@ In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
     git checkout -b release/v1.13.14-0.2.0.rc.4
     git push -u origin release/v1.13.14-0.2.0.rc.4
     git checkout -b myusername/release/v1.13.14-0.2.0.rc.4
-    git push -u origin myusername/release/v1.13.14-0.2.0.rc.4
     ```
 
     The `myusername/release/v1.13.14-0.2.0.rc.4` branch will be used to add "release modifications" and will target the branch `release/v1.13.14-0.2.0.rc.4` in a pull request.
@@ -21,7 +20,7 @@ In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
     - If planning a release candidate: set `libEVMReleaseCandidate` to the correct number; in this case `4`
     - If needed: change the `LibEVMVersionMajor`, `LibEVMVersionMinor` and `LibEVMVersionPatch` numbers
 1. Commit your modifications to [params/version.libevm.go](/params/version.libevm.go) with a commit title `chore: release v1.13.14-0.2.0.rc.4`.
-1. Push your modified branch to the remote `git push`
+1. Push your modified branch to the remote `git push -u origin myusername/release/v1.13.14-0.2.0.rc.4`
 1. Open a pull request from your modified branch `myusername/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`, for example with `https://github.com/ava-labs/libevm/compare/release/v1.13.14-0.2.0.rc.4...myusername/release/v1.13.14-0.2.0.rc.4?expand=1`. Set the tile to "chore: release `v1.13.14-0.2.0.rc.4`"
 1. Wait for all the checks to pass on the pull request
 1. Fast forward merge your branch in the release branch:

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -1,6 +1,6 @@
 # Release
 
-In the following, we create a release candidate tag `v1.13.14-0.2.0.rc.4`.
+In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
 
 1. Create two branches, usually from the tip of the `main` branch, but the base commit MAY be from anywhere on `main`:
 

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -1,33 +1,55 @@
 # Release
 
-In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
+In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4` and your Github username is `myusername`. We set environment variables accordingly:
+
+```bash
+VERSION=v1.13.14-0.2.0.rc.4
+USERNAME=myusername
+```
 
 1. Create two branches, usually from the tip of the `main` branch, but the base commit MAY be from anywhere on `main`:
 
     ```bash
     git fetch origin main:main
     git checkout main
-    git checkout -b release/v1.13.14-0.2.0.rc.4
-    git push -u origin release/v1.13.14-0.2.0.rc.4
-    git checkout -b myusername/release/v1.13.14-0.2.0.rc.4
+    git checkout -b "release/$VERSION"
+    git push -u origin "release/$VERSION"
+    git checkout -b "$USERNAME/release/$VERSION"
     ```
 
-    The `myusername/release/v1.13.14-0.2.0.rc.4` branch will be used to add "release modifications" and will target the branch `release/v1.13.14-0.2.0.rc.4` in a pull request.
+    The `$USERNAME/release/$VERSION` branch will be used to add "release modifications" and will target the branch `release/$VERSION` in a pull request.
 1. Run the script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks). You may have to resolve conflicts. If you encounter a CI error NOT from the `go_test_tooling` job, ideally [amend](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) the cherry-picked commit(s) responsible for each issue.
 1. Modify [params/version.libevm.go](/params/version.libevm.go)
     - Change the `LibEVMReleaseType` to the correct release type, for example `ReleaseCandidate`
     - If planning a release candidate: set `libEVMReleaseCandidate` to the correct number; in this case `4`
     - If needed: change the `LibEVMVersionMajor`, `LibEVMVersionMinor` and `LibEVMVersionPatch` numbers
-    - Change the `LibEVMVersion` to the correct final version string (`version.libevm_test.go` will ensure that this is correctly formatted)
-1. Commit your modifications to [params/version.libevm.go](/params/version.libevm.go) with a commit title `chore: release v1.13.14-0.2.0.rc.4`.
-1. Push your modified branch to the remote `git push -u origin myusername/release/v1.13.14-0.2.0.rc.4`
-1. Open a pull request from your modified branch `myusername/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`, for example with `https://github.com/ava-labs/libevm/compare/release/v1.13.14-0.2.0.rc.4...myusername/release/v1.13.14-0.2.0.rc.4?expand=1`. Set the title to "chore: release `v1.13.14-0.2.0.rc.4`"
+    - Change the `LibEVMVersion` to the correct final version string `$VERSION` (`version.libevm_test.go` will ensure that this is correctly formatted)
+1. Commit your modifications to [params/version.libevm.go](/params/version.libevm.go) with a commit title `chore: release v1.13.14-0.2.0.rc.4`:
+
+    ```bash
+    git commit -m "chore: release $VERSION"
+    ```
+
+1. Push your modified branch to the remote `git push -u origin $USERNAME/release/$VERSION`
+1. Open a pull request from your modified branch `$USERNAME/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`:
+    1. You can create the pull request for example using
+
+        ```bash
+        open -a "Google Chrome" https://github.com/ava-labs/libevm/compare/release/$VERSION...$USERNAME/release/$VERSION
+        ```
+
+    1. Set the title of the pull request to
+
+        ```txt
+        chore: release `v1.13.14-0.2.0.rc.4`
+        ```
+
 1. Wait for all the checks to pass on the pull request
 1. Fast forward merge your branch in the release branch:
 
     ```bash
-    git checkout release/v1.13.14-0.2.0.rc.4
-    git merge --ff-only myusername/release/v1.13.14-0.2.0.rc.4
+    git checkout "release/$VERSION"
+    git merge --ff-only "$USERNAME/release/$VERSION"
     git push
     ```
 
@@ -35,13 +57,13 @@ In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
 1. Finally create your tag and push it using the release branch:
 
     ```bash
-    git tag v1.13.14-0.2.0.rc.4
-    git push origin v1.13.14-0.2.0.rc.4
+    git tag "$VERSION"
+    git push origin "$VERSION"
     ```
 
 1. (optional) you can then cleanup with:
 
     ```bash
-    git branch -D release/v1.13.14-0.2.0.rc.4 myusername/release/v1.13.14-0.2.0.rc.4
-    git push -d origin myusername/release/v1.13.14-0.2.0.rc.4
+    git branch -D "release/$VERSION" "$USERNAME/release/$VERSION"
+    git push -d origin "$USERNAME/release/$VERSION"
     ```

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -1,0 +1,26 @@
+# Release
+
+In the following, we create a release candidate tag `v1.13.14-0.2.0.rc.4`.
+
+1. Create two branches, usually from the `main` branch:
+
+    ```bash
+    git fetch origin main:main
+    git checkout main
+    git checkout -b release/v1.13.14-0.2.0.rc.4
+    git push -u origin release/v1.13.14-0.2.0.rc.4
+    git checkout -b myusername/release/v1.13.14-0.2.0.rc.4
+    git push -u origin myusername/release/v1.13.14-0.2.0.rc.4
+    ```
+
+    The `myusername/release/v1.13.14-0.2.0.rc.4` branch will be used to add "release modifications" and will target the branch `release/v1.13.14-0.2.0.rc.4` in a pull request.
+1. Run script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks)
+    - you may have to resolve conflicts
+1. Modify [params/version.libevm.go](/params/version.libevm.go)
+    - Change the `LibEVMVersion` to the correct final version name
+    - Change the `LibEVMReleaseType` to the correct release type, for example `ReleaseCandidate`
+    - If planning a release candidate: set `libEVMReleaseCandidate` to the correct number; in this case `4`
+    - If needed: change the `LibEVMVersionMajor`, `LibEVMVersionMinor` and `LibEVMVersionPatch` numbers
+1. Commit your modifications to [params/version.libevm.go](/params/version.libevm.go) with a commit title `chore: release v1.13.14-0.2.0.rc.4`.
+1. Push your modified branch to the remote `git push`
+1. Open a pull request from your modified branch `myusername/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`, for example with `https://github.com/ava-labs/libevm/compare/release/v1.13.14-0.2.0.rc.4...myusername/release/v1.13.14-0.2.0.rc.4?expand=1`. Set the tile to "chore: release `v1.13.14-0.2.0.rc.4`"

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -15,10 +15,10 @@ In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
     The `myusername/release/v1.13.14-0.2.0.rc.4` branch will be used to add "release modifications" and will target the branch `release/v1.13.14-0.2.0.rc.4` in a pull request.
 1. Run the script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks). You may have to resolve conflicts.
 1. Modify [params/version.libevm.go](/params/version.libevm.go)
-    - Change the `LibEVMVersion` to the correct final version string (`version.libevm_test.go` will ensure that this is correctly formatted)
     - Change the `LibEVMReleaseType` to the correct release type, for example `ReleaseCandidate`
     - If planning a release candidate: set `libEVMReleaseCandidate` to the correct number; in this case `4`
     - If needed: change the `LibEVMVersionMajor`, `LibEVMVersionMinor` and `LibEVMVersionPatch` numbers
+    - Change the `LibEVMVersion` to the correct final version string (`version.libevm_test.go` will ensure that this is correctly formatted)
 1. Commit your modifications to [params/version.libevm.go](/params/version.libevm.go) with a commit title `chore: release v1.13.14-0.2.0.rc.4`.
 1. Push your modified branch to the remote `git push -u origin myusername/release/v1.13.14-0.2.0.rc.4`
 1. Open a pull request from your modified branch `myusername/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`, for example with `https://github.com/ava-labs/libevm/compare/release/v1.13.14-0.2.0.rc.4...myusername/release/v1.13.14-0.2.0.rc.4?expand=1`. Set the title to "chore: release `v1.13.14-0.2.0.rc.4`"

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -2,7 +2,7 @@
 
 In the following, we create a release candidate tag `v1.13.14-0.2.0.rc.4`.
 
-1. Create two branches, usually from the `main` branch:
+1. Create two branches, usually from the tip of the `main` branch, but the base commit MAY be from anywhere on `main`:
 
     ```bash
     git fetch origin main:main

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -24,3 +24,26 @@ In the following, we create a release candidate tag `v1.13.14-0.2.0.rc.4`.
 1. Commit your modifications to [params/version.libevm.go](/params/version.libevm.go) with a commit title `chore: release v1.13.14-0.2.0.rc.4`.
 1. Push your modified branch to the remote `git push`
 1. Open a pull request from your modified branch `myusername/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`, for example with `https://github.com/ava-labs/libevm/compare/release/v1.13.14-0.2.0.rc.4...myusername/release/v1.13.14-0.2.0.rc.4?expand=1`. Set the tile to "chore: release `v1.13.14-0.2.0.rc.4`"
+1. Wait for all the checks to pass on the pull request
+1. Fast forward merge your branch in the release branch:
+
+    ```bash
+    git checkout release/v1.13.14-0.2.0.rc.4
+    git merge --ff-only myusername/release/v1.13.14-0.2.0.rc.4
+    git push
+    ```
+
+    This will also close the ongoing pull request.
+1. Finally create your tag and push it using the release branch:
+
+    ```bash
+    git tag v1.13.14-0.2.0.rc.4
+    git push v1.13.14-0.2.0.rc.4
+    ```
+
+1. (optional) you can then cleanup with:
+
+    ```bash
+    git branch -D release/v1.13.14-0.2.0.rc.4 myusername/release/v1.13.14-0.2.0.rc.4
+    git push -d origin myusername/release/v1.13.14-0.2.0.rc.4
+    ```

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -21,7 +21,7 @@ In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
     - If needed: change the `LibEVMVersionMajor`, `LibEVMVersionMinor` and `LibEVMVersionPatch` numbers
 1. Commit your modifications to [params/version.libevm.go](/params/version.libevm.go) with a commit title `chore: release v1.13.14-0.2.0.rc.4`.
 1. Push your modified branch to the remote `git push -u origin myusername/release/v1.13.14-0.2.0.rc.4`
-1. Open a pull request from your modified branch `myusername/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`, for example with `https://github.com/ava-labs/libevm/compare/release/v1.13.14-0.2.0.rc.4...myusername/release/v1.13.14-0.2.0.rc.4?expand=1`. Set the tile to "chore: release `v1.13.14-0.2.0.rc.4`"
+1. Open a pull request from your modified branch `myusername/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`, for example with `https://github.com/ava-labs/libevm/compare/release/v1.13.14-0.2.0.rc.4...myusername/release/v1.13.14-0.2.0.rc.4?expand=1`. Set the title to "chore: release `v1.13.14-0.2.0.rc.4`"
 1. Wait for all the checks to pass on the pull request
 1. Fast forward merge your branch in the release branch:
 

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -38,7 +38,7 @@ In the following, we create a release candidate tag `v1.13.14-0.2.0.rc.4`.
 
     ```bash
     git tag v1.13.14-0.2.0.rc.4
-    git push v1.13.14-0.2.0.rc.4
+    git push origin v1.13.14-0.2.0.rc.4
     ```
 
 1. (optional) you can then cleanup with:

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -16,7 +16,7 @@ In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
     The `myusername/release/v1.13.14-0.2.0.rc.4` branch will be used to add "release modifications" and will target the branch `release/v1.13.14-0.2.0.rc.4` in a pull request.
 1. Run the script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks). You may have to resolve conflicts.
 1. Modify [params/version.libevm.go](/params/version.libevm.go)
-    - Change the `LibEVMVersion` to the correct final version name
+    - Change the `LibEVMVersion` to the correct final version string (`version.libevm_test.go` will ensure that this is correctly formatted)
     - Change the `LibEVMReleaseType` to the correct release type, for example `ReleaseCandidate`
     - If planning a release candidate: set `libEVMReleaseCandidate` to the correct number; in this case `4`
     - If needed: change the `LibEVMVersionMajor`, `LibEVMVersionMinor` and `LibEVMVersionPatch` numbers

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -13,7 +13,7 @@ In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4`.
     ```
 
     The `myusername/release/v1.13.14-0.2.0.rc.4` branch will be used to add "release modifications" and will target the branch `release/v1.13.14-0.2.0.rc.4` in a pull request.
-1. Run the script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks). You may have to resolve conflicts.
+1. Run the script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks). You may have to resolve conflicts. If you encounter a CI error NOT from the `go_test_tooling` job, ideally [amend](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) the cherry-picked commit(s) responsible for each issue.
 1. Modify [params/version.libevm.go](/params/version.libevm.go)
     - Change the `LibEVMReleaseType` to the correct release type, for example `ReleaseCandidate`
     - If planning a release candidate: set `libEVMReleaseCandidate` to the correct number; in this case `4`

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -14,8 +14,7 @@ In the following, we create a release candidate tag `v1.13.14-0.2.0.rc.4`.
     ```
 
     The `myusername/release/v1.13.14-0.2.0.rc.4` branch will be used to add "release modifications" and will target the branch `release/v1.13.14-0.2.0.rc.4` in a pull request.
-1. Run script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks)
-    - you may have to resolve conflicts
+1. Run the script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks). You may have to resolve conflicts.
 1. Modify [params/version.libevm.go](/params/version.libevm.go)
     - Change the `LibEVMVersion` to the correct final version name
     - Change the `LibEVMReleaseType` to the correct release type, for example `ReleaseCandidate`

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -4,7 +4,7 @@ In the following, we create a release candidate version `v1.13.14-0.2.0.rc.4` an
 
 ```bash
 VERSION=v1.13.14-0.2.0.rc.4
-USERNAME=myusername
+GH_USER=myusername
 ```
 
 1. Create two branches, usually from the tip of the `main` branch, but the base commit MAY be from anywhere on `main`:
@@ -14,10 +14,10 @@ USERNAME=myusername
     git checkout main
     git checkout -b "release/$VERSION"
     git push -u origin "release/$VERSION"
-    git checkout -b "$USERNAME/release/$VERSION"
+    git checkout -b "$GH_USER/release/$VERSION"
     ```
 
-    The `$USERNAME/release/$VERSION` branch will be used to add "release modifications" and will target the branch `release/$VERSION` in a pull request.
+    The `$GH_USER/release/$VERSION` branch will be used to add "release modifications" and will target the branch `release/$VERSION` in a pull request.
 1. Run the script `./cherrypick.sh` which cherry picks all Geth commits listed in [cherrypicks](cherrypicks). You may have to resolve conflicts. If you encounter a CI error NOT from the `go_test_tooling` job, ideally [amend](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) the cherry-picked commit(s) responsible for each issue.
 1. Modify [params/version.libevm.go](/params/version.libevm.go)
     - Change the `LibEVMReleaseType` to the correct release type, for example `ReleaseCandidate`
@@ -30,12 +30,12 @@ USERNAME=myusername
     git commit -m "chore: release $VERSION"
     ```
 
-1. Push your modified branch to the remote `git push -u origin $USERNAME/release/$VERSION`
-1. Open a pull request from your modified branch `$USERNAME/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`:
+1. Push your modified branch to the remote `git push -u origin $GH_USER/release/$VERSION`
+1. Open a pull request from your modified branch `$GH_USER/release/v1.13.14-0.2.0.rc.4` and targeting `release/v1.13.14-0.2.0.rc.4`:
     1. You can create the pull request for example using
 
         ```bash
-        open -a "Google Chrome" https://github.com/ava-labs/libevm/compare/release/$VERSION...$USERNAME/release/$VERSION
+        open -a "Google Chrome" https://github.com/ava-labs/libevm/compare/release/$VERSION...$GH_USER/release/$VERSION
         ```
 
     1. Set the title of the pull request to
@@ -49,7 +49,7 @@ USERNAME=myusername
 
     ```bash
     git checkout "release/$VERSION"
-    git merge --ff-only "$USERNAME/release/$VERSION"
+    git merge --ff-only "$GH_USER/release/$VERSION"
     git push
     ```
 
@@ -64,6 +64,6 @@ USERNAME=myusername
 1. (optional) you can then cleanup with:
 
     ```bash
-    git branch -D "release/$VERSION" "$USERNAME/release/$VERSION"
-    git push -d origin "$USERNAME/release/$VERSION"
+    git branch -D "release/$VERSION" "$GH_USER/release/$VERSION"
+    git push -d origin "$GH_USER/release/$VERSION"
     ```

--- a/libevm/tooling/release/README.md
+++ b/libevm/tooling/release/README.md
@@ -23,7 +23,7 @@ USERNAME=myusername
     - Change the `LibEVMReleaseType` to the correct release type, for example `ReleaseCandidate`
     - If planning a release candidate: set `libEVMReleaseCandidate` to the correct number; in this case `4`
     - If needed: change the `LibEVMVersionMajor`, `LibEVMVersionMinor` and `LibEVMVersionPatch` numbers
-    - Change the `LibEVMVersion` to the correct final version string `$VERSION` (`version.libevm_test.go` will ensure that this is correctly formatted)
+    - Change the `LibEVMVersion` to the correct final version string `$VERSION` (`version.libevm_test.go` will ensure that this is correctly formatted). See the [`LibEVMVersion` comment](https://pkg.go.dev/github.com/ava-labs/libevm/params#LibEVMVersion) for more details regarding its semantics.
 1. Commit your modifications to [params/version.libevm.go](/params/version.libevm.go) with a commit title `chore: release v1.13.14-0.2.0.rc.4`:
 
     ```bash


### PR DESCRIPTION
## Why this should be merged

The documentation was lacking on how to create a new release tag, using newer automation tools developed.

## How this works

Add readme.md in libevm/tooling/release and reference it in the root readme.md

## How this was tested

Following each step to create https://github.com/ava-labs/libevm/releases/tag/v1.13.14-0.2.0.rc.4 