### PR TITLE
test: add log handler for error promotion to `testing.TB`

### DIFF
--- a/libevm/ethtest/log.go
+++ b/libevm/ethtest/log.go
@@ -1,0 +1,46 @@
+package ethtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ava-labs/libevm/log"
+	"golang.org/x/exp/slog"
+)
+
+// NewTBHandler constructs a [slog.Handler] that propagates logs to [testing.TB].
+// Logs at [log.LevelWarn] or above go to [testing.TB.Errorf], except
+// [log.LevelCrit] which goes to [testing.TB.Fatalf]. All other logs go to
+// [testing.TB.Logf].
+//
+//nolint:thelper // The outputs include the logging site while the TB site is most useful if here
+func NewTBHandler(tb testing.TB) slog.Handler {
+	return &tbHandler{tb: tb}
+}
+
+type tbHandler struct {
+	tb testing.TB
+}
+
+func (h *tbHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= log.LevelWarn
+}
+
+func (h *tbHandler) Handle(_ context.Context, r slog.Record) error {
+	var to func(string, ...any)
+	switch {
+	case r.Level >= log.LevelCrit:
+		to = h.tb.Fatalf
+	case r.Level >= log.LevelWarn:
+		to = h.tb.Errorf
+	default:
+		to = h.tb.Logf
+	}
+	to("[%s] %s", log.LevelAlignedString(r.Level), r.Message)
+	return nil
+}
+
+// WithAttrs and WithGroup return the receiver unchanged. Attribute/group
+// context is not needed for test failure detection.
+func (h *tbHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *tbHandler) WithGroup(string) slog.Handler      { return h }

--- a/libevm/ethtest/log.go
+++ b/libevm/ethtest/log.go
@@ -46,7 +46,7 @@ type tbHandler struct {
 }
 
 func (h *tbHandler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= h.level
+	return level >= min(h.level, slog.LevelWarn)
 }
 
 func (h *tbHandler) Handle(_ context.Context, r slog.Record) error {

--- a/libevm/ethtest/log.go
+++ b/libevm/ethtest/log.go
@@ -8,13 +8,13 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-// NewTBHandler constructs a [slog.Handler] that propagates logs to [testing.TB].
+// NewTBLogHandler constructs a [slog.Handler] that propagates logs to [testing.TB].
 // Logs at [log.LevelWarn] or above go to [testing.TB.Errorf], except
 // [log.LevelCrit] which goes to [testing.TB.Fatalf]. All other logs go to
 // [testing.TB.Logf].
 //
 //nolint:thelper // The outputs include the logging site while the TB site is most useful if here
-func NewTBHandler(tb testing.TB) slog.Handler {
+func NewTBLogHandler(tb testing.TB) slog.Handler {
 	return &tbHandler{tb: tb}
 }
 

--- a/libevm/ethtest/log.go
+++ b/libevm/ethtest/log.go
@@ -1,4 +1,4 @@
-// Copyright 2025 the libevm authors.
+// Copyright 2026 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License

--- a/libevm/ethtest/log.go
+++ b/libevm/ethtest/log.go
@@ -49,7 +49,7 @@ func (h *tbHandler) Enabled(_ context.Context, level slog.Level) bool {
 	return level >= min(h.level, slog.LevelWarn)
 }
 
-func (h *tbHandler) Handle(_ context.Context, r slog.Record) error {
+func (h *tbHandler) Handle(_ context.Context, rec slog.Record) error {
 	to := h.tb.Logf
 	switch {
 	case r.Level >= log.LevelCrit:

--- a/libevm/ethtest/log.go
+++ b/libevm/ethtest/log.go
@@ -27,14 +27,12 @@ func (h *tbHandler) Enabled(_ context.Context, level slog.Level) bool {
 }
 
 func (h *tbHandler) Handle(_ context.Context, r slog.Record) error {
-	var to func(string, ...any)
+	to := h.tb.Logf
 	switch {
 	case r.Level >= log.LevelCrit:
 		to = h.tb.Fatalf
 	case r.Level >= log.LevelWarn:
 		to = h.tb.Errorf
-	default:
-		to = h.tb.Logf
 	}
 	to("[%s] %s", log.LevelAlignedString(r.Level), r.Message)
 	return nil

--- a/libevm/ethtest/log.go
+++ b/libevm/ethtest/log.go
@@ -21,8 +21,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/ava-labs/libevm/log"
 	"golang.org/x/exp/slog"
+
+	"github.com/ava-labs/libevm/log"
 )
 
 // NewTBLogHandler constructs a [slog.Handler] that propagates logs to [testing.TB].

--- a/libevm/ethtest/log.go
+++ b/libevm/ethtest/log.go
@@ -1,7 +1,24 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
 package ethtest
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/ava-labs/libevm/log"
@@ -11,19 +28,24 @@ import (
 // NewTBLogHandler constructs a [slog.Handler] that propagates logs to [testing.TB].
 // Logs at [log.LevelWarn] or above go to [testing.TB.Errorf], except
 // [log.LevelCrit] which goes to [testing.TB.Fatalf]. All other logs go to
-// [testing.TB.Logf].
+// [testing.TB.Logf]. The level parameter controls which logs are enabled.
 //
 //nolint:thelper // The outputs include the logging site while the TB site is most useful if here
-func NewTBLogHandler(tb testing.TB) slog.Handler {
-	return &tbHandler{tb: tb}
+func NewTBLogHandler(tb testing.TB, level slog.Level) slog.Handler {
+	return &tbHandler{
+		tb:    tb,
+		level: level,
+	}
 }
 
 type tbHandler struct {
-	tb testing.TB
+	tb    testing.TB
+	level slog.Level
+	attrs []slog.Attr
 }
 
 func (h *tbHandler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= log.LevelWarn
+	return level >= h.level
 }
 
 func (h *tbHandler) Handle(_ context.Context, r slog.Record) error {
@@ -34,11 +56,28 @@ func (h *tbHandler) Handle(_ context.Context, r slog.Record) error {
 	case r.Level >= log.LevelWarn:
 		to = h.tb.Errorf
 	}
-	to("[%s] %s", log.LevelAlignedString(r.Level), r.Message)
+
+	_, file, line, _ := runtime.Caller(3)
+
+	fields := make(map[string]any, len(h.attrs)+r.NumAttrs())
+	for _, attr := range h.attrs {
+		fields[attr.Key] = attr.Value.Any()
+	}
+	r.Attrs(func(attr slog.Attr) bool {
+		fields[attr.Key] = attr.Value.Any()
+		return true
+	})
+
+	to("[%s] %s %v - %s:%d", log.LevelAlignedString(r.Level), r.Message, fields, file, line)
 	return nil
 }
 
-// WithAttrs and WithGroup return the receiver unchanged. Attribute/group
-// context is not needed for test failure detection.
-func (h *tbHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h *tbHandler) WithGroup(string) slog.Handler      { return h }
+func (h *tbHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &tbHandler{
+		tb:    h.tb,
+		level: h.level,
+		attrs: append(h.attrs[:len(h.attrs):len(h.attrs)], attrs...),
+	}
+}
+
+func (h *tbHandler) WithGroup(string) slog.Handler { return h }

--- a/libevm/ethtest/logger.go
+++ b/libevm/ethtest/logger.go
@@ -77,7 +77,7 @@ func (h *tbHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &tbHandler{
 		tb:    h.tb,
 		level: h.level,
-		attrs: append(h.attrs[:len(h.attrs):len(h.attrs)], attrs...),
+		attrs: slices.Concat(slices.Clone(h.attrs), attrs),
 	}
 }
 

--- a/libevm/ethtest/logger.go
+++ b/libevm/ethtest/logger.go
@@ -52,24 +52,24 @@ func (h *tbHandler) Enabled(_ context.Context, level slog.Level) bool {
 func (h *tbHandler) Handle(_ context.Context, rec slog.Record) error {
 	to := h.tb.Logf
 	switch {
-	case r.Level >= log.LevelCrit:
+	case rec.Level >= log.LevelCrit:
 		to = h.tb.Fatalf
-	case r.Level >= log.LevelWarn:
+	case rec.Level >= log.LevelWarn:
 		to = h.tb.Errorf
 	}
 
 	_, file, line, _ := runtime.Caller(3)
 
-	fields := make(map[string]any, len(h.attrs)+r.NumAttrs())
-	for _, attr := range h.attrs {
-		fields[attr.Key] = attr.Value.Any()
+	fields := make(map[string]any, len(h.attrs)+rec.NumAttrs())
+	for _, a := range h.attrs {
+		fields[a.Key] = a.Value.Any()
 	}
-	r.Attrs(func(attr slog.Attr) bool {
-		fields[attr.Key] = attr.Value.Any()
+	rec.Attrs(func(a slog.Attr) bool {
+		fields[a.Key] = a.Value.Any()
 		return true
 	})
 
-	to("[%s] %s %v - %s:%d", log.LevelAlignedString(r.Level), r.Message, fields, file, line)
+	to("[%s] %s %v - %s:%d", log.LevelAlignedString(rec.Level), rec.Message, fields, file, line)
 	return nil
 }
 

--- a/libevm/ethtest/logger.go
+++ b/libevm/ethtest/logger.go
@@ -19,6 +19,7 @@ package ethtest
 import (
 	"context"
 	"runtime"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/slog"

--- a/libevm/ethtest/logger_test.go
+++ b/libevm/ethtest/logger_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 the libevm authors.
+// Copyright 2026 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License

--- a/libevm/ethtest/logger_test.go
+++ b/libevm/ethtest/logger_test.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slog"
 
 	"github.com/ava-labs/libevm/log"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type tbRecorder struct {

--- a/libevm/ethtest/logger_test.go
+++ b/libevm/ethtest/logger_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package ethtest
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/exp/slog"
+
+	"github.com/ava-labs/libevm/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tbRecorder struct {
+	testing.TB
+	logged, errored []string
+}
+
+func (r *tbRecorder) Logf(format string, a ...any) {
+	r.logged = append(r.logged, fmt.Sprintf(format, a...))
+}
+
+func (r *tbRecorder) Errorf(format string, a ...any) {
+	r.errored = append(r.errored, fmt.Sprintf(format, a...))
+}
+
+func TestTBLogHandler(t *testing.T) {
+	got := &tbRecorder{}
+	l := log.NewLogger(NewTBLogHandler(got, slog.LevelDebug))
+
+	l.Debug("Cockroach")            // Logf
+	l.Info("Hello", "who", "world") // Logf
+	l.Warn("Smoke")                 // Errorf
+	l.Error("Fire")                 // Errorf
+	// Crit will call os.Exit(1) so we don't test it.
+
+	require.Len(t, got.logged, 2, "Logf() calls")
+	require.Len(t, got.errored, 2, "Errorf() calls")
+
+	// Check simplest elements without being brittle about exact formatting
+	// See https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html.
+	assert.Contains(t, got.logged[0], "Cockroach")
+	assert.Contains(t, got.logged[1], "Hello")
+	assert.Contains(t, got.logged[1], "who")
+	assert.Contains(t, got.logged[1], "world")
+
+	assert.Contains(t, got.errored[0], "Smoke")
+	assert.Contains(t, got.errored[1], "Fire")
+}

--- a/libevm/hookstest/stub_test.go
+++ b/libevm/hookstest/stub_test.go
@@ -17,11 +17,9 @@
 package hookstest
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slog"
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
@@ -37,7 +35,7 @@ func TestSetupGenesisBlockWithStub(t *testing.T) {
 	// [log.Crit] being called.
 	l := log.Root()
 	t.Cleanup(func() { log.SetDefault(l) })
-	log.SetDefault(log.NewLogger(slog.NewTextHandler(os.Stderr, nil)))
+	log.SetDefault(log.NewLogger(ethtest.NewTBLogHandler(t, log.LevelDebug)))
 
 	stub := &Stub{}
 	extras := stub.Register(t)


### PR DESCRIPTION
This adds a test logger for libevm, that treats errors as they _should_ be treated. 

- Logs at `log.LevelWarn` and above trigger `t.Errorf()`, causing tests to fail
- Critical logs fail immediately: Logs at `log.LevelCrit` trigger `t.Fatalf()`                                                               
- Info/debug logs pass through: Lower severity logs use `t.Logf()` for informational output                                                        

You can use the logger like this: 

```go
  import (
      "github.com/ava-labs/libevm/ethtest"
      "github.com/ava-labs/libevm/log"
  )

  func TestSomething(t *testing.T) {
     logger := log.NewLogger(ethtest.NewTBLogHandler(t, log.LevelDebug))

     // Or to set globally
     log.SetDefault(log.NewLogger(ethtest.NewTBLogHandler(t, log.LevelDebug))
  }
```

I was thinking about adding tests to show this works, but it seemed silly to test a testing utility. 