### PR TITLE
feat: temporary extras

### DIFF
--- a/core/state/statedb.libevm.go
+++ b/core/state/statedb.libevm.go
@@ -87,8 +87,10 @@ func RegisterExtras(s StateDBHooks) {
 // registration is returned to its former state, be that none or the types
 // originally passed to [RegisterExtras].
 //
-// This MUST NOT be used in a live chain. It is solely intended for off-chain
-// consumers that require access to extras, and is also not threadsafe.
+// This MUST NOT be used on a live chain. It is solely intended for off-chain
+// consumers that require access to extras. Said consumers SHOULD NOT, however
+// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
+// function instead as it atomically overrides all possible packages.
 func WithTempRegisteredExtras(s StateDBHooks, fn func()) {
 	registeredExtras.TempOverride(s, fn)
 }

--- a/core/state/statedb.libevm.go
+++ b/core/state/statedb.libevm.go
@@ -82,6 +82,17 @@ func RegisterExtras(s StateDBHooks) {
 	registeredExtras.MustRegister(s)
 }
 
+// WithTempRegisteredExtras temporarily registers `s` as if calling
+// [RegisterExtras] the same type parameter. After `fn` returns, the
+// registration is returned to its former state, be that none or the types
+// originally passed to [RegisterExtras].
+//
+// This MUST NOT be used in a live chain. It is solely intended for off-chain
+// consumers that require access to extras, and is also not threadsafe.
+func WithTempRegisteredExtras(s StateDBHooks, fn func()) {
+	registeredExtras.TempOverride(s, fn)
+}
+
 // TestOnlyClearRegisteredExtras clears the arguments previously passed to
 // [RegisterExtras]. It panics if called from a non-testing call stack.
 //

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -130,7 +130,7 @@ type BlockBodyHooks interface {
 // to no type having been registered.
 type NOOPBlockBodyHooks struct{}
 
-var _ BlockBodyPayload[*NOOPBlockBodyHooks] = NOOPBlockBodyHooks{}
+var _ BlockBodyPayload[*NOOPBlockBodyHooks] = (*NOOPBlockBodyHooks)(nil)
 
 func (NOOPBlockBodyHooks) Copy() *NOOPBlockBodyHooks { return &NOOPBlockBodyHooks{} }
 

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -101,9 +101,10 @@ func payloadsAndConstructors[
 
 // WithTempRegisteredExtras temporarily registers `HPtr`, `BPtr`, and `SA` as if
 // calling [RegisterExtras] the same type parameters. The [ExtraPayloads] are
-// passed to `fn` instead of being returned. After `fn` returns, the
-// registration is returned to its former state, be that none or the types
-// originally passed to [RegisterExtras].
+// passed to `fn` instead of being returned; the argument MUST NOT be persisted
+// beyond the life of `fn`. After `fn` returns, the registration is returned to
+// its former state, be that none or the types originally passed to
+// [RegisterExtras].
 //
 // This MUST NOT be used in a live chain. It is solely intended for off-chain
 // consumers that require access to extras.
@@ -133,9 +134,9 @@ type BlockBodyHooksPointer[B any, Self any] interface {
 // A BlockBodyPayload is an implementation of [BlockBodyHooks] that is also able
 // to clone itself. Both [Block.Body] and [Block.WithBody] require this
 // functionality to copy the payload between the types.
-type BlockBodyPayload[BPtr any] interface {
+type BlockBodyPayload[Self any] interface {
 	BlockBodyHooks
-	Copy() BPtr
+	Copy() Self
 }
 
 // TestOnlyClearRegisteredExtras clears the [Extras] previously passed to

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -106,10 +106,12 @@ func payloadsAndConstructors[
 // its former state, be that none or the types originally passed to
 // [RegisterExtras].
 //
-// This MUST NOT be used in a live chain. It is solely intended for off-chain
-// consumers that require access to extras, and is also not threadsafe.
+// This MUST NOT be used on a live chain. It is solely intended for off-chain
+// consumers that require access to extras. Said consumers SHOULD NOT, however
+// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
+// function instead as it atomically overrides all possible packages.
 func WithTempRegisteredExtras[
-	H any, B any, SA any,
+	H, B, SA any,
 	HPtr HeaderHooksPointer[H],
 	BPtr BlockBodyHooksPointer[B, BPtr],
 ](fn func(ExtraPayloads[HPtr, BPtr, SA])) {

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -107,7 +107,7 @@ func payloadsAndConstructors[
 // [RegisterExtras].
 //
 // This MUST NOT be used in a live chain. It is solely intended for off-chain
-// consumers that require access to extras.
+// consumers that require access to extras, and is also not threadsafe.
 func WithTempRegisteredExtras[
 	H any, B any, SA any,
 	HPtr HeaderHooksPointer[H],

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -44,17 +44,27 @@ import (
 // [Header] or [Block] / [Body] is a non-nil `HPtr` or `BPtr` respectively. The
 // latter guarantee ensures that hooks won't be called on nil-pointer receivers.
 func RegisterExtras[
-	H any, HPtr interface {
-		HeaderHooks
-		*H
-	},
-	B any, BPtr interface {
-		BlockBodyPayload[BPtr]
-		*B
-	},
+	H any, HPtr HeaderHooksPointer[H],
+	B any, BPtr BlockBodyHooksPointer[B, BPtr],
 	SA any,
 ]() ExtraPayloads[HPtr, BPtr, SA] {
-	extra := ExtraPayloads[HPtr, BPtr, SA]{
+	payloads, ctors := payloadsAndConstructors[H, HPtr, B, BPtr, SA]()
+	registeredExtras.MustRegister(ctors)
+	log.Info(
+		"Registered core/types extras",
+		"Header", log.TypeOf(pseudo.Zero[HPtr]().Value.Get()),
+		"Block/Body", log.TypeOf(pseudo.Zero[BPtr]().Value.Get()),
+		"StateAccount", log.TypeOf(pseudo.Zero[SA]().Value.Get()),
+	)
+	return payloads
+}
+
+func payloadsAndConstructors[
+	H any, HPtr HeaderHooksPointer[H],
+	B any, BPtr BlockBodyHooksPointer[B, BPtr],
+	SA any,
+]() (ExtraPayloads[HPtr, BPtr, SA], *extraConstructors) {
+	payloads := ExtraPayloads[HPtr, BPtr, SA]{
 		Header: pseudo.NewAccessor[*Header, HPtr](
 			(*Header).extraPayload,
 			func(h *Header, t *pseudo.Type) { h.extra = t },
@@ -72,7 +82,7 @@ func RegisterExtras[
 			func(a StateOrSlimAccount, t *pseudo.Type) { a.extra().t = t },
 		),
 	}
-	registeredExtras.MustRegister(&extraConstructors{
+	ctors := &extraConstructors{
 		stateAccountType: func() string {
 			var x SA
 			return fmt.Sprintf("%T", x)
@@ -84,15 +94,40 @@ func RegisterExtras[
 		newHeader:       pseudo.NewConstructor[H]().NewPointer, // i.e. non-nil HPtr
 		newBlockOrBody:  pseudo.NewConstructor[B]().NewPointer, // i.e. non-nil BPtr
 		newStateAccount: pseudo.NewConstructor[SA]().Zero,
-		hooks:           extra,
-	})
-	log.Info(
-		"Registered core/types extras",
-		"Header", log.TypeOf(pseudo.Zero[HPtr]().Value.Get()),
-		"Block/Body", log.TypeOf(pseudo.Zero[BPtr]().Value.Get()),
-		"StateAccount", log.TypeOf(pseudo.Zero[SA]().Value.Get()),
-	)
-	return extra
+		hooks:           payloads,
+	}
+	return payloads, ctors
+}
+
+// WithTempRegisteredExtras temporarily registers `HPtr`, `BPtr`, and `SA` as if
+// calling [RegisterExtras] the same type parameters. The [ExtraPayloads] are
+// passed to `fn` instead of being returned. After `fn` returns, the
+// registration is returned to its former state, be that none or the types
+// originally passed to [RegisterExtras].
+//
+// This MUST NOT be used in a live chain. It is solely intended for off-chain
+// consumers that require access to extras.
+func WithTempRegisteredExtras[
+	H any, B any, SA any,
+	HPtr HeaderHooksPointer[H],
+	BPtr BlockBodyHooksPointer[B, BPtr],
+](fn func(ExtraPayloads[HPtr, BPtr, SA])) {
+	payloads, ctors := payloadsAndConstructors[H, HPtr, B, BPtr, SA]()
+	registeredExtras.TempOverride(ctors, func() { fn(payloads) })
+}
+
+// A HeaderHooksPointer is a type constraint for an implementation of
+// [HeaderHooks] with a pointer receiver.
+type HeaderHooksPointer[H any] interface {
+	HeaderHooks
+	*H
+}
+
+// A BlockBodyHooksPointer is a type constraint for an implementation of
+// [BlockBodyPayload] with a pointer receiver.
+type BlockBodyHooksPointer[B any, Self any] interface {
+	BlockBodyPayload[Self]
+	*B
 }
 
 // A BlockBodyPayload is an implementation of [BlockBodyHooks] that is also able

--- a/core/types/tempextras.libevm_test.go
+++ b/core/types/tempextras.libevm_test.go
@@ -19,9 +19,10 @@ package types
 import (
 	"testing"
 
-	"github.com/ava-labs/libevm/rlp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/libevm/rlp"
 )
 
 type tempBlockBodyHooks struct {

--- a/core/types/tempextras.libevm_test.go
+++ b/core/types/tempextras.libevm_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"testing"
+)
+
+func TestTempRegisteredExtras(t *testing.T) {
+	TestOnlyClearRegisteredExtras()
+	t.Cleanup(TestOnlyClearRegisteredExtras)
+
+	type (
+		primary struct {
+			NOOPHeaderHooks
+		}
+		override struct {
+			NOOPHeaderHooks
+		}
+	)
+
+	RegisterExtras[primary, *primary, NOOPBlockBodyHooks, *NOOPBlockBodyHooks, bool]()
+	testPrimaryExtras := func(t *testing.T) {
+		t.Helper()
+		assertHeaderHooksConcreteType[*primary](t)
+	}
+
+	t.Run("before_temp", testPrimaryExtras)
+	t.Run("WithTempRegisteredExtras", func(t *testing.T) {
+		WithTempRegisteredExtras(func(ExtraPayloads[*override, *NOOPBlockBodyHooks, bool]) {
+			assertHeaderHooksConcreteType[*override](t)
+		})
+	})
+	t.Run("after_temp", testPrimaryExtras)
+}
+
+func assertHeaderHooksConcreteType[WantT any](t *testing.T) {
+	t.Helper()
+
+	hdr := new(Header)
+	switch got := hdr.hooks().(type) {
+	case WantT:
+	default:
+		var want WantT
+		t.Errorf("%T.hooks() got concrete type %T; want %T", hdr, got, want)
+	}
+}

--- a/core/vm/hooks.libevm.go
+++ b/core/vm/hooks.libevm.go
@@ -32,8 +32,10 @@ func RegisterHooks(h Hooks) {
 // is returned to its former state, be that none or the types originally passed
 // to [RegisterHooks].
 //
-// This MUST NOT be used in a live chain. It is solely intended for off-chain
-// consumers that require access to extras, and is also not threadsafe.
+// This MUST NOT be used on a live chain. It is solely intended for off-chain
+// consumers that require access to extras. Said consumers SHOULD NOT, however
+// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
+// function instead as it atomically overrides all possible packages.
 func WithTempRegisteredHooks(h Hooks, fn func()) {
 	libevmHooks.TempOverride(h, fn)
 }

--- a/core/vm/hooks.libevm.go
+++ b/core/vm/hooks.libevm.go
@@ -27,6 +27,17 @@ func RegisterHooks(h Hooks) {
 	libevmHooks.MustRegister(h)
 }
 
+// WithTempRegisteredHooks temporarily registers `h` as if calling
+// [RegisterHooks] the same type parameter. After `fn` returns, the registration
+// is returned to its former state, be that none or the types originally passed
+// to [RegisterHooks].
+//
+// This MUST NOT be used in a live chain. It is solely intended for off-chain
+// consumers that require access to extras, and is also not threadsafe.
+func WithTempRegisteredHooks(h Hooks, fn func()) {
+	libevmHooks.TempOverride(h, fn)
+}
+
 // TestOnlyClearRegisteredHooks clears the [Hooks] previously passed to
 // [RegisterHooks]. It panics if called from a non-testing call stack.
 func TestOnlyClearRegisteredHooks() {

--- a/libevm/register/register.go
+++ b/libevm/register/register.go
@@ -1,4 +1,4 @@
-// Copyright 2024 the libevm authors.
+// Copyright 2024-2025 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License
@@ -65,4 +65,29 @@ func (o *AtMostOnce[T]) TestOnlyClear() {
 	testonly.OrPanic(func() {
 		o.v = nil
 	})
+}
+
+// TempOverride calls `fn`, overriding any registered `T`, but only for the life
+// of the call.
+//
+// It is valid to call this method with or without a prior call to
+// [AtMostOnce.Register].
+func (o *AtMostOnce[T]) TempOverride(with T, fn func()) {
+	o.temp(&with, fn)
+}
+
+// TempClear calls `fn`, clearing any registered `T`, but only for the life of
+// the call.
+//
+// It is valid to call this method with or without a prior call to
+// [AtMostOnce.Register].
+func (o *AtMostOnce[T]) TempClear(fn func()) {
+	o.temp(nil, fn)
+}
+
+func (o *AtMostOnce[T]) temp(with *T, fn func()) {
+	old := o.v
+	o.v = with
+	fn()
+	o.v = old
 }

--- a/libevm/register/register.go
+++ b/libevm/register/register.go
@@ -68,7 +68,7 @@ func (o *AtMostOnce[T]) TestOnlyClear() {
 }
 
 // TempOverride calls `fn`, overriding any registered `T`, but only for the life
-// of the call.
+// of the call. It is not threadsafe.
 //
 // It is valid to call this method with or without a prior call to
 // [AtMostOnce.Register].
@@ -77,7 +77,7 @@ func (o *AtMostOnce[T]) TempOverride(with T, fn func()) {
 }
 
 // TempClear calls `fn`, clearing any registered `T`, but only for the life of
-// the call.
+// the call. It is not threadsafe.
 //
 // It is valid to call this method with or without a prior call to
 // [AtMostOnce.Register].

--- a/libevm/register/register_test.go
+++ b/libevm/register/register_test.go
@@ -1,0 +1,78 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package register
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtMostOnce(t *testing.T) {
+	var sut AtMostOnce[int]
+	assertRegistered := func(t *testing.T, want int) {
+		t.Helper()
+		require.True(t, sut.Registered(), "Registered()")
+		assert.Equal(t, want, sut.Get(), "Get()")
+	}
+
+	const val int = 42
+	require.NoError(t, sut.Register(val), "Register()")
+	assertRegistered(t, val)
+
+	assert.PanicsWithValue(
+		t, ErrReRegistration,
+		func() { sut.MustRegister(0) },
+		"MustRegister() after Register()",
+	)
+
+	t.Run("TestOnlyClear", func(t *testing.T) {
+		sut.TestOnlyClear()
+		require.False(t, sut.Registered(), "Registered()")
+
+		t.Run("re-registration", func(t *testing.T) {
+			sut.MustRegister(val)
+			assertRegistered(t, val)
+		})
+	})
+	if t.Failed() {
+		return
+	}
+
+	t.Run("TempOverride", func(t *testing.T) {
+		t.Run("during", func(t *testing.T) {
+			sut.TempOverride(val+1, func() {
+				assertRegistered(t, val+1)
+			})
+		})
+		t.Run("after", func(t *testing.T) {
+			assertRegistered(t, val)
+		})
+	})
+
+	t.Run("TempClear", func(t *testing.T) {
+		t.Run("during", func(t *testing.T) {
+			sut.TempClear(func() {
+				assert.False(t, sut.Registered(), "Registered()")
+			})
+		})
+		t.Run("after", func(t *testing.T) {
+			assertRegistered(t, val)
+		})
+	})
+}

--- a/libevm/temporary/temporary.go
+++ b/libevm/temporary/temporary.go
@@ -1,0 +1,65 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+// Package temporary provides thread-safe, temporary registration of all libevm
+// hooks and payloads.
+package temporary
+
+import (
+	"sync"
+
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/core/vm"
+	"github.com/ava-labs/libevm/params"
+)
+
+var mu sync.Mutex
+
+// WithRegisteredExtras takes a global lock and temporarily registers [params],
+// [state], [types], and [vm] extras before calling the provided function. It
+// can be thought of as an atomic call to all functions equivalent to
+// [params.WithTempRegisteredExtras].
+//
+// This is the *only* safe way to override libevm functionality. Direct calls to
+// the package-specific temporary registration functions are not advised.
+//
+// WithRegisteredExtras MUST NOT be used on a live chain. It is solely intended
+// for off-chain consumers that require access to extras.
+func WithRegisteredExtras[
+	C params.ChainConfigHooks, R params.RulesHooks,
+	H, B, SA any,
+	HPtr types.HeaderHooksPointer[H],
+	BPtr types.BlockBodyHooksPointer[B, BPtr],
+](
+	paramsExtras params.Extras[C, R],
+	sdbHooks state.StateDBHooks,
+	vmHooks vm.Hooks,
+	fn func(params.ExtraPayloads[C, R], types.ExtraPayloads[HPtr, BPtr, SA]),
+) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	params.WithTempRegisteredExtras(paramsExtras, func(paramsPayloads params.ExtraPayloads[C, R]) {
+		types.WithTempRegisteredExtras(func(typesPayloads types.ExtraPayloads[HPtr, BPtr, SA]) {
+			state.WithTempRegisteredExtras(sdbHooks, func() {
+				vm.WithTempRegisteredHooks(vmHooks, func() {
+					fn(paramsPayloads, typesPayloads)
+				})
+			})
+		})
+	})
+}

--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -102,7 +102,7 @@ func payloadsAndConstructors[C ChainConfigHooks, R RulesHooks](e Extras[C, R]) (
 // [RegisterExtras].
 //
 // This MUST NOT be used in a live chain. It is solely intended for off-chain
-// consumers that require access to extras.
+// consumers that require access to extras, and is also not threadsafe.
 func WithTempRegisteredExtras[C ChainConfigHooks, R RulesHooks](
 	e Extras[C, R],
 	fn func(ExtraPayloads[C, R]),

--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -94,10 +94,11 @@ func payloadsAndConstructors[C ChainConfigHooks, R RulesHooks](e Extras[C, R]) (
 	}
 }
 
-// WithTempRegisteredExtras temporarily registers `C` and `R` as if calling
-// [RegisterExtras] with `e`. The [ExtraPayloads] are passed to `fn` instead of
-// being returned. After `fn` returns, the registration is returned to its
-// former state, be that none or the types originally passed to
+// WithTempRegisteredExtras temporarily registers `HPtr`, `BPtr`, and `SA` as if
+// calling [RegisterExtras] the same type parameters. The [ExtraPayloads] are
+// passed to `fn` instead of being returned; the argument MUST NOT be persisted
+// beyond the life of `fn`. After `fn` returns, the registration is returned to
+// its former state, be that none or the types originally passed to
 // [RegisterExtras].
 //
 // This MUST NOT be used in a live chain. It is solely intended for off-chain

--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -101,8 +101,10 @@ func payloadsAndConstructors[C ChainConfigHooks, R RulesHooks](e Extras[C, R]) (
 // its former state, be that none or the types originally passed to
 // [RegisterExtras].
 //
-// This MUST NOT be used in a live chain. It is solely intended for off-chain
-// consumers that require access to extras, and is also not threadsafe.
+// This MUST NOT be used on a live chain. It is solely intended for off-chain
+// consumers that require access to extras. Said consumers SHOULD NOT, however
+// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
+// function instead as it atomically overrides all possible packages.
 func WithTempRegisteredExtras[C ChainConfigHooks, R RulesHooks](
 	e Extras[C, R],
 	fn func(ExtraPayloads[C, R]),


### PR DESCRIPTION
## Why this should be merged

Registration of extras requires runtime enforcement of payload types. In production, only a single set of types can be registered and any attempts at re-registration will panic (by design). Although this makes production usage safe, it doesn't allow downstream consumers (e.g. data indexers) to use extras from different chains (e.g. `coreth` _and_ `subnet-evm`) at the same time.

## How this works

1. The `libevm/register.AtMostOnce` type can now be overridden temporarily.
2. `params`, `core/types`, `core/vm`, and `state` packages introduce `WithTempRegisteredExtras()` functions.
3. `libevm/temporary.WithRegisteredExtras()` provides "atomic" override of all extras.

In all cases, the scope of the override is limited to the life of a single function call.

## How this was tested

Relative to numbered list above:

1. Unit test of new and existing functionality.
2. Integration tests of both packages, demonstrating both payload and behavioural override.