### PR TITLE
feat: `libevm/triedb/firewood` scaffolding with proposal propagation

### DIFF
--- a/libevm/triedb/firewood/firewood.go
+++ b/libevm/triedb/firewood/firewood.go
@@ -1,0 +1,25 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+// The firewood package provides a [triedb.BackendDB] based on [Firewood].
+//
+// [Firewood]: https://github.com/ava-labs/firewood
+package firewood
+
+import "github.com/ava-labs/libevm/triedb"
+
+// Protects the import in this file so [triedb.BackendDB] linked comments work.
+var _ triedb.BackendDB

--- a/libevm/triedb/firewood/firewood.go
+++ b/libevm/triedb/firewood/firewood.go
@@ -38,7 +38,7 @@ type database struct {
 
 func (db *database) Update(root, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set, opts ...stateconf.TrieDBUpdateOption) error {
 	// TODO(alarso16)
-	var _ *proposal = extras.MergedNodeSet.Get(nodes)
+	var _ *proposals = extras.MergedNodeSet.Get(nodes)
 
 	db.afterUpdate(nodes) // MUST be the last statement before the final return
 	return errors.New("unimplemented")

--- a/libevm/triedb/firewood/firewood.go
+++ b/libevm/triedb/firewood/firewood.go
@@ -14,12 +14,39 @@
 // along with the go-ethereum library. If not, see
 // <http://www.gnu.org/licenses/>.
 
-// The firewood package provides a [triedb.BackendDB] based on [Firewood].
+// The firewood package provides a [triedb.DBOverride] backed by [Firewood].
 //
 // [Firewood]: https://github.com/ava-labs/firewood
 package firewood
 
-import "github.com/ava-labs/libevm/triedb"
+import (
+	"errors"
+	"runtime"
 
-// Protects the import in this file so [triedb.BackendDB] linked comments work.
-var _ triedb.BackendDB
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/libevm/stateconf"
+	"github.com/ava-labs/libevm/trie/trienode"
+	"github.com/ava-labs/libevm/trie/triestate"
+	"github.com/ava-labs/libevm/triedb"
+)
+
+var _ triedb.DBOverride = (*database)(nil)
+
+type database struct {
+	triedb.DBOverride // TODO(alarso16) remove once this type implements the interface
+}
+
+func (db *database) Update(root, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set, opts ...stateconf.TrieDBUpdateOption) error {
+	// TODO(alarso16)
+	var _ *proposal = extras.MergedNodeSet.Get(nodes)
+
+	db.afterUpdate(nodes) // MUST be the last statement before the final return
+	return errors.New("unimplemented")
+}
+
+// afterUpdate MUST be called at the end of [database.Update] to ensure that the
+// Rust handle isn't freed any earlier. This is an overly cautious, defensive
+// approach that will make Rustaceans scream "I told you so".
+func (db *database) afterUpdate(nodes *trienode.MergedNodeSet) {
+	runtime.KeepAlive(extras.MergedNodeSet.Get(nodes))
+}

--- a/libevm/triedb/firewood/proposals.go
+++ b/libevm/triedb/firewood/proposals.go
@@ -1,0 +1,56 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package firewood
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/trie/trienode"
+)
+
+// RegisterExtras
+func RegisterExtras() {
+	extras = trienode.RegisterExtras[proposal, proposal, struct{}]()
+}
+
+var extras trienode.ExtraPayloads[*proposal, *proposal, struct{}]
+
+type proposal struct {
+	handle *handle
+}
+
+// TODO(alarso16) this type is entirely arbitrary and exists only to allow
+// initial integration testing.
+type handle struct {
+	root        common.Hash
+	memoryFreed bool
+}
+
+// MergeNodeSet implements [trienode.MergedNodeSetHooks], copying at most one
+// proposal handle into the merged set.
+func (h *proposal) MergeNodeSet(into *trienode.MergedNodeSet, set *trienode.NodeSet) error {
+	merged := extras.MergedNodeSet.Get(into)
+	if merged.handle != nil {
+		return fmt.Errorf(">1 %T carrying non-nil %T", set, merged.handle)
+	}
+	merged.handle = extras.NodeSet.Get(set).handle
+	return nil
+}
+
+// AddNode implements [trienode.NodeSetHooks] as a noop.
+func (h *proposal) AddNode(*trienode.NodeSet, []byte, *trienode.Node) {}

--- a/libevm/triedb/firewood/proposals_test.go
+++ b/libevm/triedb/firewood/proposals_test.go
@@ -123,6 +123,8 @@ func TestProposalPropagation(t *testing.T) {
 	t.Run("GC_finalizer_invoked", func(t *testing.T) {
 		finalized := backend.got.finalized
 
+		// Everything that might still hold a reference to the `proposal`,
+		// stopping it from being garbage collected.
 		sdb = nil
 		cache = nil
 		tdb = nil

--- a/libevm/triedb/firewood/proposals_test.go
+++ b/libevm/triedb/firewood/proposals_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package firewood
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/stateconf"
+	"github.com/ava-labs/libevm/trie"
+	"github.com/ava-labs/libevm/trie/trienode"
+	"github.com/ava-labs/libevm/trie/triestate"
+	"github.com/ava-labs/libevm/triedb"
+	"github.com/ava-labs/libevm/triedb/database"
+	"github.com/ava-labs/libevm/triedb/hashdb"
+)
+
+func TestMain(m *testing.M) {
+	RegisterExtras()
+	os.Exit(m.Run())
+}
+
+type hashDBWithDummyProposals struct {
+	*hashdb.Database
+	gotProposalHandle *handle
+}
+
+func (db *hashDBWithDummyProposals) Reader(root common.Hash) (database.Reader, error) {
+	return db.Database.Reader(root)
+}
+
+func (db *hashDBWithDummyProposals) Update(root, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set, opts ...stateconf.TrieDBUpdateOption) error {
+	db.gotProposalHandle = extras.MergedNodeSet.Get(nodes).handle
+	return db.Database.Update(root, parent, block, nodes, states, opts...)
+}
+
+type cacheWithDummyProposals struct {
+	state.Database
+}
+
+func (db *cacheWithDummyProposals) OpenTrie(root common.Hash) (state.Trie, error) {
+	t, err := db.Database.OpenTrie(root)
+	if err != nil {
+		return nil, err
+	}
+	return &trieWithDummyProposals{Trie: t}, nil
+}
+
+func (db *cacheWithDummyProposals) CopyTrie(t state.Trie) state.Trie {
+	return &trieWithDummyProposals{
+		Trie: db.Database.CopyTrie(t.(*trieWithDummyProposals).Trie), // let it panic, see if I care!
+	}
+}
+
+type trieWithDummyProposals struct {
+	state.Trie
+}
+
+func (t *trieWithDummyProposals) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
+	root, set, err := t.Trie.Commit(collectLeaf)
+	if err != nil {
+		return common.Hash{}, nil, err
+	}
+
+	// This, combined with [proposalPayload.MergeNodeSet], is where the magic
+	// happens. We use the existing geth plumbing to carry the proposal back to
+	// [hashDBWithDummyProposals.Update], knowing that the Go GC will trigger
+	// the FFI call to free the Rust memory.
+	payload := &proposal{
+		handle: &handle{root: root},
+	}
+	runtime.SetFinalizer(payload, func(p *proposal) {
+		p.handle.memoryFreed = true
+	})
+	extras.NodeSet.Set(set, payload)
+
+	return root, set, nil
+}
+
+func TestProposalPropagation(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	backend := &hashDBWithDummyProposals{
+		Database: hashdb.New(db, nil, trie.MerkleResolver{}),
+	}
+	tdb := triedb.NewDatabase(db, &triedb.Config{
+		DBOverride: func(db ethdb.Database) triedb.DBOverride {
+			return backend
+		},
+	})
+
+	cache := &cacheWithDummyProposals{
+		Database: state.NewDatabaseWithNodeDB(db, tdb),
+	}
+	sdb, err := state.New(types.EmptyRootHash, cache, nil)
+	require.NoError(t, err, "state.New([empty root], ...)")
+
+	sdb.SetState(common.Address{}, common.Hash{}, common.Hash{42})
+	root, err := sdb.Commit(1, false)
+	require.NoErrorf(t, err, "%T.Commit()", sdb)
+
+	got := backend.gotProposalHandle
+	want := &handle{
+		root:        root,
+		memoryFreed: false,
+	}
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(handle{})); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
+	}
+
+	// Ensure that the proposal payload is no longer reachable.
+	sdb = nil
+	cache = nil
+	tdb = nil
+	backend = nil
+	runtime.GC()
+	assert.True(t, got.memoryFreed)
+}

--- a/trie/trienode/node.go
+++ b/trie/trienode/node.go
@@ -32,7 +32,7 @@ type Node struct {
 	Hash common.Hash // Node hash, empty for deleted node
 	Blob []byte      // Encoded node blob, nil for the deleted node
 
-	extra *pseudo.Type // libevm
+	extra *pseudo.Type
 }
 
 // Size returns the total memory size used by this node.
@@ -68,7 +68,7 @@ type NodeSet struct {
 	updates int // the count of updated and inserted nodes
 	deletes int // the count of deleted nodes
 
-	extra *pseudo.Type // libevm
+	extra *pseudo.Type
 }
 
 // NewNodeSet initializes a node set. The owner is zero for the account trie and
@@ -171,7 +171,7 @@ func (set *NodeSet) Summary() string {
 type MergedNodeSet struct {
 	Sets map[common.Hash]*NodeSet
 
-	extra *pseudo.Type // libevm
+	extra *pseudo.Type
 }
 
 // NewMergedNodeSet initializes an empty merged set.

--- a/trie/trienode/node.libevm.go
+++ b/trie/trienode/node.libevm.go
@@ -23,12 +23,12 @@ import (
 
 // MergedNodeSetHooks
 type MergedNodeSetHooks interface {
-	Merge(into *MergedNodeSet, _ *NodeSet) error
+	MergeNodeSet(into *MergedNodeSet, _ *NodeSet) error
 }
 
 // NodeSetHooks
 type NodeSetHooks interface {
-	Add(into *NodeSet, path []byte, _ *Node)
+	AddNode(into *NodeSet, path []byte, _ *Node)
 }
 
 // RegisterExtras
@@ -92,14 +92,14 @@ func (set *MergedNodeSet) Merge(other *NodeSet) error {
 		return err
 	}
 	if r := registeredExtras; r.Registered() {
-		return r.Get().hooks.hooksFromMNS(set).Merge(set, other)
+		return r.Get().hooks.hooksFromMNS(set).MergeNodeSet(set, other)
 	}
 	return nil
 }
 
 func (set *NodeSet) mergePayload(path []byte, n *Node) {
 	if r := registeredExtras; r.Registered() {
-		r.Get().hooks.hooksFromNS(set).Add(set, path, n)
+		r.Get().hooks.hooksFromNS(set).AddNode(set, path, n)
 	}
 }
 

--- a/trie/trienode/node.libevm.go
+++ b/trie/trienode/node.libevm.go
@@ -1,0 +1,153 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package trienode
+
+import (
+	"github.com/ava-labs/libevm/libevm/pseudo"
+	"github.com/ava-labs/libevm/libevm/register"
+)
+
+// MergedNodeSetHooks
+type MergedNodeSetHooks interface {
+	Merge(into *MergedNodeSet, _ *NodeSet) error
+}
+
+// NodeSetHooks
+type NodeSetHooks interface {
+	Add(into *NodeSet, path []byte, _ *Node)
+}
+
+// RegisterExtras
+func RegisterExtras[
+	MNS, NS, N any,
+	MNSPtr interface {
+		MergedNodeSetHooks
+		*MNS
+	},
+	NSPtr interface {
+		NodeSetHooks
+		*NS
+	},
+]() ExtraPayloads[MNSPtr, NSPtr, N] {
+	payloads := ExtraPayloads[MNSPtr, NSPtr, N]{
+		MergedNodeSet: pseudo.NewAccessor[*MergedNodeSet, MNSPtr](
+			(*MergedNodeSet).extraPayload,
+			func(s *MergedNodeSet, t *pseudo.Type) { s.extra = t },
+		),
+		NodeSet: pseudo.NewAccessor[*NodeSet, NSPtr](
+			(*NodeSet).extraPayload,
+			func(s *NodeSet, t *pseudo.Type) { s.extra = t },
+		),
+		Node: pseudo.NewAccessor[*Node, N](
+			(*Node).extraPayload,
+			func(n *Node, t *pseudo.Type) { n.extra = t },
+		),
+	}
+
+	registeredExtras.MustRegister(&extraConstructors{
+		newMergedNodeSet: pseudo.NewConstructor[MNS]().NewPointer,
+		newNodeSet:       pseudo.NewConstructor[NS]().NewPointer,
+		newNode:          pseudo.NewConstructor[N]().Zero,
+		hooks:            payloads,
+	})
+
+	return payloads
+}
+
+// TestOnlyClearRegisteredExtras
+func TestOnlyClearRegisteredExtras() {
+	registeredExtras.TestOnlyClear()
+}
+
+var registeredExtras register.AtMostOnce[*extraConstructors]
+
+type extraConstructors struct {
+	newMergedNodeSet func() *pseudo.Type
+	newNodeSet       func() *pseudo.Type
+	newNode          func() *pseudo.Type
+	hooks            interface {
+		hooksFromMNS(*MergedNodeSet) MergedNodeSetHooks
+		hooksFromNS(*NodeSet) NodeSetHooks
+	}
+}
+
+// Merge merges the provided dirty nodes of a trie into the set. The assumption
+// is held that no duplicated set belonging to the same trie will be merged twice.
+func (set *MergedNodeSet) Merge(other *NodeSet) error {
+	if err := set.merge(other); err != nil {
+		return err
+	}
+	if r := registeredExtras; r.Registered() {
+		return r.Get().hooks.hooksFromMNS(set).Merge(set, other)
+	}
+	return nil
+}
+
+func (set *NodeSet) mergePayload(path []byte, n *Node) {
+	if r := registeredExtras; r.Registered() {
+		r.Get().hooks.hooksFromNS(set).Add(set, path, n)
+	}
+}
+
+// ExtraPayloads
+type ExtraPayloads[
+	MNS MergedNodeSetHooks,
+	NS NodeSetHooks,
+	N any,
+] struct {
+	MergedNodeSet pseudo.Accessor[*MergedNodeSet, MNS]
+	NodeSet       pseudo.Accessor[*NodeSet, NS]
+	Node          pseudo.Accessor[*Node, N]
+}
+
+func (e ExtraPayloads[MNS, NS, N]) hooksFromMNS(s *MergedNodeSet) MergedNodeSetHooks {
+	return e.MergedNodeSet.Get(s)
+}
+
+func (e ExtraPayloads[MNS, NS, N]) hooksFromNS(s *NodeSet) NodeSetHooks {
+	return e.NodeSet.Get(s)
+}
+
+func extraPayloadOrSetDefault(field **pseudo.Type, construct func(*extraConstructors) *pseudo.Type) *pseudo.Type {
+	r := registeredExtras
+	if !r.Registered() {
+		// See params.ChainConfig.extraPayload() for panic rationale.
+		panic("<T>.extraPayload() called before RegisterExtras()")
+	}
+	if *field == nil {
+		*field = construct(r.Get())
+	}
+	return *field
+}
+
+func (set *MergedNodeSet) extraPayload() *pseudo.Type {
+	return extraPayloadOrSetDefault(&set.extra, func(c *extraConstructors) *pseudo.Type {
+		return c.newMergedNodeSet()
+	})
+}
+
+func (set *NodeSet) extraPayload() *pseudo.Type {
+	return extraPayloadOrSetDefault(&set.extra, func(c *extraConstructors) *pseudo.Type {
+		return c.newNodeSet()
+	})
+}
+
+func (n *Node) extraPayload() *pseudo.Type {
+	return extraPayloadOrSetDefault(&n.extra, func(c *extraConstructors) *pseudo.Type {
+		return c.newNode()
+	})
+}

--- a/trie/trienode/node.libevm.go
+++ b/trie/trienode/node.libevm.go
@@ -23,12 +23,16 @@ import (
 
 // MergedNodeSetHooks are called as part of standard [MergedNodeSet] behaviour.
 type MergedNodeSetHooks interface {
-	AfterMergeNodeSet(into *MergedNodeSet, _ *NodeSet) error
+	// AfterMergeNodeSet is called at the end of [MergedNodeSet.Merge], with the
+	// method receiver and argument propagated.
+	AfterMergeNodeSet(receiver *MergedNodeSet, _ *NodeSet) error
 }
 
 // NodeSetHooks are called as part of standard [NodeSet] behaviour.
 type NodeSetHooks interface {
-	AfterAddNode(into *NodeSet, path []byte, _ *Node)
+	// AfterAddNode is called at the end of [NodeSet.AddNode], with the method
+	// receiver and arguments propagated.
+	AfterAddNode(receiver *NodeSet, path []byte, _ *Node)
 }
 
 // RegisterExtras registers types `MNSPtr`, `NSPtr`, and `N` to be carried as

--- a/trie/trienode/node.libevm_test.go
+++ b/trie/trienode/node.libevm_test.go
@@ -20,9 +20,10 @@ import (
 	"maps"
 	"testing"
 
-	"github.com/ava-labs/libevm/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/libevm/common"
 )
 
 type nodePayload struct {

--- a/trie/trienode/node.libevm_test.go
+++ b/trie/trienode/node.libevm_test.go
@@ -33,7 +33,7 @@ type setPayload struct {
 	added map[string]uint64
 }
 
-func (p *setPayload) Add(_ *NodeSet, path []byte, n *Node) {
+func (p *setPayload) AddNode(_ *NodeSet, path []byte, n *Node) {
 	if p.added == nil {
 		p.added = make(map[string]uint64)
 	}
@@ -44,7 +44,7 @@ type mergedSetPayload struct {
 	merged []map[string]uint64
 }
 
-func (p *mergedSetPayload) Merge(_ *MergedNodeSet, ns *NodeSet) error {
+func (p *mergedSetPayload) MergeNodeSet(_ *MergedNodeSet, ns *NodeSet) error {
 	p.merged = append(p.merged, maps.Clone(extras.NodeSet.Get(ns).added))
 	return nil
 }

--- a/trie/trienode/node.libevm_test.go
+++ b/trie/trienode/node.libevm_test.go
@@ -33,7 +33,7 @@ type setPayload struct {
 	added map[string]uint64
 }
 
-func (p *setPayload) AddNode(_ *NodeSet, path []byte, n *Node) {
+func (p *setPayload) AfterAddNode(_ *NodeSet, path []byte, n *Node) {
 	if p.added == nil {
 		p.added = make(map[string]uint64)
 	}
@@ -44,21 +44,21 @@ type mergedSetPayload struct {
 	merged []map[string]uint64
 }
 
-func (p *mergedSetPayload) MergeNodeSet(_ *MergedNodeSet, ns *NodeSet) error {
+func (p *mergedSetPayload) AfterMergeNodeSet(_ *MergedNodeSet, ns *NodeSet) error {
 	p.merged = append(p.merged, maps.Clone(extras.NodeSet.Get(ns).added))
 	return nil
 }
 
-var extras ExtraPayloads[*mergedSetPayload, *setPayload, nodePayload]
+var extras ExtraPayloads[*mergedSetPayload, *setPayload, *nodePayload]
 
 func TestExtras(t *testing.T) {
 	extras = RegisterExtras[mergedSetPayload, setPayload, nodePayload]()
 	t.Cleanup(TestOnlyClearRegisteredExtras)
 
 	n1 := New(common.Hash{0}, nil)
-	extras.Node.Set(n1, nodePayload{x: 1})
+	extras.Node.Set(n1, &nodePayload{x: 1})
 	n42 := New(common.Hash{1}, nil)
-	extras.Node.Set(n42, nodePayload{x: 42})
+	extras.Node.Set(n42, &nodePayload{x: 42})
 
 	set := NewNodeSet(common.Hash{})
 	merge := NewMergedNodeSet()

--- a/trie/trienode/node.libevm_test.go
+++ b/trie/trienode/node.libevm_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package trienode
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+type nodePayload struct {
+	x uint64
+}
+
+type setPayload struct {
+	added map[string]uint64
+}
+
+func (p *setPayload) Add(_ *NodeSet, path []byte, n *Node) {
+	if p.added == nil {
+		p.added = make(map[string]uint64)
+	}
+	p.added[string(path)] = extras.Node.Get(n).x
+}
+
+type mergedSetPayload struct {
+	merged []map[string]uint64
+}
+
+func (p *mergedSetPayload) Merge(_ *MergedNodeSet, ns *NodeSet) error {
+	p.merged = append(p.merged, maps.Clone(extras.NodeSet.Get(ns).added))
+	return nil
+}
+
+var extras ExtraPayloads[*mergedSetPayload, *setPayload, nodePayload]
+
+func TestExtras(t *testing.T) {
+	extras = RegisterExtras[mergedSetPayload, setPayload, nodePayload]()
+	t.Cleanup(TestOnlyClearRegisteredExtras)
+
+	n1 := New(common.Hash{0}, nil)
+	extras.Node.Set(n1, nodePayload{x: 1})
+	n42 := New(common.Hash{1}, nil)
+	extras.Node.Set(n42, nodePayload{x: 42})
+
+	set := NewNodeSet(common.Hash{})
+	merge := NewMergedNodeSet()
+	set.AddNode([]byte("n1"), n1)
+	require.NoError(t, merge.Merge(set))
+
+	set.AddNode([]byte("n42"), n42)
+	require.NoError(t, merge.Merge(set))
+
+	got := extras.MergedNodeSet.Get(merge).merged
+	want := []map[string]uint64{
+		{
+			"n1": 1,
+		},
+		{
+			"n1":  1,
+			"n42": 42,
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("%T payload diff (-want +got):\n%s", merge, diff)
+	}
+}


### PR DESCRIPTION
## Why this should be merged

Preparatory work for support of Firewood as a `triedb.DBOverride`.

## How this works

1. `trienode` package has `pseudo` payloads added to nodes and sets, with hooks to allow the payloads to be propagated along with set mergers.
2. The `NodeSet` and `MergedNodeSet` payloads are used to propagate Firewood proposal handles from `Trie.Commit()` through to `triedb.BackendDB.Update()`, along with GC management to free Rust-owned proposals. THe handles are currently only dummies, used as plumbing.

## How this was tested

Integration tests of both (1) and (2). The `firewood` tests exercise the entire stack from `state.StateDB` down to `triedb` backend implementation (which will be Firewood).