### PR TITLE
core: refactor IntrinsicGas function to accept rules parameter

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -133,8 +133,14 @@ func Transaction(ctx *cli.Context) error {
 			r.Address = sender
 		}
 		// Check intrinsic gas
+<<<<<<< HEAD
 		if gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil,
 			chainConfig.IsHomestead(new(big.Int)), chainConfig.IsIstanbul(new(big.Int)), chainConfig.IsShanghai(new(big.Int), 0)); err != nil {
+=======
+		rules := chainConfig.Rules(common.Big0, true, 0)
+		gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, &rules)
+		if err != nil {
+>>>>>>> 6f1b514f2 (core: refactor IntrinsicGas function to accept rules parameter)
 			r.Error = err
 			results = append(results, r)
 			continue

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -80,10 +80,24 @@ var (
 // value-transfer transaction with n bytes of extra data in each
 // block.
 func genValueTx(nbytes int) func(int, *BlockGen) {
+<<<<<<< HEAD
 	return func(i int, gen *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
 		gas, _ := IntrinsicGas(data, nil, false, false, false, false)
+=======
+	// We can reuse the data for all transactions.
+	// During signing, the method tx.WithSignature(s, sig)
+	// performs:
+	// 	cpy := tx.inner.copy()
+	//	cpy.setSignatureValues(signer.ChainID(), v, r, s)
+	// After this operation, the data can be reused by the caller.
+	data := make([]byte, nbytes)
+	rules := params.NonActivatedConfig.Rules(common.Big0, false, 0)
+	return func(i int, gen *BlockGen) {
+		toaddr := common.Address{}
+		gas, _ := IntrinsicGas(data, nil, nil, false, &rules)
+>>>>>>> 6f1b514f2 (core: refactor IntrinsicGas function to accept rules parameter)
 		signer := gen.Signer()
 		gasPrice := big.NewInt(0)
 		if gen.header.BaseFee != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -67,10 +67,14 @@ func (result *ExecutionResult) Revert() []byte {
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
+<<<<<<< HEAD
 func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation bool, isHomestead, isEIP2028, isEIP3860 bool) (uint64, error) {
+=======
+func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.SetCodeAuthorization, isContractCreation bool, rules *params.Rules) (uint64, error) {
+>>>>>>> 6f1b514f2 (core: refactor IntrinsicGas function to accept rules parameter)
 	// Set the starting gas for the raw transaction
 	var gas uint64
-	if isContractCreation && isHomestead {
+	if isContractCreation && rules.IsHomestead {
 		gas = params.TxGasContractCreation
 	} else {
 		gas = params.TxGas
@@ -87,7 +91,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 		}
 		// Make sure we don't exceed uint64 for all data combinations
 		nonZeroGas := params.TxDataNonZeroGasFrontier
-		if isEIP2028 {
+		if rules.IsIstanbul {
 			nonZeroGas = params.TxDataNonZeroGasEIP2028
 		}
 		if (math.MaxUint64-gas)/nonZeroGas < nz {
@@ -101,7 +105,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 		}
 		gas += z * params.TxDataZeroGas
 
-		if isContractCreation && isEIP3860 {
+		if isContractCreation && rules.IsShanghai {
 			lenWords := toWordSize(dataLen)
 			if (math.MaxUint64-gas)/params.InitCodeWordGas < lenWords {
 				return 0, ErrGasUintOverflow
@@ -395,7 +399,11 @@ func (st *StateTransition) transitionDb() (*ExecutionResult, error) {
 	)
 
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
+<<<<<<< HEAD
 	gas, err := IntrinsicGas(msg.Data, msg.AccessList, contractCreation, rules.IsHomestead, rules.IsIstanbul, rules.IsShanghai)
+=======
+	gas, err := IntrinsicGas(msg.Data, msg.AccessList, msg.SetCodeAuthorizations, contractCreation, &rules)
+>>>>>>> 6f1b514f2 (core: refactor IntrinsicGas function to accept rules parameter)
 	if err != nil {
 		return nil, err
 	}

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -102,7 +102,11 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	// Ensure the transaction has more gas than the bare minimum needed to cover
 	// the transaction metadata
+<<<<<<< HEAD
 	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, opts.Config.IsIstanbul(head.Number), opts.Config.IsShanghai(head.Number, head.Time))
+=======
+	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, &rules)
+>>>>>>> 6f1b514f2 (core: refactor IntrinsicGas function to accept rules parameter)
 	if err != nil {
 		return err
 	}

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -55,7 +55,11 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 			return nil, nil, err
 		}
 		// Intrinsic gas
+<<<<<<< HEAD
 		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, isHomestead, isIstanbul, false)
+=======
+		requiredGas, err = core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, rules)
+>>>>>>> 6f1b514f2 (core: refactor IntrinsicGas function to accept rules parameter)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Updated the IntrinsicGas function signature to take a pointer to rules instead of multiple boolean flags for gas calculations. This change simplifies the function calls across various components, including transaction validation and gas computation in state transitions, enhancing code readability and maintainability.

## Why this should be merged

## How this works

## How this was tested
