### PR TITLE
chore: v1.13.14-0.3.0.rc.1

### DIFF
--- a/params/version.libevm.go
+++ b/params/version.libevm.go
@@ -21,8 +21,8 @@ const (
 	LibEVMVersionMinor = 3
 	LibEVMVersionPatch = 0
 
-	LibEVMReleaseType      ReleaseType = BetaRelease
-	libEVMReleaseCandidate uint        = 0 // ignored unless [LibEVMReleaseType] == [ReleaseCandidate]
+	LibEVMReleaseType      ReleaseType = ReleaseCandidate
+	libEVMReleaseCandidate uint        = 1 // ignored unless [LibEVMReleaseType] == [ReleaseCandidate]
 )
 
 // LibEVMVersion holds the textual version string of `libevm` modifications.
@@ -48,7 +48,7 @@ const (
 // triplet.
 //
 // [semver v2]: https://semver.org/
-const LibEVMVersion = "1.13.14-0.3.0.beta"
+const LibEVMVersion = "1.13.14-0.3.0.rc.1"
 
 // A ReleaseType is a suffix for [LibEVMVersion].
 type ReleaseType string


### PR DESCRIPTION
## Why this should be merged

Release `v1.13.14-0.3.0.rc.1`

## How this works

Change release type.

## How this was tested

N/A