### PR TITLE
refactor(core/vm): expose clearing of registered hooks in tests

### DIFF
--- a/core/vm/evm.libevm_test.go
+++ b/core/vm/evm.libevm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 the libevm authors.
+// Copyright 2024-2025 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License
@@ -48,11 +48,9 @@ func (o *evmArgOverrider) OverrideEVMResetArgs(r params.Rules, _ *EVMResetArgs) 
 
 func (o *evmArgOverrider) register(t *testing.T) {
 	t.Helper()
-	libevmHooks = nil
+	TestOnlyClearRegisteredHooks()
 	RegisterHooks(o)
-	t.Cleanup(func() {
-		libevmHooks = nil
-	})
+	t.Cleanup(TestOnlyClearRegisteredHooks)
 }
 
 func TestOverrideNewEVMArgs(t *testing.T) {

--- a/core/vm/hooks.libevm.go
+++ b/core/vm/hooks.libevm.go
@@ -1,4 +1,4 @@
-// Copyright 2024 the libevm authors.
+// Copyright 2024-2025 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License
@@ -16,18 +16,24 @@
 
 package vm
 
-import "github.com/ava-labs/libevm/params"
+import (
+	"github.com/ava-labs/libevm/libevm/register"
+	"github.com/ava-labs/libevm/params"
+)
 
 // RegisterHooks registers the Hooks. It is expected to be called in an `init()`
 // function and MUST NOT be called more than once.
 func RegisterHooks(h Hooks) {
-	if libevmHooks != nil {
-		panic("already registered")
-	}
-	libevmHooks = h
+	libevmHooks.MustRegister(h)
 }
 
-var libevmHooks Hooks
+// TestOnlyClearRegisteredHooks clears the [Hooks] previously passed to
+// [RegisterHooks]. It panics if called from a non-testing call stack.
+func TestOnlyClearRegisteredHooks() {
+	libevmHooks.TestOnlyClear()
+}
+
+var libevmHooks register.AtMostOnce[Hooks]
 
 // Hooks are arbitrary configuration functions to modify default VM behaviour.
 // See [RegisterHooks].
@@ -60,17 +66,17 @@ func overrideNewEVMArgs(
 	chainConfig *params.ChainConfig,
 	config Config,
 ) (BlockContext, TxContext, StateDB, *params.ChainConfig, Config) {
-	if libevmHooks == nil {
+	if !libevmHooks.Registered() {
 		return blockCtx, txCtx, statedb, chainConfig, config
 	}
-	args := libevmHooks.OverrideNewEVMArgs(&NewEVMArgs{blockCtx, txCtx, statedb, chainConfig, config})
+	args := libevmHooks.Get().OverrideNewEVMArgs(&NewEVMArgs{blockCtx, txCtx, statedb, chainConfig, config})
 	return args.BlockContext, args.TxContext, args.StateDB, args.ChainConfig, args.Config
 }
 
 func (evm *EVM) overrideEVMResetArgs(txCtx TxContext, statedb StateDB) (TxContext, StateDB) {
-	if libevmHooks == nil {
+	if !libevmHooks.Registered() {
 		return txCtx, statedb
 	}
-	args := libevmHooks.OverrideEVMResetArgs(evm.chainRules, &EVMResetArgs{txCtx, statedb})
+	args := libevmHooks.Get().OverrideEVMResetArgs(evm.chainRules, &EVMResetArgs{txCtx, statedb})
 	return args.TxContext, args.StateDB
 }


### PR DESCRIPTION
## Why this should be merged

Importing some `avalanchego` test fixtures automatically imports `coreth` packages that register extras, which affects testing of other VMs that depend on `libevm`. All other registered extras can be cleared with the pattern in this PR.

## How this works

Uses the `register.AtMostOnce` type already used in `params` and `types`. I forgot to update the `vm` package when implementing the type.

## How this was tested

Existing unit tests.