### PR TITLE
feat(rawdb): skip freezers

### DIFF
--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/options"
 )
 
 type tableSize struct {
@@ -77,7 +78,10 @@ func inspect(name string, order map[string]bool, reader ethdb.AncientReader) (fr
 }
 
 // inspectFreezers inspects all freezers registered in the system.
-func inspectFreezers(db ethdb.Database) ([]freezerInfo, error) {
+func inspectFreezers(db ethdb.Database, opts ...InspectDatabaseOption) ([]freezerInfo, error) {
+	if options.As[inspectDatabaseConfig](opts...).skipFreezers {
+		return nil, nil
+	}
 	var infos []freezerInfo
 	for _, freezer := range freezers {
 		switch freezer {

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -604,13 +604,9 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte, opts ...Insp
 		{"Light client", "Bloom trie nodes", bloomTrieNodes.Size(), bloomTrieNodes.Count()},
 	}
 	// Inspect all registered append-only file store then.
-	ancients, err := inspectFreezers(db)
+	ancients, err := inspectFreezers(db, opts...)
 	if err != nil {
-		if errors.Is(err, errNotSupported) && libevmConfig.skipFreezers {
-			ancients = make([]freezerInfo, 0)
-		} else {
-			return err
-		}
+		return err
 	}
 	for _, ancient := range ancients {
 		for _, table := range ancient.sizes {

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -606,7 +606,11 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte, opts ...Insp
 	// Inspect all registered append-only file store then.
 	ancients, err := inspectFreezers(db)
 	if err != nil {
-		return err
+		if errors.Is(err, errNotSupported) && libevmConfig.skipFreezers {
+			ancients = make([]freezerInfo, 0)
+		} else {
+			return err
+		}
 	}
 	for _, ancient := range ancients {
 		for _, table := range ancient.sizes {

--- a/core/rawdb/database.libevm.go
+++ b/core/rawdb/database.libevm.go
@@ -28,6 +28,7 @@ type inspectDatabaseConfig struct {
 	statRecorders     []func([]byte, common.StorageSize) bool
 	isMetas           []func([]byte) bool
 	statsTransformers []func([][]string) [][]string
+	skipFreezers      bool
 }
 
 func (c inspectDatabaseConfig) recordStat(key []byte, size common.StorageSize) bool {
@@ -89,5 +90,12 @@ func WithDatabaseMetadataKeys(isMetadata func(key []byte) bool) InspectDatabaseO
 func WithDatabaseStatsTransformer(transform func(rows [][]string) [][]string) InspectDatabaseOption {
 	return newInspectOpt(func(c *inspectDatabaseConfig) {
 		c.statsTransformers = append(c.statsTransformers, transform)
+	})
+}
+
+// WithSkipFreezers returns an option that causes for freezer inspection to be skipped.
+func WithSkipFreezers() InspectDatabaseOption {
+	return newInspectOpt(func(c *inspectDatabaseConfig) {
+		c.skipFreezers = true
 	})
 }

--- a/core/rawdb/database.libevm_test.go
+++ b/core/rawdb/database.libevm_test.go
@@ -20,13 +20,28 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"testing"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/stretchr/testify/require"
+
 	// To ensure that all methods are available to importing packages, this test
 	// is defined in package `rawdb_test` instead of `rawdb`.
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/ethdb"
 )
+
+func TestSkipFreezers(t *testing.T) {
+	require := require.New(t)
+	db := rawdb.NewMemoryDatabase()
+
+	var (
+		keyPrefix []byte
+		keyStart  []byte
+	)
+
+	require.NoError(rawdb.InspectDatabase(db, keyPrefix, keyStart, rawdb.WithSkipFreezers()))
+}
 
 // ExampleDatabaseStat demonstrates the method signatures of DatabaseStat, which
 // exposes an otherwise unexported type that won't have its methods documented.

--- a/core/rawdb/database.libevm_test.go
+++ b/core/rawdb/database.libevm_test.go
@@ -22,9 +22,9 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/ava-labs/libevm/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/libevm/common"
 	// To ensure that all methods are available to importing packages, this test
 	// is defined in package `rawdb_test` instead of `rawdb`.
 	"github.com/ava-labs/libevm/core/rawdb"


### PR DESCRIPTION
## Why this should be merged

As described in https://github.com/ava-labs/coreth/issues/1137, database inspection of a Coreth chain database fails because `InspectDatabase()` expects for freezers to be used. This PR fixes this bug by adding an option to skip freezer inspection.

This PR should be followed with a downstream PR in Coreth to pass in an option to skip freezer inspection during database inspection.

## How this works

Extends `inspectDatabaseConfig` with a `skipFreezers` field and adds the associated option function for it.

## How this was tested

CI + ran `InspectDatabase()` against Coreth locally
