### PR TITLE
fix: do not expose eth_close from the FilterAPI

### DIFF
--- a/eth/filters/api.libevm.go
+++ b/eth/filters/api.libevm.go
@@ -16,7 +16,9 @@
 
 package filters
 
-// Close releases resources held by the API.
-func (api *FilterAPI) Close() {
+// CloseAPI releases resources held by the API.
+//
+// This is not implemented as a method to avoid exposing it via RPC.
+func CloseAPI(api *FilterAPI) {
 	close(api.quit)
 }

--- a/eth/filters/api.libevm_test.go
+++ b/eth/filters/api.libevm_test.go
@@ -53,5 +53,5 @@ func TestClose(t *testing.T) {
 	defer backend.Close()
 	sys := NewFilterSystem(backend, Config{})
 	api := NewFilterAPI(sys, false)
-	api.Close()
+	CloseAPI(api)
 }


### PR DESCRIPTION
## Why this should be merged

Currently, `eth_close` is being registered as an available RPC due to `Close` being an exported function on the `FilterAPI`.

## How this works

Converts the method to a function that takes in the API.

## How this was tested

Updated unit test.