### PR TITLE
chore: bump go to `1.25.8`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,12 +44,14 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          install-mode: goinstall
           only-new-issues: true
           args: --enable-only goheader
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          install-mode: goinstall
 
   yamllint:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/libevm
 
-go 1.24.8
+go 1.25.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/libevm
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0

--- a/libevm/tooling/go.mod
+++ b/libevm/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/libevm/libevm/tooling
 
-go 1.24.8
+go 1.25.7
 
 replace github.com/ava-labs/libevm => ../../
 

--- a/libevm/tooling/go.mod
+++ b/libevm/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/libevm/libevm/tooling
 
-go 1.25.7
+go 1.25.8
 
 replace github.com/ava-labs/libevm => ../../
 


### PR DESCRIPTION
This updates Go to `1.25.8`, matching AvalancheGo 