### PR TITLE
feat: Add `UnpackInputs` to ABI

### DIFF
--- a/accounts/abi/abi.libevm.go
+++ b/accounts/abi/abi.libevm.go
@@ -105,6 +105,19 @@ func (abi ABI) UnpackInputIntoInterface(v any, methodOrEventName string, data []
 	return in.Copy(v, unpacked)
 }
 
+// UnpackInput is equivalent to [ABI.Unpack], with all the same caveats, except
+// that it treats `data` as:
+//
+//  1. Input when handling a method; or
+//  2. Unindexed data when handling an event.
+func (abi ABI) UnpackInput(methodOrEventName string, data []byte) ([]any, error) {
+	in, err := abi.methodOrEventInputs(methodOrEventName)
+	if err != nil {
+		return nil, err
+	}
+	return in.Unpack(data)
+}
+
 func (abi ABI) methodOrEventInputs(name string) (Arguments, error) {
 	if m, ok := abi.Methods[name]; ok {
 		return m.Inputs, nil

--- a/accounts/abi/abi.libevm.go
+++ b/accounts/abi/abi.libevm.go
@@ -93,10 +93,8 @@ func (abi ABI) PackOutput(method string, args ...any) ([]byte, error) {
 //
 //  1. Input when handling a method; or
 //  2. Unindexed data when handling an event.
-//  3. If useStrictLength is true, an error is returned if the length of data
-//     does not exactly match the expected length of 32.
-func (abi ABI) UnpackInputIntoInterface(v any, methodOrEventName string, data []byte, useStrictLength bool) error {
-	in, err := abi.methodOrEventInputs(methodOrEventName, data, useStrictLength)
+func (abi ABI) UnpackInputIntoInterface(v any, methodOrEventName string, data []byte) error {
+	in, err := abi.methodOrEventInputs(methodOrEventName)
 	if err != nil {
 		return err
 	}
@@ -112,21 +110,16 @@ func (abi ABI) UnpackInputIntoInterface(v any, methodOrEventName string, data []
 //
 //  1. Input when handling a method; or
 //  2. Unindexed data when handling an event.
-//  3. If useStrictLength is true, an error is returned if the length of data
-//     does not exactly match the expected length of 32.
-func (abi ABI) UnpackInput(methodOrEventName string, data []byte, useStrictLength bool) ([]any, error) {
-	in, err := abi.methodOrEventInputs(methodOrEventName, data, useStrictLength)
+func (abi ABI) UnpackInput(methodOrEventName string, data []byte) ([]any, error) {
+	in, err := abi.methodOrEventInputs(methodOrEventName)
 	if err != nil {
 		return nil, err
 	}
 	return in.Unpack(data)
 }
 
-func (abi ABI) methodOrEventInputs(name string, data []byte, useStrictLength bool) (Arguments, error) {
+func (abi ABI) methodOrEventInputs(name string) (Arguments, error) {
 	if m, ok := abi.Methods[name]; ok {
-		if useStrictLength && len(data)%32 != 0 {
-			return nil, fmt.Errorf("method %q input data length %d is not a multiple of 32", name, len(data))
-		}
 		return m.Inputs, nil
 	}
 	if ev, ok := abi.Events[name]; ok {

--- a/accounts/abi/abi.libevm_test.go
+++ b/accounts/abi/abi.libevm_test.go
@@ -152,7 +152,7 @@ func TestEventPackingRoundTrip(t *testing.T) {
 				require.Equal(t, reflect.Pointer, typ.Kind(), "unpacking type MUST be a pointer")
 
 				got := reflect.New(typ.Elem()).Interface()
-				require.NoError(t, abi.UnpackInputIntoInterface(got, test.eventName, test.wantData, true))
+				require.NoError(t, abi.UnpackInputIntoInterface(got, test.eventName, test.wantData))
 
 				if diff := cmp.Diff(test.wantUnpacked, got, compareBigInts()); diff != "" {
 					t.Errorf("%T.UnpackInputIntoInterface(%T) diff (-want +got):\n%s", abi, got, diff)
@@ -252,7 +252,7 @@ func TestUnpackWithPadding(t *testing.T) {
 			t.Run("UnpackInputIntoInterface", func(t *testing.T) {
 				var got receiveFuncInput
 
-				require.NoErrorf(t, abi.UnpackInputIntoInterface(&got, method, data, false), "%T.UnpackInputIntoInterface()", abi)
+				require.NoErrorf(t, abi.UnpackInputIntoInterface(&got, method, data), "%T.UnpackInputIntoInterface()", abi)
 
 				if diff := cmp.Diff(input, got, compareBigInts()); diff != "" {
 					t.Errorf("%T.Pack() -> %T.UnpackInputIntoInterface(%T, ...) round-trip diff (-want +got):\n%s", abi, abi, got, diff)
@@ -260,7 +260,7 @@ func TestUnpackWithPadding(t *testing.T) {
 			})
 
 			t.Run("UnpackInput", func(t *testing.T) {
-				res, err := abi.UnpackInput(method, data, false)
+				res, err := abi.UnpackInput(method, data)
 				require.NoErrorf(t, err, "%T.UnpackInput()", abi)
 
 				s, ok := res[0].(common.Address)

--- a/accounts/abi/abi.libevm_test.go
+++ b/accounts/abi/abi.libevm_test.go
@@ -152,7 +152,7 @@ func TestEventPackingRoundTrip(t *testing.T) {
 				require.Equal(t, reflect.Pointer, typ.Kind(), "unpacking type MUST be a pointer")
 
 				got := reflect.New(typ.Elem()).Interface()
-				require.NoError(t, abi.UnpackInputIntoInterface(got, test.eventName, test.wantData))
+				require.NoError(t, abi.UnpackInputIntoInterface(got, test.eventName, test.wantData, true))
 
 				if diff := cmp.Diff(test.wantUnpacked, got, compareBigInts()); diff != "" {
 					t.Errorf("%T.UnpackInputIntoInterface(%T) diff (-want +got):\n%s", abi, got, diff)
@@ -252,7 +252,7 @@ func TestUnpackWithPadding(t *testing.T) {
 			t.Run("UnpackInputIntoInterface", func(t *testing.T) {
 				var got receiveFuncInput
 
-				require.NoErrorf(t, abi.UnpackInputIntoInterface(&got, method, data), "%T.UnpackInputIntoInterface()", abi)
+				require.NoErrorf(t, abi.UnpackInputIntoInterface(&got, method, data, false), "%T.UnpackInputIntoInterface()", abi)
 
 				if diff := cmp.Diff(input, got, compareBigInts()); diff != "" {
 					t.Errorf("%T.Pack() -> %T.UnpackInputIntoInterface(%T, ...) round-trip diff (-want +got):\n%s", abi, abi, got, diff)
@@ -260,7 +260,7 @@ func TestUnpackWithPadding(t *testing.T) {
 			})
 
 			t.Run("UnpackInput", func(t *testing.T) {
-				res, err := abi.UnpackInput(method, data)
+				res, err := abi.UnpackInput(method, data, false)
 				require.NoErrorf(t, err, "%T.UnpackInput()", abi)
 
 				s, ok := res[0].(common.Address)

--- a/accounts/abi/abi.libevm_test.go
+++ b/accounts/abi/abi.libevm_test.go
@@ -209,7 +209,7 @@ func init() {
 	}
 }
 
-func TestUnpackWithPadding(t *testing.T) {
+func TestUnpackInputWithPadding(t *testing.T) {
 	tests := []struct {
 		name              string
 		extraPaddingBytes int
@@ -262,6 +262,7 @@ func TestUnpackWithPadding(t *testing.T) {
 			t.Run("UnpackInput", func(t *testing.T) {
 				res, err := abi.UnpackInput(method, data)
 				require.NoErrorf(t, err, "%T.UnpackInput()", abi)
+				require.Len(t, res, 3, "expected 3 unpacked arguments")
 
 				s, ok := res[0].(common.Address)
 				require.True(t, ok, "expected arg 0 to be common.Address")


### PR DESCRIPTION
## Why this should be merged

See ava-labs/avalanchego#4865

## How this works

Expands upon `abi.UnpackInputIntoInterface` to return a list of `any`

## How this was tested

Appended to UT
