### PR TITLE
chore: Cherry-pick rpc: avoid unnecessary RST_STREAM, PING frames sent by client

### DIFF
--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -96,7 +96,7 @@ func confirmHTTPRequestYieldsStatusCode(t *testing.T, method, contentType, body 
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	resp.Body.Close()
+	cleanlyCloseBody(resp.Body)
 	confirmStatusCode(t, resp.StatusCode, expectedStatusCode)
 }
 


### PR DESCRIPTION
See original `go-ethereum` PR for context: https://github.com/ethereum/go-ethereum/pull/33122

This commit should be added to the tracker in https://github.com/ava-labs/libevm/issues/128 once merged.