### PR TITLE
chore: fix linter issues that CI missed

### DIFF
--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -65,11 +65,11 @@ func TestMinimumGasConsumption(t *testing.T) {
 	// All transactions will be basic transfers so consume [params.TxGas] by
 	// default.
 	tests := []struct {
-		name             string
-		gasLimit uint64
-		refund   uint64
-		minConsumption   uint64
-		wantUsed         uint64
+		name           string
+		gasLimit       uint64
+		refund         uint64
+		minConsumption uint64
+		wantUsed       uint64
 	}{
 		{
 			name:           "consume_extra",


### PR DESCRIPTION
## Why this should be merged

#185 was allowed to merge despite CI requiring the `lint` job.

## How this works

Fix linter issues.

## How this was tested

The first commit is an empty commit, expected to fail CI, to confirm that the job is in fact required.