### PR TITLE
feat!: disambiguate EVM-semantic and raw caller/self addresses for precompiles

### DIFF
--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -223,9 +223,11 @@ func (args *evmCallArgs) env() *environment {
 	}
 
 	return &environment{
-		evm:      args.evm,
-		self:     contract,
-		callType: args.callType,
+		evm:       args.evm,
+		self:      contract,
+		callType:  args.callType,
+		rawCaller: args.caller.Address(),
+		rawSelf:   args.addr,
 	}
 }
 

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -217,9 +217,9 @@ func TestNewStatefulPrecompile(t *testing.T) {
 	state.SetBalance(caller, new(uint256.Int).Not(uint256.NewInt(0)))
 	evm.Origin = eoa
 
-	// By definition, the raw caller and self are the same, regardless of the
-	// incoming call type.
-	rawAddresses := &libevm.CallerAndSelf{
+	// By definition, the raw caller and self are the same for every test case,
+	// regardless of the incoming call type.
+	rawAddresses := libevm.CallerAndSelf{
 		Caller: caller,
 		Self:   precompile,
 	}
@@ -240,12 +240,9 @@ func TestNewStatefulPrecompile(t *testing.T) {
 				return evm.Call(callerContract, precompile, input, gasLimit, transferValue)
 			},
 			wantAddresses: &libevm.AddressContext{
-				Origin: eoa,
-				EVMSemantic: libevm.CallerAndSelf{
-					Caller: caller,
-					Self:   precompile,
-				},
-				Raw: rawAddresses,
+				Origin:      eoa,
+				EVMSemantic: rawAddresses,
+				Raw:         &rawAddresses,
 			},
 			wantReadOnly:      false,
 			wantTransferValue: transferValue,
@@ -262,7 +259,7 @@ func TestNewStatefulPrecompile(t *testing.T) {
 					Caller: caller,
 					Self:   caller,
 				},
-				Raw: rawAddresses,
+				Raw: &rawAddresses,
 			},
 			wantReadOnly:      false,
 			wantTransferValue: transferValue,
@@ -279,7 +276,7 @@ func TestNewStatefulPrecompile(t *testing.T) {
 					Caller: eoa, // inherited from caller
 					Self:   caller,
 				},
-				Raw: rawAddresses,
+				Raw: &rawAddresses,
 			},
 			wantReadOnly:      false,
 			wantTransferValue: uint256.NewInt(0),
@@ -291,12 +288,9 @@ func TestNewStatefulPrecompile(t *testing.T) {
 				return evm.StaticCall(callerContract, precompile, input, gasLimit)
 			},
 			wantAddresses: &libevm.AddressContext{
-				Origin: eoa,
-				EVMSemantic: libevm.CallerAndSelf{
-					Caller: caller,
-					Self:   precompile,
-				},
-				Raw: rawAddresses,
+				Origin:      eoa,
+				EVMSemantic: rawAddresses,
+				Raw:         &rawAddresses,
 			},
 			wantReadOnly:      true,
 			wantTransferValue: uint256.NewInt(0),
@@ -824,7 +818,7 @@ func TestPrecompileMakeCall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.incomingCallType.String(), func(t *testing.T) {
-			// From the perspective of `dest` after a CALL.
+			// From the perspective of `dest` after a CALL from `sut`.
 			tt.want.Addresses.Raw = &tt.want.Addresses.EVMSemantic
 
 			t.Logf("calldata = %q", tt.eoaTxCallData)

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -36,6 +36,8 @@ type environment struct {
 	evm      *EVM
 	self     *Contract
 	callType CallType
+
+	rawSelf, rawCaller common.Address
 }
 
 func (e *environment) Gas() uint64            { return e.self.Gas }
@@ -82,6 +84,10 @@ func (e *environment) Addresses() *libevm.AddressContext {
 		EVMSemantic: libevm.CallerAndSelf{
 			Caller: e.self.CallerAddress,
 			Self:   e.self.Address(),
+		},
+		Raw: &libevm.CallerAndSelf{
+			Caller: e.rawCaller,
+			Self:   e.rawSelf,
 		},
 	}
 }

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -79,8 +79,10 @@ func (e *environment) ReadOnly() bool {
 func (e *environment) Addresses() *libevm.AddressContext {
 	return &libevm.AddressContext{
 		Origin: e.evm.Origin,
-		Caller: e.self.CallerAddress,
-		Self:   e.self.Address(),
+		EVMSemantic: libevm.CallerAndSelf{
+			Caller: e.self.CallerAddress,
+			Self:   e.self.Address(),
+		},
 	}
 }
 

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -61,14 +61,29 @@ type StateReader interface {
 // AddressContext carries addresses available to contexts such as calls and
 // contract creation.
 //
-// With respect to contract creation, the Self address MAY be the predicted
-// address of the contract about to be deployed, which may not exist yet.
+// With respect to contract creation, the EVMSemantic.Self address MAY be the
+// predicted address of the contract about to be deployed, which might not exist
+// yet.
 type AddressContext struct {
-	Origin      common.Address // always equivalent to vm.ORIGIN op code
+	Origin common.Address // equivalent to vm.ORIGIN op code
+	// EVMSemantic addresses are those defined by the rules of the EVM, based on
+	// the type of call made to a contract; i.e. the addresses pushed to the
+	// stack by the vm.CALLER and vm.SELF op codes, respectively.
 	EVMSemantic CallerAndSelf
-	Raw         *CallerAndSelf
+	// Raw addresses are those that would be available to a contract under a
+	// standard CALL; i.e. not interpreted according EVM rules. They are the
+	// "intuitive" addresses such that the `Caller` is the account that called
+	// `Self` even if it did so via DELEGATECALL or CALLCODE (in which cases
+	// `Raw` and `EVMSemantic` would differ).
+	//
+	// Raw MUST NOT be nil when returned to a precompile implementation but MAY
+	// be nil in other situations (e.g. hooks), which MUST document behaviour on
+	// a case-by-case basis.
+	Raw *CallerAndSelf
 }
 
+// CallerAndSelf carries said addresses for use in an [AddressContext], where
+// the definitions of `Caller` and `Self` are defined based on context.
 type CallerAndSelf struct {
 	Caller common.Address
 	Self   common.Address

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -64,7 +64,12 @@ type StateReader interface {
 // With respect to contract creation, the Self address MAY be the predicted
 // address of the contract about to be deployed, which may not exist yet.
 type AddressContext struct {
-	Origin common.Address // equivalent to vm.ORIGIN op code
-	Caller common.Address // equivalent to vm.CALLER op code
-	Self   common.Address // equivalent to vm.ADDRESS op code
+	Origin      common.Address // always equivalent to vm.ORIGIN op code
+	EVMSemantic CallerAndSelf
+	Raw         *CallerAndSelf
+}
+
+type CallerAndSelf struct {
+	Caller common.Address
+	Self   common.Address
 }

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -67,7 +67,8 @@ type RulesHooks interface {
 // by returning a nil (allowed) or non-nil (blocked) error.
 type RulesAllowlistHooks interface {
 	// CanCreateContract is called after the deployer's nonce is incremented but
-	// before all other state-modifying actions.
+	// before all other state-modifying actions. The [libevm.AddressContext.Raw]
+	// field will always be nil.
 	CanCreateContract(_ *libevm.AddressContext, gas uint64, _ libevm.StateReader) (gasRemaining uint64, _ error)
 	CanExecuteTransaction(from common.Address, to *common.Address, _ libevm.StateReader) error
 }


### PR DESCRIPTION
## Why this should be merged

Provides precompiles with unambiguous access to contextual addresses, without the consumer needing to understand how they change under different call types.

## How this works

The `libevm.AddressContext` type, which used to carry 3 addresses, now provides different versions of `Caller` and `Self`. The EVM-semantic versions are as defined by the rules of the EVM (and available before this change). The raw versions are the unmodified caller and self.

## How this was tested

Extension of existing UTs to include raw addresses in addition to existing, EVM-semantic ones.