### PR TITLE
feat: add access list gas hook to params.RulesHooks

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto/kzg4844"
-	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 )
@@ -111,49 +110,16 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 		}
 	}
 	if accessList != nil {
-		accessListGas, err := accessListIntrinsicGas(accessList, rules)
-		if err != nil {
+		if hookGas, override, err := libevmAccessListGas(gas, accessList, rules); err != nil {
 			return 0, err
+		} else if override {
+			gas += hookGas
+		} else { //libevm: upstream original
+			gas += uint64(len(accessList)) * params.TxAccessListAddressGas
+			gas += uint64(accessList.StorageKeys()) * params.TxAccessListStorageKeyGas
 		}
-		if math.MaxUint64-gas < accessListGas {
-			return 0, ErrGasUintOverflow
-		}
-		gas += accessListGas
 	}
 	return gas, nil
-}
-
-// accessListIntrinsicGas returns the intrinsic gas for an access list. If the
-// hook returns override=true, uses the hook's gas value; otherwise uses the
-// default per-address and per-storage-key calculation. Returns an error if the
-// hook returns one.
-func accessListIntrinsicGas(accessList types.AccessList, rules params.Rules) (uint64, error) {
-	hookGas, override, err := rules.Hooks().AccessListGas(convertAccessList(accessList))
-	if err != nil {
-		return 0, err
-	}
-	if override {
-		return hookGas, nil
-	}
-	return defaultAccessListGas(accessList), nil
-}
-
-// defaultAccessListGas returns the default upstream intrinsic gas for an access list.
-func defaultAccessListGas(accessList types.AccessList) uint64 {
-	return uint64(len(accessList))*params.TxAccessListAddressGas +
-		uint64(accessList.StorageKeys())*params.TxAccessListStorageKeyGas
-}
-
-// convertAccessList converts a types.AccessList to a libevm.AccessList.
-func convertAccessList(accessList types.AccessList) libevm.AccessList {
-	al := make(libevm.AccessList, len(accessList))
-	for i, tuple := range accessList {
-		al[i] = libevm.AccessTuple{
-			Address:     tuple.Address,
-			StorageKeys: tuple.StorageKeys,
-		}
-	}
-	return al
 }
 
 // toWordSize returns the ceiled word size required for init code payment calculation.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto/kzg4844"
+	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 )
@@ -110,10 +111,41 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 		}
 	}
 	if accessList != nil {
-		gas += uint64(len(accessList)) * params.TxAccessListAddressGas
-		gas += uint64(accessList.StorageKeys()) * params.TxAccessListStorageKeyGas
+		accessListGas := accessListIntrinsicGas(accessList, rules)
+		if math.MaxUint64-gas < accessListGas {
+			return 0, ErrGasUintOverflow
+		}
+		gas += accessListGas
 	}
 	return gas, nil
+}
+
+// accessListIntrinsicGas returns the intrinsic gas for an access list.
+// It first checks if the hook overrides the gas calculation, and if so, returns the hook's value.
+// If the hook does not override, it returns the default upstream intrinsic gas.
+func accessListIntrinsicGas(accessList types.AccessList, rules params.Rules) uint64 {
+	if hookGas, override := rules.Hooks().AccessListGas(convertAccessList(accessList)); override {
+		return hookGas
+	}
+	return defaultAccessListGas(accessList)
+}
+
+// defaultAccessListGas returns the default upstream intrinsic gas for an access list.
+func defaultAccessListGas(accessList types.AccessList) uint64 {
+	return uint64(len(accessList))*params.TxAccessListAddressGas +
+		uint64(accessList.StorageKeys())*params.TxAccessListStorageKeyGas
+}
+
+// convertAccessList converts a types.AccessList to a libevm.AccessList.
+func convertAccessList(accessList types.AccessList) libevm.AccessList {
+	al := make(libevm.AccessList, len(accessList))
+	for i, tuple := range accessList {
+		al[i] = libevm.AccessTuple{
+			Address:     tuple.Address,
+			StorageKeys: tuple.StorageKeys,
+		}
+	}
+	return al
 }
 
 // toWordSize returns the ceiled word size required for init code payment calculation.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -111,7 +111,10 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 		}
 	}
 	if accessList != nil {
-		accessListGas := accessListIntrinsicGas(accessList, rules)
+		accessListGas, err := accessListIntrinsicGas(accessList, rules)
+		if err != nil {
+			return 0, err
+		}
 		if math.MaxUint64-gas < accessListGas {
 			return 0, ErrGasUintOverflow
 		}
@@ -120,14 +123,19 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 	return gas, nil
 }
 
-// accessListIntrinsicGas returns the intrinsic gas for an access list.
-// It first checks if the hook overrides the gas calculation, and if so, returns the hook's value.
-// If the hook does not override, it returns the default upstream intrinsic gas.
-func accessListIntrinsicGas(accessList types.AccessList, rules params.Rules) uint64 {
-	if hookGas, override := rules.Hooks().AccessListGas(convertAccessList(accessList)); override {
-		return hookGas
+// accessListIntrinsicGas returns the intrinsic gas for an access list. If the
+// hook returns override=true, uses the hook's gas value; otherwise uses the
+// default per-address and per-storage-key calculation. Returns an error if the
+// hook returns one.
+func accessListIntrinsicGas(accessList types.AccessList, rules params.Rules) (uint64, error) {
+	hookGas, override, err := rules.Hooks().AccessListGas(convertAccessList(accessList))
+	if err != nil {
+		return 0, err
 	}
-	return defaultAccessListGas(accessList)
+	if override {
+		return hookGas, nil
+	}
+	return defaultAccessListGas(accessList), nil
 }
 
 // defaultAccessListGas returns the default upstream intrinsic gas for an access list.

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -18,8 +18,11 @@ package core
 
 import (
 	"fmt"
+	"math"
 
+	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
+	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/params"
 )
@@ -105,4 +108,30 @@ func (st *StateTransition) consumeMinimumGas() {
 		st.gasRemaining,
 		limit-minConsume,
 	)
+}
+
+// libevmAccessListGas is a convenience wrapper for calling the
+// [params.RulesHooks.AccessListGas] hook. It converts the raw access list to a
+// DTO and calls the hook. Returns the gas to be charged for the access list,
+// whether the hook overrides the default calculation and any error.
+// It MAY return an error for gas overflow if the hook returns a gas value that
+// would cause an overflow with [currGas]. It MUST be called with a non-nil
+// access list.
+func libevmAccessListGas(currGas uint64, raw types.AccessList, rules params.Rules) (gas uint64, override bool, err error) {
+	list := make(libevm.AccessList, len(raw))
+	for i, tuple := range raw {
+		list[i] = libevm.AccessTuple{
+			Address:     tuple.Address,
+			StorageKeys: tuple.StorageKeys,
+		}
+	}
+
+	hookGas, override, err := rules.Hooks().AccessListGas(list)
+	if !override || err != nil {
+		return 0, false, err
+	}
+	if math.MaxUint64-currGas < hookGas {
+		return 0, false, ErrGasUintOverflow
+	}
+	return hookGas, true, nil
 }

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -150,7 +150,7 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "core.IntrinsicGas(...)")
-			require.Equal(t, tt.wantGas, got)
+			require.Equal(t, tt.wantGas, got, "core.IntrinsicGas(...)")
 		})
 	}
 }

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -71,7 +71,7 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 		},
 	}}
 	defaultAccessListGas := uint64(len(accessList))*params.TxAccessListAddressGas +
-		uint64(accessList.StorageKeys())*params.TxAccessListStorageKeyGas
+		uint64(accessList.StorageKeys())*params.TxAccessListStorageKeyGas //nolint:gosec // Known to not overflow
 
 	tests := []struct {
 		name       string

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -17,6 +17,7 @@ package core_test
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -59,6 +60,166 @@ func TestCanExecuteTransaction(t *testing.T) {
 	}
 	_, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(30e6))
 	require.EqualError(t, err, makeErr(msg.From, msg.To, value).Error())
+}
+
+func TestIntrinsicGasAccessListHook(t *testing.T) {
+	accessList := types.AccessList{{
+		Address: common.Address{1},
+		StorageKeys: []common.Hash{
+			{1},
+			{2},
+		},
+	}}
+	defaultAccessListGas := uint64(len(accessList))*params.TxAccessListAddressGas +
+		uint64(accessList.StorageKeys())*params.TxAccessListStorageKeyGas
+
+	tests := []struct {
+		name       string
+		accessList types.AccessList
+		hookGas    uint64
+		override   bool
+		wantGas    uint64
+		wantErr    error
+	}{
+		{
+			name:       "hook_overrides_with_custom_gas",
+			accessList: accessList,
+			hookGas:    100,
+			override:   true,
+			wantGas:    params.TxGas + 100,
+		},
+		{
+			name:       "hook_overrides_with_zero",
+			accessList: accessList,
+			hookGas:    0,
+			override:   true,
+			wantGas:    params.TxGas,
+		},
+		{
+			name:       "hook_does_not_override_uses_default",
+			accessList: accessList,
+			hookGas:    0,
+			override:   false,
+			wantGas:    params.TxGas + defaultAccessListGas,
+		},
+		{
+			name:       "nil_access_list_hook_not_called",
+			accessList: nil,
+			hookGas:    100,
+			override:   true,
+			wantGas:    params.TxGas,
+		},
+		{
+			name:       "empty_access_list_with_override",
+			accessList: types.AccessList{},
+			hookGas:    100,
+			override:   true,
+			wantGas:    params.TxGas + 100,
+		},
+		{
+			name:       "hook_gas_causes_overflow",
+			accessList: accessList,
+			hookGas:    math.MaxUint64,
+			override:   true,
+			wantErr:    core.ErrGasUintOverflow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hooks := &hookstest.Stub{
+				AccessListGasFn: func(accessListDTO libevm.AccessList) (uint64, bool) {
+					return tt.hookGas, tt.override
+				},
+			}
+			hooks.Register(t)
+
+			rules := params.NonActivatedConfig.Rules(new(big.Int), false, 0)
+			got, err := core.IntrinsicGas(nil, tt.accessList, false, rules)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err, "core.IntrinsicGas(...)")
+			require.Equal(t, tt.wantGas, got)
+		})
+	}
+}
+
+func TestIntrinsicGasAccessListHookDTO(t *testing.T) {
+	tests := []struct {
+		name       string
+		accessList types.AccessList
+	}{
+		{
+			name: "single_address_multiple_keys",
+			accessList: types.AccessList{{
+				Address:     common.Address{1},
+				StorageKeys: []common.Hash{{1}, {2}},
+			}},
+		},
+		{
+			name: "multiple_addresses",
+			accessList: types.AccessList{
+				{
+					Address:     common.Address{1},
+					StorageKeys: []common.Hash{{1}},
+				},
+				{
+					Address:     common.Address{2},
+					StorageKeys: []common.Hash{{2}, {3}},
+				},
+			},
+		},
+		{
+			name: "address_with_no_storage_keys",
+			accessList: types.AccessList{{
+				Address:     common.Address{1},
+				StorageKeys: []common.Hash{},
+			}},
+		},
+		{
+			name: "address_with_nil_storage_keys",
+			accessList: types.AccessList{{
+				Address:     common.Address{1},
+				StorageKeys: nil,
+			}},
+		},
+		{
+			name:       "empty_access_list",
+			accessList: types.AccessList{},
+		},
+		{
+			name: "full_address_and_hash",
+			accessList: types.AccessList{{
+				Address: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+				StorageKeys: []common.Hash{
+					common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+				},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hooks := &hookstest.Stub{
+				AccessListGasFn: func(dto libevm.AccessList) (uint64, bool) {
+					require.Len(t, dto, len(tt.accessList), "access list length mismatch")
+					for i, tuple := range tt.accessList {
+						require.Equal(t, tuple.Address, dto[i].Address, "address mismatch at index %d", i)
+						require.Equal(t, tuple.StorageKeys, dto[i].StorageKeys, "storage keys mismatch at index %d", i)
+					}
+					return 0, true
+				},
+			}
+			hooks.Register(t)
+
+			rules := params.NonActivatedConfig.Rules(new(big.Int), false, 0)
+			_, err := core.IntrinsicGas(nil, tt.accessList, false, rules)
+			require.NoError(t, err, "core.IntrinsicGas(...)")
+		})
+	}
 }
 
 func TestMinimumGasConsumption(t *testing.T) {

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -141,8 +141,8 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 				AccessListGasFn: func(dto libevm.AccessList) (uint64, bool, error) {
 					require.Len(t, dto, len(tt.accessList), "access list length mismatch")
 					for i, tuple := range tt.accessList {
-						require.Equal(t, tuple.Address, dto[i].Address, "address mismatch at index %d", i)
-						require.Equal(t, tuple.StorageKeys, dto[i].StorageKeys, "storage keys mismatch at index %d", i)
+						assert.Equal(t, tuple.Address, dto[i].Address, "address mismatch at index %d", i)
+						assert.Equal(t, tuple.StorageKeys, dto[i].StorageKeys, "storage keys mismatch at index %d", i)
 					}
 					hookCalled = true
 					return tt.hookGas, tt.override, tt.hookErr

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/libevm/common"

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -16,6 +16,7 @@
 package core_test
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -73,6 +74,8 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 	defaultAccessListGas := uint64(len(accessList))*params.TxAccessListAddressGas +
 		uint64(accessList.StorageKeys())*params.TxAccessListStorageKeyGas //nolint:gosec // Known to not overflow
 
+	testErr := errors.New("test error")
+
 	tests := []struct {
 		name       string
 		accessList types.AccessList
@@ -106,8 +109,6 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 		{
 			name:       "nil_access_list_hook_not_called",
 			accessList: nil,
-			hookGas:    100,
-			override:   true,
 			wantGas:    params.TxGas,
 		},
 		{
@@ -127,16 +128,23 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 		{
 			name:       "hook_returns_error",
 			accessList: accessList,
-			hookErr:    core.ErrGasUintOverflow,
+			hookErr:    testErr,
 			override:   true,
-			wantErr:    core.ErrGasUintOverflow,
+			wantErr:    testErr,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			hookCalled := false
 			hooks := &hookstest.Stub{
-				AccessListGasFn: func(accessListDTO libevm.AccessList) (uint64, bool, error) {
+				AccessListGasFn: func(dto libevm.AccessList) (uint64, bool, error) {
+					require.Len(t, dto, len(tt.accessList), "access list length mismatch")
+					for i, tuple := range tt.accessList {
+						require.Equal(t, tuple.Address, dto[i].Address, "address mismatch at index %d", i)
+						require.Equal(t, tuple.StorageKeys, dto[i].StorageKeys, "storage keys mismatch at index %d", i)
+					}
+					hookCalled = true
 					return tt.hookGas, tt.override, tt.hookErr
 				},
 			}
@@ -145,87 +153,9 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 			rules := params.NonActivatedConfig.Rules(new(big.Int), false, 0)
 			got, err := core.IntrinsicGas(nil, tt.accessList, false, rules)
 
-			if tt.wantErr != nil {
-				require.ErrorIs(t, err, tt.wantErr)
-				return
-			}
-			require.NoError(t, err, "core.IntrinsicGas(...)")
+			require.ErrorIs(t, err, tt.wantErr)
 			require.Equal(t, tt.wantGas, got)
-		})
-	}
-}
-
-func TestIntrinsicGasAccessListHookDTO(t *testing.T) {
-	tests := []struct {
-		name       string
-		accessList types.AccessList
-	}{
-		{
-			name: "single_address_multiple_keys",
-			accessList: types.AccessList{{
-				Address:     common.Address{1},
-				StorageKeys: []common.Hash{{1}, {2}},
-			}},
-		},
-		{
-			name: "multiple_addresses",
-			accessList: types.AccessList{
-				{
-					Address:     common.Address{1},
-					StorageKeys: []common.Hash{{1}},
-				},
-				{
-					Address:     common.Address{2},
-					StorageKeys: []common.Hash{{2}, {3}},
-				},
-			},
-		},
-		{
-			name: "address_with_no_storage_keys",
-			accessList: types.AccessList{{
-				Address:     common.Address{1},
-				StorageKeys: []common.Hash{},
-			}},
-		},
-		{
-			name: "address_with_nil_storage_keys",
-			accessList: types.AccessList{{
-				Address:     common.Address{1},
-				StorageKeys: nil,
-			}},
-		},
-		{
-			name:       "empty_access_list",
-			accessList: types.AccessList{},
-		},
-		{
-			name: "full_address_and_hash",
-			accessList: types.AccessList{{
-				Address: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-				StorageKeys: []common.Hash{
-					common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
-				},
-			}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			hooks := &hookstest.Stub{
-				AccessListGasFn: func(dto libevm.AccessList) (uint64, bool, error) {
-					require.Len(t, dto, len(tt.accessList), "access list length mismatch")
-					for i, tuple := range tt.accessList {
-						require.Equal(t, tuple.Address, dto[i].Address, "address mismatch at index %d", i)
-						require.Equal(t, tuple.StorageKeys, dto[i].StorageKeys, "storage keys mismatch at index %d", i)
-					}
-					return 0, true, nil
-				},
-			}
-			hooks.Register(t)
-
-			rules := params.NonActivatedConfig.Rules(new(big.Int), false, 0)
-			_, err := core.IntrinsicGas(nil, tt.accessList, false, rules)
-			require.NoError(t, err, "core.IntrinsicGas(...)")
+			require.Equal(t, tt.accessList != nil, hookCalled)
 		})
 	}
 }

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -77,6 +77,7 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 		name       string
 		accessList types.AccessList
 		hookGas    uint64
+		hookErr    error
 		override   bool
 		wantGas    uint64
 		wantErr    error
@@ -123,13 +124,20 @@ func TestIntrinsicGasAccessListHook(t *testing.T) {
 			override:   true,
 			wantErr:    core.ErrGasUintOverflow,
 		},
+		{
+			name:       "hook_returns_error",
+			accessList: accessList,
+			hookErr:    core.ErrGasUintOverflow,
+			override:   true,
+			wantErr:    core.ErrGasUintOverflow,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hooks := &hookstest.Stub{
-				AccessListGasFn: func(accessListDTO libevm.AccessList) (uint64, bool) {
-					return tt.hookGas, tt.override
+				AccessListGasFn: func(accessListDTO libevm.AccessList) (uint64, bool, error) {
+					return tt.hookGas, tt.override, tt.hookErr
 				},
 			}
 			hooks.Register(t)
@@ -204,13 +212,13 @@ func TestIntrinsicGasAccessListHookDTO(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hooks := &hookstest.Stub{
-				AccessListGasFn: func(dto libevm.AccessList) (uint64, bool) {
+				AccessListGasFn: func(dto libevm.AccessList) (uint64, bool, error) {
 					require.Len(t, dto, len(tt.accessList), "access list length mismatch")
 					for i, tuple := range tt.accessList {
 						require.Equal(t, tuple.Address, dto[i].Address, "address mismatch at index %d", i)
 						require.Equal(t, tuple.StorageKeys, dto[i].StorageKeys, "storage keys mismatch at index %d", i)
 					}
-					return 0, true
+					return 0, true, nil
 				},
 			}
 			hooks.Register(t)

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -47,6 +47,7 @@ type Stub struct {
 	DescriptionSuffix       string
 	PrecompileOverrides     map[common.Address]libevm.PrecompiledContract
 	ActivePrecompilesFn     func([]common.Address) []common.Address
+	AccessListGasFn         func(libevm.AccessList) (uint64, bool)
 	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
 	CanCreateContractFn     func(*libevm.AddressContext, uint64, libevm.StateReader) (uint64, error)
 	MinimumGasConsumptionFn func(txGasLimit uint64) uint64
@@ -89,6 +90,15 @@ func (s Stub) ActivePrecompiles(active []common.Address) []common.Address {
 		return f(active)
 	}
 	return active
+}
+
+// AccessListGas proxies arguments to the s.AccessListGasFn function if non-nil,
+// otherwise it returns override=false to signal using the default calculation.
+func (s Stub) AccessListGas(accessList libevm.AccessList) (uint64, bool) {
+	if f := s.AccessListGasFn; f != nil {
+		return f(accessList)
+	}
+	return 0, false
 }
 
 // CheckConfigForkOrder proxies arguments to the s.CheckConfigForkOrderFn

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -47,7 +47,7 @@ type Stub struct {
 	DescriptionSuffix       string
 	PrecompileOverrides     map[common.Address]libevm.PrecompiledContract
 	ActivePrecompilesFn     func([]common.Address) []common.Address
-	AccessListGasFn         func(libevm.AccessList) (uint64, bool)
+	AccessListGasFn         func(libevm.AccessList) (uint64, bool, error)
 	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
 	CanCreateContractFn     func(*libevm.AddressContext, uint64, libevm.StateReader) (uint64, error)
 	MinimumGasConsumptionFn func(txGasLimit uint64) uint64
@@ -94,11 +94,11 @@ func (s Stub) ActivePrecompiles(active []common.Address) []common.Address {
 
 // AccessListGas proxies arguments to the s.AccessListGasFn function if non-nil,
 // otherwise it returns override=false to signal using the default calculation.
-func (s Stub) AccessListGas(accessList libevm.AccessList) (uint64, bool) {
+func (s Stub) AccessListGas(accessList libevm.AccessList) (uint64, bool, error) {
 	if f := s.AccessListGasFn; f != nil {
 		return f(accessList)
 	}
-	return 0, false
+	return 0, false, nil
 }
 
 // CheckConfigForkOrder proxies arguments to the s.CheckConfigForkOrderFn

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -31,6 +31,16 @@ type PrecompiledContract interface {
 	Run(input []byte) ([]byte, error)
 }
 
+// AccessList mirrors core/types.AccessList for packages that cannot import
+// core/types without causing a circular dependency.
+type AccessList []AccessTuple
+
+// AccessTuple is the element type of an [AccessList].
+type AccessTuple struct {
+	Address     common.Address
+	StorageKeys []common.Hash
+}
+
 // StateReader is a subset of vm.StateDB, exposing only methods that read from
 // but do not modify state. See method comments in vm.StateDB, which aren't
 // copied here as they risk becoming outdated.

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -35,7 +35,8 @@ type PrecompiledContract interface {
 // core/types without causing a circular dependency.
 type AccessList []AccessTuple
 
-// AccessTuple is the element type of an [AccessList].
+// AccessTuple mirrors core/types.AccessTuple for packages that cannot import
+// core/types without causing a circular dependency.
 type AccessTuple struct {
 	Address     common.Address
 	StorageKeys []common.Hash

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -147,7 +147,7 @@ func (NOOPHooks) ActivePrecompiles(active []common.Address) []common.Address {
 	return active
 }
 
-// AccessListGas returns override=false, signalling to use the default calculation.
+// AccessListGas returns override=false and nil error, signalling to use the default calculation.
 func (NOOPHooks) AccessListGas(_ libevm.AccessList) (uint64, bool, error) {
 	return 0, false, nil
 }

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -59,8 +59,9 @@ type RulesHooks interface {
 	// intrinsic gas to be charged for it. If override is true, the returned gas
 	// replaces the default per-address and per-storage-key calculation. If
 	// override is false, the default calculation is used. This hook is not
-	// called if the access list is nil.
-	AccessListGas(accessList libevm.AccessList) (gas uint64, override bool)
+	// called if the access list is nil. The hook may return an error (e.g., for
+	// gas overflow).
+	AccessListGas(accessList libevm.AccessList) (gas uint64, override bool, _ error)
 	// MinimumGasConsumption receives a transaction's gas limit and returns the
 	// minimum quantity of gas units to be charged for said transaction. If the
 	// returned value is greater than the transaction's limit, the minimum spend
@@ -147,8 +148,8 @@ func (NOOPHooks) ActivePrecompiles(active []common.Address) []common.Address {
 }
 
 // AccessListGas returns override=false, signalling to use the default calculation.
-func (NOOPHooks) AccessListGas(_ libevm.AccessList) (uint64, bool) {
-	return 0, false
+func (NOOPHooks) AccessListGas(_ libevm.AccessList) (uint64, bool, error) {
+	return 0, false, nil
 }
 
 // MinimumGasConsumption always returns 0.

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -55,6 +55,12 @@ type RulesHooks interface {
 	// received slice. The value it returns MUST be consistent with the
 	// behaviour of the PrecompileOverride hook.
 	ActivePrecompiles([]common.Address) []common.Address
+	// AccessListGas receives the transaction access list and returns the
+	// intrinsic gas to be charged for it. If override is true, the returned gas
+	// replaces the default per-address and per-storage-key calculation. If
+	// override is false, the default calculation is used. This hook is not
+	// called if the access list is nil.
+	AccessListGas(accessList libevm.AccessList) (gas uint64, override bool)
 	// MinimumGasConsumption receives a transaction's gas limit and returns the
 	// minimum quantity of gas units to be charged for said transaction. If the
 	// returned value is greater than the transaction's limit, the minimum spend
@@ -138,6 +144,11 @@ func (NOOPHooks) PrecompileOverride(common.Address) (libevm.PrecompiledContract,
 // ActivePrecompiles echoes the active addresses unchanged.
 func (NOOPHooks) ActivePrecompiles(active []common.Address) []common.Address {
 	return active
+}
+
+// AccessListGas returns override=false, signalling to use the default calculation.
+func (NOOPHooks) AccessListGas(_ libevm.AccessList) (uint64, bool) {
+	return 0, false
 }
 
 // MinimumGasConsumption always returns 0.

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -59,7 +59,7 @@ type RulesHooks interface {
 	// intrinsic gas to be charged for it. If override is true, the returned gas
 	// replaces the default per-address and per-storage-key calculation. If
 	// override is false, the default calculation is used. This hook is not
-	// called if the access list is nil. The hook may return an error (e.g., for
+	// called if the access list is nil. The hook MAY return an error (e.g., for
 	// gas overflow).
 	AccessListGas(accessList libevm.AccessList) (gas uint64, override bool, err error)
 	// MinimumGasConsumption receives a transaction's gas limit and returns the

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -61,7 +61,7 @@ type RulesHooks interface {
 	// override is false, the default calculation is used. This hook is not
 	// called if the access list is nil. The hook may return an error (e.g., for
 	// gas overflow).
-	AccessListGas(accessList libevm.AccessList) (gas uint64, override bool, _ error)
+	AccessListGas(accessList libevm.AccessList) (gas uint64, override bool, err error)
 	// MinimumGasConsumption receives a transaction's gas limit and returns the
 	// minimum quantity of gas units to be charged for said transaction. If the
 	// returned value is greater than the transaction's limit, the minimum spend


### PR DESCRIPTION
## Why this should be merged

Coreth + Subnet-EVM has their own `IntrinsicGas` calculation tailored for warp with access lists. With SAE we plan to use keep using libevm's own `IntrinsicGas` function. This hook is intended to provide the required support to modify access list gas calculation.  

## How this works

* Adds `AccessListGas` hook to `params.RulesHooks` which would replace the existing access list gas calculation if overridden.
* Adds a DTO to workaround cyclic import between `params` and `core` package.

## How this was tested

Added UTs.
