### PR TITLE
feat: receipt marshalling for RPCs

### DIFF
--- a/internal/ethapi/api.libevm.go
+++ b/internal/ethapi/api.libevm.go
@@ -28,3 +28,8 @@ import (
 func NewRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, blockTime uint64, index uint64, baseFee *big.Int, config *params.ChainConfig) *RPCTransaction {
 	return newRPCTransaction(tx, blockHash, blockNumber, blockTime, index, baseFee, config)
 }
+
+// MarshalReceipt exports the [marshalReceipt] function.
+func MarshalReceipt(r *types.Receipt, blockHash common.Hash, blockNumber uint64, signer types.Signer, tx *types.Transaction, txIndex int) map[string]any {
+	return marshalReceipt(r, blockHash, blockNumber, signer, tx, txIndex)
+}

--- a/libevm/ethapi/ethapi.go
+++ b/libevm/ethapi/ethapi.go
@@ -86,3 +86,8 @@ func NewRPCPendingTransaction(tx *types.Transaction, current *types.Header, conf
 func NewRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, blockTime uint64, index uint64, baseFee *big.Int, config *params.ChainConfig) *RPCTransaction {
 	return ethapi.NewRPCTransaction(tx, blockHash, blockNumber, blockTime, index, baseFee, config)
 }
+
+// MarshalReceipt is identical to [ethapi.MarshalReceipt].
+func MarshalReceipt(r *types.Receipt, blockHash common.Hash, blockNumber uint64, signer types.Signer, tx *types.Transaction, txIndex int) map[string]any {
+	return ethapi.MarshalReceipt(r, blockHash, blockNumber, signer, tx, txIndex)
+}


### PR DESCRIPTION
## Why this should be merged

Allow SAE to provide direct `types.Receipt` access.

## How this works

Function aliases.

## How this was tested

n/a