### PR TITLE
fix(ci): `go_tooling` CI job git checkout tip of PR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # everything  with:
+          fetch-depth: 0 # everything
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # everything
+          fetch-depth: 0 # everything  with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Why this should be merged

The release-branch CI job tests branch properties of the `git` DAG but GitHub's `actions/checkout` by default creates a speculative merge commit against which PR CI is run. Running against this hypothetical situation makes the tests fail.

## How this works

[`actions/checkout` uses PR tip](https://github.com/actions/checkout?tab=readme-ov-file#checkout-pull-request-head-commit-instead-of-merge-commit)

## How this was tested

Future run against a release branch.