### PR TITLE
chore: export SignTransactionResult

### DIFF
--- a/libevm/ethapi/ethapi.go
+++ b/libevm/ethapi/ethapi.go
@@ -53,11 +53,12 @@ type (
 
 // Type aliases for types used as arguments or responses to the APIs.
 type (
-	RPCTransaction  = ethapi.RPCTransaction
-	TransactionArgs = ethapi.TransactionArgs
-	StateOverride   = ethapi.StateOverride
-	BlockOverrides  = ethapi.BlockOverrides
-	RevertError     = ethapi.RevertError
+	RPCTransaction        = ethapi.RPCTransaction
+	TransactionArgs       = ethapi.TransactionArgs
+	StateOverride         = ethapi.StateOverride
+	BlockOverrides        = ethapi.BlockOverrides
+	RevertError           = ethapi.RevertError
+	SignTransactionResult = ethapi.SignTransactionResult
 )
 
 // NewEthereumAPI is identical to [ethapi.NewEthereumAPI].


### PR DESCRIPTION
This is needed by strevm to unmarshal `eth_fillTransaction` responses in tests.