### PR TITLE
feat: Add packing methods to accounts.abi

### DIFF
--- a/accounts/abi/abi.libevm.go
+++ b/accounts/abi/abi.libevm.go
@@ -1,0 +1,87 @@
+// Copyright 2024-2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/libevm/common"
+)
+
+// PackEvent packs the given event name and arguments to conform the ABI.
+// Returns the topics for the event including the event signature (if non-anonymous event) and
+// hashes derived from indexed arguments and the packed data of non-indexed args according to
+// the event ABI specification.
+// The order of arguments must match the order of the event definition.
+// https://docs.soliditylang.org/en/v0.8.17/abi-spec.html#indexed-event-encoding.
+// Note: PackEvent does not support array (fixed or dynamic-size) or struct types.
+func (abi ABI) PackEvent(name string, args ...interface{}) ([]common.Hash, []byte, error) {
+	event, exist := abi.Events[name]
+	if !exist {
+		return nil, nil, fmt.Errorf("event '%s' not found", name)
+	}
+	if len(args) != len(event.Inputs) {
+		return nil, nil, fmt.Errorf("event '%s' unexpected number of inputs %d", name, len(args))
+	}
+
+	var (
+		nonIndexedInputs = make([]interface{}, 0)
+		indexedInputs    = make([]interface{}, 0)
+		nonIndexedArgs   Arguments
+		indexedArgs      Arguments
+	)
+
+	for i, arg := range event.Inputs {
+		if arg.Indexed {
+			indexedArgs = append(indexedArgs, arg)
+			indexedInputs = append(indexedInputs, args[i])
+		} else {
+			nonIndexedArgs = append(nonIndexedArgs, arg)
+			nonIndexedInputs = append(nonIndexedInputs, args[i])
+		}
+	}
+
+	packedArguments, err := nonIndexedArgs.Pack(nonIndexedInputs...)
+	if err != nil {
+		return nil, nil, err
+	}
+	topics := make([]common.Hash, 0, len(indexedArgs)+1)
+	if !event.Anonymous {
+		topics = append(topics, event.ID)
+	}
+	indexedTopics, err := PackTopics(indexedInputs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return append(topics, indexedTopics...), packedArguments, nil
+}
+
+// PackOutput packs the given [args] as the output of given method [name] to conform the ABI.
+// This does not include method ID.
+func (abi ABI) PackOutput(name string, args ...interface{}) ([]byte, error) {
+	// Fetch the ABI of the requested method
+	method, exist := abi.Methods[name]
+	if !exist {
+		return nil, fmt.Errorf("method '%s' not found", name)
+	}
+	arguments, err := method.Outputs.Pack(args...)
+	if err != nil {
+		return nil, err
+	}
+	return arguments, nil
+}

--- a/accounts/abi/abi.libevm_test.go
+++ b/accounts/abi/abi.libevm_test.go
@@ -1,0 +1,218 @@
+// Copyright 2024-2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"bytes"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const TestABI = `[{"type":"function","name":"receive","inputs":[{"name":"sender","type":"address"},{"name":"amount","type":"uint256"},{"name":"memo","type":"bytes"}],"outputs":[{"internalType":"bool","name":"isAllowed","type":"bool"}]}]`
+
+func TestABI_PackEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		json           string
+		event          string
+		args           []interface{}
+		expectedTopics []common.Hash
+		expectedData   []byte
+	}{
+		{
+			name: "received",
+			json: `[
+			{"type":"event","name":"received","anonymous":false,"inputs":[
+				{"indexed":false,"name":"sender","type":"address"},
+				{"indexed":false,"name":"amount","type":"uint256"},
+				{"indexed":false,"name":"memo","type":"bytes"}
+				]
+			}]`,
+			event: "received(address,uint256,bytes)",
+			args: []interface{}{
+				common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
+				big.NewInt(1),
+				[]byte{0x88},
+			},
+			expectedTopics: []common.Hash{
+				common.HexToHash("0x75fd880d39c1daf53b6547ab6cb59451fc6452d27caa90e5b6649dd8293b9eed"),
+			},
+			expectedData: common.Hex2Bytes("000000000000000000000000376c47978271565f56deb45495afa69e59c16ab20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000018800000000000000000000000000000000000000000000000000000000000000"),
+		},
+		{
+			name: "received",
+			json: `[
+			{"type":"event","name":"received","anonymous":true,"inputs":[
+				{"indexed":false,"name":"sender","type":"address"},
+				{"indexed":false,"name":"amount","type":"uint256"},
+				{"indexed":false,"name":"memo","type":"bytes"}
+				]
+			}]`,
+			event: "received(address,uint256,bytes)",
+			args: []interface{}{
+				common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
+				big.NewInt(1),
+				[]byte{0x88},
+			},
+			expectedTopics: []common.Hash{},
+			expectedData:   common.Hex2Bytes("000000000000000000000000376c47978271565f56deb45495afa69e59c16ab20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000018800000000000000000000000000000000000000000000000000000000000000"),
+		}, {
+			name: "Transfer",
+			json: `[
+				{ "constant": true, "inputs": [], "name": "name", "outputs": [ { "name": "", "type": "string" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_spender", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "approve", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "totalSupply", "outputs": [ { "name": "", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_from", "type": "address" }, { "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "transferFrom", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "decimals", "outputs": [ { "name": "", "type": "uint8" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": true, "inputs": [ { "name": "_owner", "type": "address" } ], "name": "balanceOf", "outputs": [ { "name": "balance", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "symbol", "outputs": [ { "name": "", "type": "string" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "transfer", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [ { "name": "_owner", "type": "address" }, { "name": "_spender", "type": "address" } ], "name": "allowance", "outputs": [ { "name": "", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "payable": true, "stateMutability": "payable", "type": "fallback" },
+				{ "anonymous": false, "inputs": [ { "indexed": true, "name": "owner", "type": "address" }, { "indexed": true, "name": "spender", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" } ], "name": "Approval", "type": "event" },
+				{ "anonymous": false, "inputs": [ { "indexed": true, "name": "from", "type": "address" }, { "indexed": true, "name": "to", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" } ], "name": "Transfer", "type": "event" }
+			]`,
+			event: "Transfer(address,address,uint256)",
+			args: []interface{}{
+				common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
+				common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
+				big.NewInt(100),
+			},
+			expectedTopics: []common.Hash{
+				common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+				common.HexToHash("0x0000000000000000000000008db97c7cece249c2b98bdc0226cc4c2a57bf52fc"),
+				common.HexToHash("0x000000000000000000000000376c47978271565f56deb45495afa69e59c16ab2"),
+			},
+			expectedData: common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000064"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			abi, err := JSON(strings.NewReader(test.json))
+			if err != nil {
+				t.Error(err)
+			}
+
+			topics, data, err := abi.PackEvent(test.name, test.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.EqualValues(t, test.expectedTopics, topics)
+			assert.EqualValues(t, test.expectedData, data)
+		})
+	}
+}
+
+func TestUnpackInputIntoInterface(t *testing.T) {
+	abi, err := JSON(strings.NewReader(TestABI))
+	require.NoError(t, err)
+
+	type inputType struct {
+		Sender common.Address
+		Amount *big.Int
+		Memo   []byte
+	}
+	input := inputType{
+		Sender: common.HexToAddress("0x02"),
+		Amount: big.NewInt(100),
+		Memo:   []byte("hello"),
+	}
+
+	rawData, err := abi.Pack("receive", input.Sender, input.Amount, input.Memo)
+	require.NoError(t, err)
+
+	abi, err = JSON(strings.NewReader(TestABI))
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name                   string
+		extraPaddingBytes      int
+		strictMode             bool
+		expectedErrorSubstring string
+	}{
+		{
+			name:       "No extra padding to input data",
+			strictMode: true,
+		},
+		{
+			name:              "Valid input data with 32 extra padding(%32) ",
+			extraPaddingBytes: 32,
+			strictMode:        true,
+		},
+		{
+			name:              "Valid input data with 64 extra padding(%32)",
+			extraPaddingBytes: 64,
+			strictMode:        true,
+		},
+		{
+			name:                   "Valid input data with extra padding indivisible by 32",
+			extraPaddingBytes:      33,
+			strictMode:             true,
+			expectedErrorSubstring: "abi: improperly formatted input:",
+		},
+		{
+			name:              "Valid input data with extra padding indivisible by 32, no strict mode",
+			extraPaddingBytes: 33,
+			strictMode:        false,
+		},
+	} {
+		{
+			t.Run(test.name, func(t *testing.T) {
+				// skip 4 byte selector
+				data := rawData[4:]
+				// Add extra padding to data
+				data = append(data, make([]byte, test.extraPaddingBytes)...)
+
+				// Unpack into interface
+				var v inputType
+				err = abi.UnpackInputIntoInterface(&v, "receive", data, test.strictMode) // skips 4 byte selector
+
+				if test.expectedErrorSubstring != "" {
+					require.Error(t, err)
+					require.ErrorContains(t, err, test.expectedErrorSubstring)
+				} else {
+					require.NoError(t, err)
+					// Verify unpacked values match input
+					require.Equal(t, v.Amount, input.Amount)
+					require.EqualValues(t, v.Amount, input.Amount)
+					require.True(t, bytes.Equal(v.Memo, input.Memo))
+				}
+			})
+		}
+	}
+}
+
+func TestPackOutput(t *testing.T) {
+	abi, err := JSON(strings.NewReader(TestABI))
+	require.NoError(t, err)
+
+	bytes, err := abi.PackOutput("receive", true)
+	require.NoError(t, err)
+
+	vals, err := abi.Methods["receive"].Outputs.Unpack(bytes)
+	require.NoError(t, err)
+
+	require.Len(t, vals, 1)
+	require.True(t, vals[0].(bool))
+}

--- a/accounts/abi/abi.libevm_test.go
+++ b/accounts/abi/abi.libevm_test.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ava-labs/libevm/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/libevm/common"
 )
 
 const TestABI = `[{"type":"function","name":"receive","inputs":[{"name":"sender","type":"address"},{"name":"amount","type":"uint256"},{"name":"memo","type":"bytes"}],"outputs":[{"internalType":"bool","name":"isAllowed","type":"bool"}]}]`
@@ -214,5 +215,8 @@ func TestPackOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, vals, 1)
-	require.True(t, vals[0].(bool))
+
+	boolVal, ok := vals[0].(bool)
+	require.True(t, ok)
+	require.True(t, boolVal)
 }

--- a/accounts/abi/topics.libevm.go
+++ b/accounts/abi/topics.libevm.go
@@ -1,0 +1,109 @@
+// Copyright 2024-2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/common/math"
+	"github.com/ava-labs/libevm/crypto"
+)
+
+// packTopic packs rule into the corresponding hash value for a log's topic
+// according to the Solidity documentation:
+// https://docs.soliditylang.org/en/v0.8.17/abi-spec.html#indexed-event-encoding.
+func packTopic(rule interface{}) (common.Hash, error) {
+	var topic common.Hash
+
+	// Try to generate the topic based on simple types
+	switch rule := rule.(type) {
+	case common.Hash:
+		copy(topic[:], rule[:])
+	case common.Address:
+		copy(topic[common.HashLength-common.AddressLength:], rule[:])
+	case *big.Int:
+		copy(topic[:], math.U256Bytes(rule))
+	case bool:
+		if rule {
+			topic[common.HashLength-1] = 1
+		}
+	case int8:
+		copy(topic[:], genIntType(int64(rule), 1))
+	case int16:
+		copy(topic[:], genIntType(int64(rule), 2))
+	case int32:
+		copy(topic[:], genIntType(int64(rule), 4))
+	case int64:
+		copy(topic[:], genIntType(rule, 8))
+	case uint8:
+		blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case uint16:
+		blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case uint32:
+		blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case uint64:
+		blob := new(big.Int).SetUint64(rule).Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case string:
+		hash := crypto.Keccak256Hash([]byte(rule))
+		copy(topic[:], hash[:])
+	case []byte:
+		hash := crypto.Keccak256Hash(rule)
+		copy(topic[:], hash[:])
+
+	default:
+		// todo(rjl493456442) according to solidity documentation, indexed event
+		// parameters that are not value types i.e. arrays and structs are not
+		// stored directly but instead a keccak256-hash of an encoding is stored.
+		//
+		// We only convert strings and bytes to hash, still need to deal with
+		// array(both fixed-size and dynamic-size) and struct.
+
+		// Attempt to generate the topic from funky types
+		val := reflect.ValueOf(rule)
+		switch {
+		// static byte array
+		case val.Kind() == reflect.Array && reflect.TypeOf(rule).Elem().Kind() == reflect.Uint8:
+			reflect.Copy(reflect.ValueOf(topic[:val.Len()]), val)
+		default:
+			return common.Hash{}, fmt.Errorf("unsupported indexed type: %T", rule)
+		}
+	}
+	return topic, nil
+}
+
+// PackTopics packs the array of filters into an array of corresponding topics
+// according to the Solidity documentation.
+// Note: PackTopics does not support array (fixed or dynamic-size) or struct types.
+func PackTopics(filter []interface{}) ([]common.Hash, error) {
+	topics := make([]common.Hash, len(filter))
+	for i, rule := range filter {
+		topic, err := packTopic(rule)
+		if err != nil {
+			return nil, err
+		}
+		topics[i] = topic
+	}
+
+	return topics, nil
+}


### PR DESCRIPTION
## Why this should be merged

Provides methods that ICM was using from `subnet-evm` `accounts.ABI` and brings us closer to being able to use `libevm`'s `abigen` binary. 

## How this works

- Adds `PackOutput` and `PackEvent` methods to the ABI structs.  These are the only ones that are missing for ICM's functionality and are included in the first commit.
- Adds other missing methods in the second commit
- Re-uses tests for these that were previously in `subnet-evm` in the third commit

## How this was tested

- Tests transferred over from `subnet-evm` pass 
- Confirmed it works in the ICM testing as well by including this via `replace` directive in `go.mod`
