### PR TITLE
feat(triedb): expose backend for custom use

### DIFF
--- a/triedb/database.go
+++ b/triedb/database.go
@@ -47,9 +47,9 @@ var HashDefaults = &Config{
 	HashDB:    hashdb.Defaults,
 }
 
-// Backend defines the methods needed to access/update trie nodes in different
-// state schemes.
-type Backend interface {
+// backend defines the methods needed to access/update trie nodes in different
+// state scheme.
+type backend interface {
 	// Scheme returns the identifier of used storage scheme.
 	Scheme() string
 
@@ -87,7 +87,7 @@ type Database struct {
 	config    *Config        // Configuration for trie database
 	diskdb    ethdb.Database // Persistent database to store the snapshot
 	preimages *preimageStore // The store for caching preimages
-	backend   Backend        // The backend for managing trie nodes
+	backend   backend        // The backend for managing trie nodes
 }
 
 // NewDatabase initializes the trie database with default settings, note
@@ -342,10 +342,4 @@ func (db *Database) SetBufferSize(size int) error {
 // IsVerkle returns the indicator if the database is holding a verkle tree.
 func (db *Database) IsVerkle() bool {
 	return db.config.IsVerkle
-}
-
-// Backend returns the underlying backend of the trie database, which
-// implements the methods for accessing additional custom methods.
-func (db *Database) Backend() Backend {
-	return db.backend
 }

--- a/triedb/database.go
+++ b/triedb/database.go
@@ -47,9 +47,9 @@ var HashDefaults = &Config{
 	HashDB:    hashdb.Defaults,
 }
 
-// backend defines the methods needed to access/update trie nodes in different
-// state scheme.
-type backend interface {
+// Backend defines the methods needed to access/update trie nodes in different
+// state schemes.
+type Backend interface {
 	// Scheme returns the identifier of used storage scheme.
 	Scheme() string
 
@@ -87,7 +87,7 @@ type Database struct {
 	config    *Config        // Configuration for trie database
 	diskdb    ethdb.Database // Persistent database to store the snapshot
 	preimages *preimageStore // The store for caching preimages
-	backend   backend        // The backend for managing trie nodes
+	backend   Backend        // The backend for managing trie nodes
 }
 
 // NewDatabase initializes the trie database with default settings, note
@@ -342,4 +342,10 @@ func (db *Database) SetBufferSize(size int) error {
 // IsVerkle returns the indicator if the database is holding a verkle tree.
 func (db *Database) IsVerkle() bool {
 	return db.config.IsVerkle
+}
+
+// Backend returns the underlying backend of the trie database, which
+// implements the methods for accessing additional custom methods.
+func (db *Database) Backend() Backend {
+	return db.backend
 }

--- a/triedb/database.libevm.go
+++ b/triedb/database.libevm.go
@@ -29,7 +29,7 @@ import (
 // BackendDB defines the intersection of methods shared by [hashdb.Database] and
 // [pathdb.Database]. It is defined to export an otherwise internal type used by
 // the non-libevm geth implementation.
-type BackendDB Backend
+type BackendDB backend
 
 // A ReaderProvider exposes its underlying Reader as an interface. Both
 // [hashdb.Database] and [pathdb.Database] return concrete types so Go's lack of
@@ -49,6 +49,11 @@ type DBConstructor func(ethdb.Database) DBOverride
 type DBOverride interface {
 	BackendDB
 	ReaderProvider
+}
+
+// Backend returns the underlying backend of the trie database.
+func (db *Database) Backend() BackendDB {
+	return db.backend
 }
 
 func (db *Database) overrideBackend(diskdb ethdb.Database, config *Config) bool {

--- a/triedb/database.libevm.go
+++ b/triedb/database.libevm.go
@@ -29,7 +29,7 @@ import (
 // BackendDB defines the intersection of methods shared by [hashdb.Database] and
 // [pathdb.Database]. It is defined to export an otherwise internal type used by
 // the non-libevm geth implementation.
-type BackendDB backend
+type BackendDB Backend
 
 // A ReaderProvider exposes its underlying Reader as an interface. Both
 // [hashdb.Database] and [pathdb.Database] return concrete types so Go's lack of


### PR DESCRIPTION
## Why this should be merged

To override the standard trie behavior for custom databases in `core/state/database.go`, custom methods may need to be defined on the backend database.

## How this works

Exposes `backend` interface for the API

## How this was tested

No tests necessary - isn't used in `libevm`.
