### PR TITLE
Add `*StateDB.TxHash` for usage with Warp

### DIFF
--- a/core/state/statedb.libevm.go
+++ b/core/state/statedb.libevm.go
@@ -24,8 +24,8 @@ import (
 	"github.com/ava-labs/libevm/libevm/stateconf"
 )
 
-// GetTxHash returns the current tx hash on the StateDB set by SetTxContext.
-func (s *StateDB) GetTxHash() common.Hash {
+// TxHash returns the current transaction hash set by SetTxContext.
+func (s *StateDB) TxHash() common.Hash {
 	return s.thash
 }
 

--- a/core/state/statedb.libevm.go
+++ b/core/state/statedb.libevm.go
@@ -24,6 +24,11 @@ import (
 	"github.com/ava-labs/libevm/libevm/stateconf"
 )
 
+// GetTxHash returns the current tx hash on the StateDB set by SetTxContext.
+func (s *StateDB) GetTxHash() common.Hash {
+	return s.thash
+}
+
 // SnapshotTree mirrors the functionality of a [snapshot.Tree], allowing for
 // drop-in replacements. This is intended as a temporary feature as a workaround
 // until a standard Tree can be used.

--- a/core/state/statedb.libevm.go
+++ b/core/state/statedb.libevm.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ava-labs/libevm/libevm/stateconf"
 )
 
-// TxHash returns the current transaction hash set by SetTxContext.
+// TxHash returns the current transaction hash set by [StateDB.SetTxContext].
 func (s *StateDB) TxHash() common.Hash {
 	return s.thash
 }

--- a/core/state/statedb.libevm_test.go
+++ b/core/state/statedb.libevm_test.go
@@ -36,6 +36,18 @@ import (
 	"github.com/ava-labs/libevm/triedb/hashdb"
 )
 
+func TestGetTxHash(t *testing.T) {
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	state, err := New(types.EmptyRootHash, db, nil)
+	require.NoError(t, err)
+
+	assert.Zero(t, state.GetTxHash(), "Tx hash should initially be uninitialized")
+
+	hash := common.Hash{1}
+	state.SetTxContext(hash, 3)
+	assert.Equal(t, hash, state.GetTxHash(), "Tx hash should have been updated")
+}
+
 func TestStateDBCommitPropagatesOptions(t *testing.T) {
 	memdb := rawdb.NewMemoryDatabase()
 	trieRec := &triedbRecorder{Database: hashdb.New(memdb, nil, &trie.MerkleResolver{})}

--- a/core/state/statedb.libevm_test.go
+++ b/core/state/statedb.libevm_test.go
@@ -36,16 +36,16 @@ import (
 	"github.com/ava-labs/libevm/triedb/hashdb"
 )
 
-func TestGetTxHash(t *testing.T) {
+func TestTxHash(t *testing.T) {
 	db := NewDatabase(rawdb.NewMemoryDatabase())
 	state, err := New(types.EmptyRootHash, db, nil)
 	require.NoError(t, err)
 
-	assert.Zero(t, state.GetTxHash(), "Tx hash should initially be uninitialized")
+	assert.Zero(t, state.TxHash(), "Tx hash should initially be uninitialized")
 
 	hash := common.Hash{1}
 	state.SetTxContext(hash, 3)
-	assert.Equal(t, hash, state.GetTxHash(), "Tx hash should have been updated")
+	assert.Equal(t, hash, state.TxHash(), "Tx hash should have been updated")
 }
 
 func TestStateDBCommitPropagatesOptions(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

Coreth and Subnet-EVM require access to the current tx hash in the Warp precompile (for selecting the correct predicate results).

This can not be exposed as a wrapper through the `OverrideEVMResetArgs` because `SetTxContext` is called _prior_ to resetting the EVM instance. Therefore, the `SetTxContext` function on any DB wrapper would never be called.

## How this works

Exposes the existing `txHash` through a `GetTxHash()` function.

## How this was tested

Added a trivial unit test.