### PR TITLE
feat: enable invalidating txs

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -364,10 +364,7 @@ func (st *StateTransition) preCheck() error {
 //
 // However if any consensus issue encountered, return the error directly with
 // nil evm execution result.
-func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
-	if err := st.canExecuteTransaction(); err != nil {
-		return nil, err
-	}
+func (st *StateTransition) transitionDb() (*ExecutionResult, error) {
 	// First check this message satisfies all consensus rules before
 	// applying the message. The rules include these clauses
 	//

--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -187,6 +187,9 @@ type PrecompileEnvironment interface {
 	BlockNumber() *big.Int
 	BlockTime() uint64
 
+	// Invalidate invalidates the transaction calling this precompile.
+	InvalidateExecution(error)
+
 	// Call is equivalent to [EVM.Call] except that the `caller` argument is
 	// removed and automatically determined according to the type of call that
 	// invoked the precompile.

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -49,6 +49,8 @@ func (e *environment) IncomingCallType() CallType        { return e.callType }
 func (e *environment) BlockNumber() *big.Int             { return new(big.Int).Set(e.evm.Context.BlockNumber) }
 func (e *environment) BlockTime() uint64                 { return e.evm.Context.Time }
 
+func (e *environment) InvalidateExecution(err error) { e.evm.InvalidateExecution(err) }
+
 func (e *environment) refundGas(add uint64) error {
 	gas, overflow := math.SafeAdd(e.self.Gas, add)
 	if overflow {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -128,6 +128,9 @@ type EVM struct {
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
 	callGasTemp uint64
+
+	// libevm
+	executionInvalidated error // see [EVM.InvalidateExecution]
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
@@ -160,6 +163,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 // Reset resets the EVM with a new transaction context.Reset
 // This is not threadsafe and should only be done very cautiously.
 func (evm *EVM) Reset(txCtx TxContext, statedb StateDB) {
+	evm.executionInvalidated = nil // see [EVM.InvalidateExecution]
 	evm.TxContext, evm.StateDB = evm.overrideEVMResetArgs(txCtx, statedb)
 }
 

--- a/core/vm/evm.libevm.go
+++ b/core/vm/evm.libevm.go
@@ -43,3 +43,21 @@ func (evm *EVM) canCreateContract(caller ContractRef, contractToCreate common.Ad
 
 	return gas, err
 }
+
+// InvalidateExecution sets the error that will be returned by
+// [EVM.ExecutionInvalidated] for the length of the current transaction; i.e.
+// until [EVM.Reset] is called. This is honoured by state-transition logic to
+// render the execution itself void (as against reverted).
+//
+// This method MUST NOT be exposed in a manner that allows contracts to set
+// the error; it MAY be exposed to precompiles.
+func (evm *EVM) InvalidateExecution(err error) {
+	evm.executionInvalidated = err
+}
+
+// ExecutionInvalidated returns the last value passed to
+// [EVM.InvalidateExecution] or nil if no such call has occurred or if
+// [EVM.Reset] has been called.
+func (evm *EVM) ExecutionInvalidated() error {
+	return evm.executionInvalidated
+}


### PR DESCRIPTION
## Why this should be merged

In case a tx's execution (specifically a registered precompile) should be invalidated, this allows the EVM to find this error.

## How this works

Adds a setter and getter that can be called from a precompile.

## How this was tested

UT
