### PR TITLE
chore: stochastic gradient descent to fix `goheader`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for go-header check https://github.com/golangci/golangci-lint/issues/2470#issuecomment-1473658471
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
## Why this should be merged

Avoids false positives from `goheader`.

## How this works

Checks out entire history to give the linter a reference point for new issues only.

## How this was tested

With great frustration by waiting for CI.