### PR TITLE
chore: bump libevm minor version to `0.3.0`

### DIFF
--- a/params/version.libevm.go
+++ b/params/version.libevm.go
@@ -18,11 +18,11 @@ package params
 
 const (
 	LibEVMVersionMajor = 0
-	LibEVMVersionMinor = 2
+	LibEVMVersionMinor = 3
 	LibEVMVersionPatch = 0
 
 	LibEVMReleaseType      ReleaseType = BetaRelease
-	libEVMReleaseCandidate uint        = 3 // ignored unless [LibEVMReleaseType] == [ReleaseCandidate]
+	libEVMReleaseCandidate uint        = 0 // ignored unless [LibEVMReleaseType] == [ReleaseCandidate]
 )
 
 // LibEVMVersion holds the textual version string of `libevm` modifications.
@@ -48,7 +48,7 @@ const (
 // triplet.
 //
 // [semver v2]: https://semver.org/
-const LibEVMVersion = "1.13.14-0.2.0.beta"
+const LibEVMVersion = "1.13.14-0.3.0.beta"
 
 // A ReleaseType is a suffix for [LibEVMVersion].
 type ReleaseType string


### PR DESCRIPTION
## Why this should be merged

Addition of recent, functionality constitutes a bump to the minor version. Doing this on `main` first for consistency and will cut a release candidate after.

## How this works

Magic

## How this was tested

Super magic
