### PR TITLE
Verify key length in range proofs

### DIFF
--- a/trie/proof.go
+++ b/trie/proof.go
@@ -487,6 +487,10 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 	}
 	// Ensure the received batch is monotonic increasing and contains no deletions
 	for i := 0; i < len(keys)-1; i++ {
+		// See: https://github.com/ava-labs/coreth/issues/907
+		if len(keys[i]) != len(keys[i+1]) {
+			return false, errors.New("keys do not have constant length")
+		}
 		if bytes.Compare(keys[i], keys[i+1]) >= 0 {
 			return false, errors.New("range is not monotonically increasing")
 		}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -489,7 +489,7 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 	for i := 0; i < len(keys)-1; i++ {
 		// See: https://github.com/ava-labs/coreth/issues/907
 		if len(keys[i]) != len(keys[i+1]) {
-			return false, errors.New("keys do not have constant length")
+			return false, errKeysHaveDifferentLengths
 		}
 		if bytes.Compare(keys[i], keys[i+1]) >= 0 {
 			return false, errors.New("range is not monotonically increasing")

--- a/trie/proof.libevm.go
+++ b/trie/proof.libevm.go
@@ -17,32 +17,7 @@
 package trie
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/ava-labs/libevm/common"
+	"errors"
 )
 
-func TestRangeProofKeysWithDifferentLengths(t *testing.T) {
-	var (
-		root  = common.HexToHash("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
-		start = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000000")
-		keys  = [][]byte{
-			common.Hex2Bytes("1000000000000000000000000000000"),
-			common.Hex2Bytes("1000000000000000000000000000000000000000000000000000000000000000"),
-		}
-		values = [][]byte{
-			common.Hex2Bytes("02"),
-			common.Hex2Bytes("03"),
-		}
-	)
-	_, err := VerifyRangeProof(
-		root,
-		start,
-		keys,
-		values,
-		nil, // force it to use stacktrie
-	)
-	require.ErrorIs(t, err, errKeysHaveDifferentLengths)
-}
+var errKeysHaveDifferentLengths = errors.New("keys have different lengths")

--- a/trie/proof.libevm_test.go
+++ b/trie/proof.libevm_test.go
@@ -1,0 +1,48 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+)
+
+func TestRangeProofKeysWithDifferentLengths(t *testing.T) {
+	var (
+		root  = common.HexToHash("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+		start = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000000")
+		keys  = [][]byte{
+			common.Hex2Bytes("1000000000000000000000000000000"),
+			common.Hex2Bytes("1000000000000000000000000000000000000000000000000000000000000000"),
+		}
+		values = [][]byte{
+			common.Hex2Bytes("02"),
+			common.Hex2Bytes("03"),
+		}
+	)
+	_, err := VerifyRangeProof(
+		root,
+		start,
+		keys,
+		values,
+		nil, // force it to use stacktrie
+	)
+	if err == nil {
+		t.Fatalf("unexpectedly verified invalid range proof: %v", err)
+	}
+}

--- a/trie/proof.libevm_test.go
+++ b/trie/proof.libevm_test.go
@@ -1,18 +1,18 @@
-// Copyright 2015 The go-ethereum Authors
-// This file is part of the go-ethereum library.
+// Copyright 2025 the libevm authors.
 //
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
 //
-// The go-ethereum library is distributed in the hope that it will be useful,
+// The libevm additions are distributed in the hope that they will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
 
 package trie
 


### PR DESCRIPTION
## Why this should be merged

This enforces an assumption that is currently made by `VerifyRangeProof`. If a key is a prefix of another key, the current code can panic.

## How this works

Enforces all keys have the same length.

## How this was tested

Added a unit test.