### PR TITLE
export json fee history result

### DIFF
--- a/ethclient/ethclient.libevm.go
+++ b/ethclient/ethclient.libevm.go
@@ -1,0 +1,21 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package ethclient
+
+type (
+	FeeHistoryResult = feeHistoryResultMarshaling
+)

--- a/ethclient/ethclient.libevm.go
+++ b/ethclient/ethclient.libevm.go
@@ -16,6 +16,7 @@
 
 package ethclient
 
-type (
-	FeeHistoryResult = feeHistoryResultMarshaling
-)
+// FeeHistoryResult exports the internal type, used for JSON-marshalling
+// [Client.FeeHistory] RPC results, to be converted to [ethereum.FeeHistory]
+// values.
+type FeeHistoryResult = feeHistoryResultMarshaling


### PR DESCRIPTION
## Why this should be merged

We're reusing this in SAE tests.

See the request in SAE PR: https://github.com/ava-labs/strevm/pull/219#discussion_r2848570973

## How this works

Exposes the json marshallable struct type

## How this was tested

Tested in the relevant SAE tests.
