### PR TITLE
chore: export TxMaxSize

### DIFF
--- a/core/txpool/legacypool/legacypool.libevm.go
+++ b/core/txpool/legacypool/legacypool.libevm.go
@@ -1,0 +1,19 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package legacypool
+
+const TxMaxSize = txMaxSize


### PR DESCRIPTION
## Why this should be merged

Currently in libevm, transactions of any size are accepted, which should not be the case. Rather than rewriting the constant in `strevm` (which seems sort of hacky), I export it here in the style of other PRs. 

