### PR TITLE
feat: expose ethapi.RPCTransaction

### DIFF
--- a/libevm/ethapi/ethapi.go
+++ b/libevm/ethapi/ethapi.go
@@ -40,6 +40,11 @@ type (
 	DebugAPI = ethapi.DebugAPI
 )
 
+// Type aliases for types used as arguments or responses to the APIs.
+type (
+	RPCTransaction = ethapi.RPCTransaction
+)
+
 // NewEthereumAPI is identical to [ethapi.NewEthereumAPI].
 func NewEthereumAPI(b Backend) *EthereumAPI {
 	return ethapi.NewEthereumAPI(b)


### PR DESCRIPTION
## Why this should be merged

Supports testing `txpool` APIs in SAE.

## How this works

Exposes the type.

## How this was tested

N/A