### PR TITLE
chore: release-branch test logs `HEAD`

### DIFF
--- a/libevm/tooling/release/release_test.go
+++ b/libevm/tooling/release/release_test.go
@@ -182,6 +182,7 @@ func testReleaseBranch(t *testing.T, targetBranch string) {
 		require.NoErrorf(t, err, "%T.Head()", repo)
 
 		head := commitFromRef(t, repo, headRef)
+		t.Logf("HEAD is %v (%s)", head.Hash, commitMsgFirstLine(head))
 		main := commitFromBranchName(t, repo, defaultBranch)
 
 		closestCommonAncestors, err := head.MergeBase(main)


### PR DESCRIPTION
## Why this should be merged

Debugging release-branch test failures in CI but not locally.

## How this works

Logs `HEAD` before testing branch properties.

## How this was tested

NA