### PR TITLE
feat: state-key transformation w/ override

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ava-labs/libevm/core/state/snapshot"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
-	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/metrics"
 	"github.com/ava-labs/libevm/params"
@@ -36,6 +35,9 @@ import (
 	"github.com/ava-labs/libevm/trie/trienode"
 	"github.com/ava-labs/libevm/trie/triestate"
 	"github.com/holiman/uint256"
+
+	// libevm extra imports
+	"github.com/ava-labs/libevm/libevm/stateconf"
 )
 
 const (

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -341,18 +341,20 @@ func (s *StateDB) GetCodeHash(addr common.Address) common.Hash {
 }
 
 // GetState retrieves a value from the given account's storage trie.
-func (s *StateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
+func (s *StateDB) GetState(addr common.Address, hash common.Hash, opts ...stateconf.StateDBStateOption) common.Hash {
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
+		hash = transformStateKey(addr, hash, opts...)
 		return stateObject.GetState(hash)
 	}
 	return common.Hash{}
 }
 
 // GetCommittedState retrieves a value from the given account's committed storage trie.
-func (s *StateDB) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+func (s *StateDB) GetCommittedState(addr common.Address, hash common.Hash, opts ...stateconf.StateDBStateOption) common.Hash {
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
+		hash = transformStateKey(addr, hash, opts...)
 		return stateObject.GetCommittedState(hash)
 	}
 	return common.Hash{}
@@ -412,9 +414,10 @@ func (s *StateDB) SetCode(addr common.Address, code []byte) {
 	}
 }
 
-func (s *StateDB) SetState(addr common.Address, key, value common.Hash) {
+func (s *StateDB) SetState(addr common.Address, key, value common.Hash, opts ...stateconf.StateDBStateOption) {
 	stateObject := s.getOrNewStateObject(addr)
 	if stateObject != nil {
+		key = transformStateKey(addr, key, opts...)
 		stateObject.SetState(key, value)
 	}
 }

--- a/core/state/statedb.libevm_test.go
+++ b/core/state/statedb.libevm_test.go
@@ -126,3 +126,54 @@ func (r *triedbRecorder) Update(
 func (r *triedbRecorder) Reader(_ common.Hash) (database.Reader, error) {
 	return r.Database.Reader(common.Hash{})
 }
+
+type highByteFlipper struct{}
+
+func flipHighByte(h common.Hash) common.Hash {
+	h[0] = ^h[0]
+	return h
+}
+
+func (highByteFlipper) TransformStateKey(_ common.Address, key common.Hash) common.Hash {
+	return flipHighByte(key)
+}
+
+func TestTransformStateKey(t *testing.T) {
+	cache := NewDatabase(rawdb.NewMemoryDatabase())
+	sdb, err := New(types.EmptyRootHash, cache, nil)
+	require.NoErrorf(t, err, "New()")
+
+	addr := common.Address{1}
+	regularKey := common.Hash{0, 'k', 'e', 'y'}
+	flippedKey := flipHighByte(regularKey)
+	regularVal := common.Hash{'r', 'e', 'g', 'u', 'l', 'a', 'r'}
+	flippedVal := common.Hash{'f', 'l', 'i', 'p', 'p', 'e', 'd'}
+
+	sdb.SetState(addr, regularKey, regularVal)
+	sdb.SetState(addr, flippedKey, flippedVal)
+
+	assertEq := func(t *testing.T, key, want common.Hash, opts ...stateconf.StateDBStateOption) {
+		t.Helper()
+		assert.Equal(t, want, sdb.GetState(addr, key, opts...))
+	}
+
+	assertEq(t, regularKey, regularVal)
+	assertEq(t, flippedKey, flippedVal)
+
+	// Typically the hook would be registered before any state access or
+	// setting, but doing it here aids testing by showing the before-and-after
+	// effects.
+	RegisterExtras(highByteFlipper{})
+	t.Cleanup(TestOnlyClearRegisteredExtras)
+
+	noTransform := stateconf.SkipStateKeyTransformation()
+	assertEq(t, regularKey, flippedVal)
+	assertEq(t, regularKey, regularVal, noTransform)
+	assertEq(t, flippedKey, regularVal)
+	assertEq(t, flippedKey, flippedVal, noTransform)
+
+	updatedVal := common.Hash{'u', 'p', 'd', 'a', 't', 'e', 'd'}
+	sdb.SetState(addr, regularKey, updatedVal)
+	assertEq(t, regularKey, updatedVal)
+	assertEq(t, flippedKey, updatedVal, noTransform)
+}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -21,9 +21,11 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
-	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
+
+	// libevm extra imports
+	"github.com/ava-labs/libevm/libevm/stateconf"
 )
 
 // StateDB is an EVM database for full state querying.

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 )
@@ -45,9 +46,9 @@ type StateDB interface {
 	SubRefund(uint64)
 	GetRefund() uint64
 
-	GetCommittedState(common.Address, common.Hash) common.Hash
-	GetState(common.Address, common.Hash) common.Hash
-	SetState(common.Address, common.Hash, common.Hash)
+	GetCommittedState(common.Address, common.Hash, ...stateconf.StateDBStateOption) common.Hash
+	GetState(common.Address, common.Hash, ...stateconf.StateDBStateOption) common.Hash
+	SetState(common.Address, common.Hash, common.Hash, ...stateconf.StateDBStateOption)
 
 	GetTransientState(addr common.Address, key common.Hash) common.Hash
 	SetTransientState(addr common.Address, key, value common.Hash)

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -25,9 +25,11 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/vm"
-	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
+
+	// libevm extra imports
+	"github.com/ava-labs/libevm/libevm/stateconf"
 )
 
 type dummyContractRef struct {

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/vm"
+	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 )
@@ -49,9 +50,12 @@ type dummyStatedb struct {
 	state.StateDB
 }
 
-func (*dummyStatedb) GetRefund() uint64                                       { return 1337 }
-func (*dummyStatedb) GetState(_ common.Address, _ common.Hash) common.Hash    { return common.Hash{} }
-func (*dummyStatedb) SetState(_ common.Address, _ common.Hash, _ common.Hash) {}
+func (*dummyStatedb) GetRefund() uint64 { return 1337 }
+func (*dummyStatedb) GetState(_ common.Address, _ common.Hash, _ ...stateconf.StateDBStateOption) common.Hash {
+	return common.Hash{}
+}
+func (*dummyStatedb) SetState(_ common.Address, _ common.Hash, _ common.Hash, _ ...stateconf.StateDBStateOption) {
+}
 
 func TestStoreCapture(t *testing.T) {
 	var (

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -20,6 +20,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/libevm/stateconf"
 )
 
 // PrecompiledContract is an exact copy of vm.PrecompiledContract, mirrored here
@@ -43,8 +44,8 @@ type StateReader interface {
 
 	GetRefund() uint64
 
-	GetCommittedState(common.Address, common.Hash) common.Hash
-	GetState(common.Address, common.Hash) common.Hash
+	GetCommittedState(common.Address, common.Hash, ...stateconf.StateDBStateOption) common.Hash
+	GetState(common.Address, common.Hash, ...stateconf.StateDBStateOption) common.Hash
 
 	GetTransientState(addr common.Address, key common.Hash) common.Hash
 

--- a/libevm/stateconf/conf.go
+++ b/libevm/stateconf/conf.go
@@ -113,3 +113,19 @@ func ExtractTrieDBUpdatePayload(opts ...TrieDBUpdateOption) (common.Hash, common
 	}
 	return *conf.parentBlockHash, *conf.currentBlockHash, true
 }
+
+type StateDBStateOption = options.Option[stateDBStateConfig]
+
+type stateDBStateConfig struct {
+	skipKeyTransformation bool
+}
+
+func SkipStateKeyTransformation() StateDBStateOption {
+	return options.Func[stateDBStateConfig](func(c *stateDBStateConfig) {
+		c.skipKeyTransformation = true
+	})
+}
+
+func ShouldTransformStateKey(opts ...StateDBStateOption) bool {
+	return !options.As(opts...).skipKeyTransformation
+}

--- a/libevm/stateconf/conf.go
+++ b/libevm/stateconf/conf.go
@@ -114,18 +114,26 @@ func ExtractTrieDBUpdatePayload(opts ...TrieDBUpdateOption) (common.Hash, common
 	return *conf.parentBlockHash, *conf.currentBlockHash, true
 }
 
+// A StateDBStateOption configures the behaviour of state.StateDB methods for
+// getting and setting state: GetState(), GetCommittedState(), and SetState().
 type StateDBStateOption = options.Option[stateDBStateConfig]
 
 type stateDBStateConfig struct {
 	skipKeyTransformation bool
 }
 
+// SkipStateKeyTransformation causes any registered state-key transformation
+// hook to be ignored. See state.RegisterExtras() for details.
 func SkipStateKeyTransformation() StateDBStateOption {
 	return options.Func[stateDBStateConfig](func(c *stateDBStateConfig) {
 		c.skipKeyTransformation = true
 	})
 }
 
+// ShouldTransformStateKey parses the options, returning whether or not any
+// registered state-key transformation hook should be used; i.e. it returns
+// `true` i.f.f. there are no [SkipStateKeyTransformation] options in the
+// arguments.
 func ShouldTransformStateKey(opts ...StateDBStateOption) bool {
 	return !options.As(opts...).skipKeyTransformation
 }


### PR DESCRIPTION
## Why this should be merged

`ava-labs/coreth` has a partitioned state-address space, achieved by setting or clearing a specific bit in the hash used to key the space. This change allows such behaviour to be achieved with pure `libevm` instead of the `StateDB` wrapping that `coreth` currently uses.

## How this works

Introduction of `state.StateDBHooks` interface, including a `TransformStateKey()` method that allows for arbitrary change of state key. If registered, this hook will be honoured by `StateDB.{Get,GetCommitted,State}Key()` methods unless they receive a `stateconf.SkipStateKeyTransformation` option.

## How this was tested

Unit test of `SetState() -> GetState() + GetCommittedState()` round trip with and without options to skip.