### PR TITLE
feat: export `P256Verify` precompile

### DIFF
--- a/core/vm/contracts.libevm.go
+++ b/core/vm/contracts.libevm.go
@@ -31,6 +31,14 @@ import (
 	"github.com/ava-labs/libevm/params"
 )
 
+// P256Verify is a [PrecompiledContract] implementation of P-256 (secp256r1)
+// ECDSA verification, as defined by [EIP-7951].
+//
+// [EIP-7951]: https://eips.ethereum.org/EIPS/eip-7951
+type P256Verify struct {
+	p256Verify
+}
+
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	orig := activePrecompiles(rules) // original, upstream implementation

--- a/core/vm/contracts_pkg_vm.libevm_test.go
+++ b/core/vm/contracts_pkg_vm.libevm_test.go
@@ -29,5 +29,5 @@ func TestExportedP256Verify(t *testing.T) {
 		delete(allPrecompiles, addr)
 	})
 
-	testJson("p256verify", addr.Hex(), t)
+	testJson("p256Verify", addr.Hex(), t)
 }

--- a/core/vm/contracts_pkg_vm.libevm_test.go
+++ b/core/vm/contracts_pkg_vm.libevm_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+)
+
+func TestExportedP256Verify(t *testing.T) {
+	addr := common.Address{'p', '2', '5', '6', 'l', 'i', 'b', 'e', 'v', 'm'}
+	allPrecompiles[addr] = &P256Verify{}
+	t.Cleanup(func() {
+		delete(allPrecompiles, addr)
+	})
+
+	testJson("p256verify", addr.Hex(), t)
+}


### PR DESCRIPTION
## Why this should be merged

Allows direct access to the P-256 verification precompile. Currently the only alternative is to rely on the planned but not guaranteed address that Ethereum will use.

## How this works

Embed the non-exported `p256verify` type in an exported struct to allow its methods to be exposed.

## How this was tested

Run the test suite for `p256verify` on `P256Verify`.