### PR TITLE
feat: `eventual` context awareness

### DIFF
--- a/libevm/eventual/eventual.go
+++ b/libevm/eventual/eventual.go
@@ -18,6 +18,8 @@
 // getting of values.
 package eventual
 
+import "context"
+
 // A Value holds a value that is set at some unknown point in the future and
 // used, possibly concurrently, by one or more peekers or a single taker
 // (together, "getters"). The zero value is NOT ready for use.
@@ -61,6 +63,19 @@ func (v Value[T]) TryPeek() (T, bool) {
 	}
 }
 
+// PeekCtx is the context-aware equivalent of [Value.Peek], returning
+// [context.Cause] if the context is cancelled before a call to [Value.Put] is
+// made.
+func (v Value[T]) PeekCtx(ctx context.Context) (T, error) {
+	select {
+	case x := <-v.ch:
+		v.ch <- x
+		return x, nil
+	case <-ctx.Done():
+		return v.zero(), context.Cause(ctx)
+	}
+}
+
 // Take returns the value and resets `v` to its default state as if immediately
 // after construction. It blocks until a call to [Value.Put].
 func (v Value[T]) Take() T {
@@ -75,6 +90,18 @@ func (v Value[T]) TryTake() (T, bool) {
 		return x, true
 	default:
 		return v.zero(), false
+	}
+}
+
+// TakeCtx is the context-aware equivalent of [Value.Take], returning
+// [context.Cause] if the context is cancelled before a call to [Value.Put] is
+// made.
+func (v Value[T]) TakeCtx(ctx context.Context) (T, error) {
+	select {
+	case x := <-v.ch:
+		return x, nil
+	case <-ctx.Done():
+		return v.zero(), context.Cause(ctx)
 	}
 }
 

--- a/libevm/eventual/eventual_test.go
+++ b/libevm/eventual/eventual_test.go
@@ -81,6 +81,7 @@ func TestValue(t *testing.T) {
 				errCause := errors.New("because")
 				cancel(errCause)
 				_, err := tt.withCtx(sut, ctx)
+				//nolint:testifylint // Doesn't need to fail the whole test with require
 				assert.ErrorIsf(t, err, errCause, "%sCtx() before Put() and context cancelled with %v", tt.method, errCause)
 			}
 

--- a/libevm/eventual/eventual_test.go
+++ b/libevm/eventual/eventual_test.go
@@ -17,6 +17,8 @@
 package eventual
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -45,18 +47,21 @@ func TestValue(t *testing.T) {
 		method       string
 		blocking     func(Value[T]) T
 		nonBlocking  func(Value[T]) (T, bool)
+		withCtx      func(Value[T], context.Context) (T, error)
 		putEveryTime bool
 	}{
 		{
 			method:       "Peek",
 			blocking:     (Value[T]).Peek,
 			nonBlocking:  (Value[T]).TryPeek,
+			withCtx:      (Value[T]).PeekCtx,
 			putEveryTime: false, // unnecessary and would block
 		},
 		{
 			method:       "Take",
 			blocking:     (Value[T]).Take,
 			nonBlocking:  (Value[T]).TryTake,
+			withCtx:      (Value[T]).TakeCtx,
 			putEveryTime: true,
 		},
 	}
@@ -66,8 +71,18 @@ func TestValue(t *testing.T) {
 			t.Parallel()
 			sut := New[T]()
 
-			_, ok := tt.nonBlocking(sut)
-			assert.Falsef(t, ok, "Try%s() before Put()", tt.method)
+			{
+				_, ok := tt.nonBlocking(sut)
+				assert.Falsef(t, ok, "Try%s() before Put()", tt.method)
+			}
+
+			{
+				ctx, cancel := context.WithCancelCause(t.Context())
+				errCause := errors.New("because")
+				cancel(errCause)
+				_, err := tt.withCtx(sut, ctx)
+				assert.ErrorIsf(t, err, errCause, "%sCtx() before Put() and context cancelled with %v", tt.method, errCause)
+			}
 
 			const val = 42
 
@@ -97,6 +112,13 @@ func TestValue(t *testing.T) {
 			}
 			if got, ok := tt.nonBlocking(sut); !ok || got != val {
 				t.Errorf("After Put(), Try%s() got (%d, %t); want (%d, true)", tt.method, got, ok, val)
+			}
+
+			if tt.putEveryTime {
+				sut.Put(val)
+			}
+			if got, err := tt.withCtx(sut, t.Context()); err != nil || got != val {
+				t.Errorf("After Put(), %sCtx() got (%d, %v); want (%d, nil)", tt.method, got, err, val)
 			}
 		})
 	}


### PR DESCRIPTION
## Why this should be merged

SAE requires context-aware `Peek()`ing.

## How this works

Adds `PeekCtx()` and `TakeCtx()`.

## How this was tested

Additional unit tests.