### PR TITLE
feat(state): Intercept `Database` creation

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -151,7 +151,7 @@ func NewDatabase(db ethdb.Database) Database {
 // NewDatabaseWithConfig creates a backing store for state. The returned database
 // is safe for concurrent use and retains a lot of collapsed RLP trie nodes in a
 // large memory cache.
-func NewDatabaseWithConfig(db ethdb.Database, config *triedb.Config) Database {
+func newDatabaseWithConfig(db ethdb.Database, config *triedb.Config) Database {
 	return &cachingDB{
 		disk:          db,
 		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
@@ -161,7 +161,7 @@ func NewDatabaseWithConfig(db ethdb.Database, config *triedb.Config) Database {
 }
 
 // NewDatabaseWithNodeDB creates a state database with an already initialized node database.
-func NewDatabaseWithNodeDB(db ethdb.Database, triedb *triedb.Database) Database {
+func newDatabaseWithNodeDB(db ethdb.Database, triedb *triedb.Database) Database {
 	return &cachingDB{
 		disk:          db,
 		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),

--- a/core/state/database.libevm.go
+++ b/core/state/database.libevm.go
@@ -42,7 +42,7 @@ func RegisterDatabaseInterceptor(dbi DatabaseInterceptor) {
 //
 // This MUST NOT be used on a live chain. It is solely intended for off-chain
 // consumers that require access to extras. Said consumers SHOULD NOT, however
-// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
+// call this function directly. Use the [libevm.WithTemporaryExtrasLock]
 // function instead as it atomically overrides all possible packages.
 func WithTempRegisteredDatabaseInterceptor(lock libevm.ExtrasLock, dbi DatabaseInterceptor, fn func() error) error {
 	if err := lock.Verify(); err != nil {

--- a/core/state/database.libevm.go
+++ b/core/state/database.libevm.go
@@ -43,7 +43,8 @@ func RegisterDatabaseInterceptor(dbi DatabaseInterceptor) {
 // This MUST NOT be used on a live chain. It is solely intended for off-chain
 // consumers that require access to extras. Said consumers SHOULD NOT, however
 // call this function directly. Use the [libevm.WithTemporaryExtrasLock]
-// function instead as it atomically overrides all possible packages.
+// function instead in combination with all other registrations to ensure
+// that temporary registrations are atomically applied.
 func WithTempRegisteredDatabaseInterceptor(lock libevm.ExtrasLock, dbi DatabaseInterceptor, fn func() error) error {
 	if err := lock.Verify(); err != nil {
 		return err

--- a/core/state/database.libevm.go
+++ b/core/state/database.libevm.go
@@ -1,0 +1,90 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm"
+	"github.com/ava-labs/libevm/libevm/register"
+	"github.com/ava-labs/libevm/triedb"
+)
+
+// DatabaseInterceptor accepts the standard [Database] implementation returned
+// by [NewDatabaseWithConfig] and [NewDatabaseWithNodeDB], allowing the
+// returned [Database] to be re-implemented with custom behavior.
+type DatabaseInterceptor func(Database) Database
+
+// RegisterDatabaseInterceptor registers the [DatabaseInterceptor] such that they modify the
+// behaviour of all [StateDB] instances. It is expected to be called in an
+// `init()` function and MUST NOT be called more than once.
+func RegisterDatabaseInterceptor(s DatabaseInterceptor) {
+	registeredInterceptor.MustRegister(s)
+}
+
+// WithTempRegisteredDatabaseInterceptor temporarily registers `i` as if calling
+// [RegisterDatabaseInterceptor] the same type parameter. After `fn` returns, the
+// registration is returned to its former state, be that none or the types
+// originally passed to [RegisterDatabaseInterceptor].
+//
+// This MUST NOT be used on a live chain. It is solely intended for off-chain
+// consumers that require access to extras. Said consumers SHOULD NOT, however
+// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
+// function instead as it atomically overrides all possible packages.
+func WithTempRegisteredDatabaseInterceptor(lock libevm.ExtrasLock, i DatabaseInterceptor, fn func() error) error {
+	if err := lock.Verify(); err != nil {
+		return err
+	}
+	return registeredInterceptor.TempOverride(i, fn)
+}
+
+// TestOnlyClearRegisteredDatabaseInterceptor clears the arguments previously passed to
+// [RegisterDatabaseInterceptor]. It panics if called from a non-testing call stack.
+//
+// In tests it SHOULD be called before every call to [RegisterDatabaseInterceptor] and then
+// defer-called afterwards, either directly or via testing.TB.Cleanup(). This is
+// a workaround for the single-call limitation on [RegisterDatabaseInterceptor].
+func TestOnlyClearRegisteredDatabaseInterceptor() {
+	registeredInterceptor.TestOnlyClear()
+}
+
+var registeredInterceptor register.AtMostOnce[DatabaseInterceptor]
+
+// NewDatabaseWithConfig creates a backing store for state. The returned database
+// is safe for concurrent use and retains a lot of collapsed RLP trie nodes in a
+// large memory cache. If a [DatabaseInterceptor] is registered, the returned
+// database will be the result of passing the [Database] returned by this
+// function to the interceptor.
+func NewDatabaseWithConfig(db ethdb.Database, config *triedb.Config) Database {
+	cache := newDatabaseWithConfig(db, config)
+	r := &registeredInterceptor
+	if !r.Registered() {
+		return cache
+	}
+	return r.Get()(cache)
+}
+
+// NewDatabaseWithNodeDB creates a state database with an already initialized node database.
+// If a [DatabaseInterceptor] is registered, the returned database will be the result of
+// passing the [Database] returned by this function to the interceptor.
+func NewDatabaseWithNodeDB(db ethdb.Database, triedb *triedb.Database) Database {
+	cache := newDatabaseWithNodeDB(db, triedb)
+	r := &registeredInterceptor
+	if !r.Registered() {
+		return cache
+	}
+	return r.Get()(cache)
+}

--- a/core/state/database.libevm.go
+++ b/core/state/database.libevm.go
@@ -1,4 +1,4 @@
-// Copyright 2024 the libevm authors.
+// Copyright 2026 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License

--- a/core/state/database.libevm.go
+++ b/core/state/database.libevm.go
@@ -23,35 +23,35 @@ import (
 	"github.com/ava-labs/libevm/triedb"
 )
 
-// DatabaseInterceptor accepts the standard [Database] implementation returned
-// by [NewDatabaseWithConfig] and [NewDatabaseWithNodeDB], allowing the
-// returned [Database] to be re-implemented with custom behavior.
+// A DatabaseInterceptor accepts the standard [Database] implementation
+// returned by [NewDatabaseWithConfig] and [NewDatabaseWithNodeDB], allowing
+// the returned [Database] to be re-implemented with custom behavior.
 type DatabaseInterceptor func(Database) Database
 
-// RegisterDatabaseInterceptor registers the [DatabaseInterceptor] such that they modify the
-// behaviour of all [StateDB] instances. It is expected to be called in an
-// `init()` function and MUST NOT be called more than once.
-func RegisterDatabaseInterceptor(s DatabaseInterceptor) {
-	registeredInterceptor.MustRegister(s)
+// RegisterDatabaseInterceptor registers the [DatabaseInterceptor] such that it
+// modifies the behaviour of all [StateDB] instances. It MUST NOT be called
+// more than once.
+func RegisterDatabaseInterceptor(dbi DatabaseInterceptor) {
+	registeredInterceptor.MustRegister(dbi)
 }
 
-// WithTempRegisteredDatabaseInterceptor temporarily registers `i` as if calling
-// [RegisterDatabaseInterceptor] the same type parameter. After `fn` returns, the
-// registration is returned to its former state, be that none or the types
-// originally passed to [RegisterDatabaseInterceptor].
+// WithTempRegisteredDatabaseInterceptor temporarily registers `dbi` as if
+// calling [RegisterDatabaseInterceptor] with the same argument. After `fn`
+// returns, the registration is returned to its former state, be that none or
+// the types originally passed to [RegisterDatabaseInterceptor].
 //
 // This MUST NOT be used on a live chain. It is solely intended for off-chain
 // consumers that require access to extras. Said consumers SHOULD NOT, however
 // call this function directly. Use the libevm/temporary.WithRegisteredExtras()
 // function instead as it atomically overrides all possible packages.
-func WithTempRegisteredDatabaseInterceptor(lock libevm.ExtrasLock, i DatabaseInterceptor, fn func() error) error {
+func WithTempRegisteredDatabaseInterceptor(lock libevm.ExtrasLock, dbi DatabaseInterceptor, fn func() error) error {
 	if err := lock.Verify(); err != nil {
 		return err
 	}
-	return registeredInterceptor.TempOverride(i, fn)
+	return registeredInterceptor.TempOverride(dbi, fn)
 }
 
-// TestOnlyClearRegisteredDatabaseInterceptor clears the arguments previously passed to
+// TestOnlyClearRegisteredDatabaseInterceptor clears the argument previously passed to
 // [RegisterDatabaseInterceptor]. It panics if called from a non-testing call stack.
 //
 // In tests it SHOULD be called before every call to [RegisterDatabaseInterceptor] and then
@@ -69,22 +69,19 @@ var registeredInterceptor register.AtMostOnce[DatabaseInterceptor]
 // database will be the result of passing the [Database] returned by this
 // function to the interceptor.
 func NewDatabaseWithConfig(db ethdb.Database, config *triedb.Config) Database {
-	cache := newDatabaseWithConfig(db, config)
-	r := &registeredInterceptor
-	if !r.Registered() {
-		return cache
-	}
-	return r.Get()(cache)
+	return interceptDB(newDatabaseWithConfig(db, config))
 }
 
 // NewDatabaseWithNodeDB creates a state database with an already initialized node database.
 // If a [DatabaseInterceptor] is registered, the returned database will be the result of
 // passing the [Database] returned by this function to the interceptor.
 func NewDatabaseWithNodeDB(db ethdb.Database, triedb *triedb.Database) Database {
-	cache := newDatabaseWithNodeDB(db, triedb)
-	r := &registeredInterceptor
-	if !r.Registered() {
-		return cache
+	return interceptDB(newDatabaseWithNodeDB(db, triedb))
+}
+
+func interceptDB(db Database) Database {
+	if r := &registeredInterceptor; r.Registered() {
+		return r.Get()(db)
 	}
-	return r.Get()(cache)
+	return db
 }

--- a/core/state/database.libevm_test.go
+++ b/core/state/database.libevm_test.go
@@ -39,12 +39,15 @@ func TestDatabaseRegistration(t *testing.T) {
 	assertDBWrapped(t, true)
 }
 func TestTempDatabaseRegistration(t *testing.T) {
-	libevm.WithTemporaryExtrasLock(func(lock libevm.ExtrasLock) error {
+	err := libevm.WithTemporaryExtrasLock(func(lock libevm.ExtrasLock) error {
 		return WithTempRegisteredDatabaseInterceptor(lock, dbInterceptor, func() error {
 			assertDBWrapped(t, true)
 			return nil
 		})
 	})
+	if err != nil {
+		t.Fatalf("during temp registration: %v", err)
+	}
 
 	assertDBWrapped(t, false)
 }

--- a/core/state/database.libevm_test.go
+++ b/core/state/database.libevm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 the libevm authors.
+// Copyright 2026 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License

--- a/core/state/database.libevm_test.go
+++ b/core/state/database.libevm_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/ava-labs/libevm/libevm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dbWrapper struct {
@@ -45,28 +47,21 @@ func TestTempDatabaseRegistration(t *testing.T) {
 			return nil
 		})
 	})
-	if err != nil {
-		t.Fatalf("during temp registration: %v", err)
-	}
+	require.NoError(t, err, "WithTempRegisteredDatabaseInterceptor")
 
 	assertDBWrapped(t, false)
 }
 
-func assertDBWrapped(t *testing.T, expectWrapped bool) {
+func assertDBWrapped(t *testing.T, wantWrapped bool) {
 	t.Helper()
 
-	db := NewDatabase(nil)
-	if _, ok := db.(*dbWrapper); ok != expectWrapped {
-		t.Errorf("expected database to be wrapped by %T, got %T", &dbWrapper{}, db)
+	var wantType any
+	if wantWrapped {
+		wantType = &dbWrapper{}
+	} else {
+		wantType = &cachingDB{}
 	}
-
-	db = NewDatabaseWithConfig(nil, nil)
-	if _, ok := db.(*dbWrapper); ok != expectWrapped {
-		t.Errorf("expected database to be wrapped by %T, got %T", &dbWrapper{}, db)
-	}
-
-	db = NewDatabaseWithNodeDB(nil, nil)
-	if _, ok := db.(*dbWrapper); ok != expectWrapped {
-		t.Errorf("expected database to be wrapped by %T, got %T", &dbWrapper{}, db)
-	}
+	assert.IsType(t, wantType, NewDatabase(nil), "NewDatabase(nil)")
+	assert.IsType(t, wantType, NewDatabaseWithConfig(nil, nil), "NewDatabaseWithConfig(nil, nil)")
+	assert.IsType(t, wantType, NewDatabaseWithNodeDB(nil, nil), "NewDatabaseWithNodeDB(nil, nil)")
 }

--- a/core/state/database.libevm_test.go
+++ b/core/state/database.libevm_test.go
@@ -19,9 +19,10 @@ package state
 import (
 	"testing"
 
-	"github.com/ava-labs/libevm/libevm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/libevm/libevm"
 )
 
 type dbWrapper struct {

--- a/core/state/database.libevm_test.go
+++ b/core/state/database.libevm_test.go
@@ -1,0 +1,69 @@
+// Copyright 2024 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/ava-labs/libevm/libevm"
+)
+
+type dbWrapper struct {
+	Database
+}
+
+func dbInterceptor(db Database) Database {
+	return &dbWrapper{Database: db}
+}
+
+func TestDatabaseRegistration(t *testing.T) {
+	assertDBWrapped(t, false)
+
+	RegisterDatabaseInterceptor(dbInterceptor)
+	t.Cleanup(TestOnlyClearRegisteredDatabaseInterceptor)
+
+	assertDBWrapped(t, true)
+}
+func TestTempDatabaseRegistration(t *testing.T) {
+	libevm.WithTemporaryExtrasLock(func(lock libevm.ExtrasLock) error {
+		return WithTempRegisteredDatabaseInterceptor(lock, dbInterceptor, func() error {
+			assertDBWrapped(t, true)
+			return nil
+		})
+	})
+
+	assertDBWrapped(t, false)
+}
+
+func assertDBWrapped(t *testing.T, expectWrapped bool) {
+	t.Helper()
+
+	db := NewDatabase(nil)
+	if _, ok := db.(*dbWrapper); ok != expectWrapped {
+		t.Errorf("expected database to be wrapped by %T, got %T", &dbWrapper{}, db)
+	}
+
+	db = NewDatabaseWithConfig(nil, nil)
+	if _, ok := db.(*dbWrapper); ok != expectWrapped {
+		t.Errorf("expected database to be wrapped by %T, got %T", &dbWrapper{}, db)
+	}
+
+	db = NewDatabaseWithNodeDB(nil, nil)
+	if _, ok := db.(*dbWrapper); ok != expectWrapped {
+		t.Errorf("expected database to be wrapped by %T, got %T", &dbWrapper{}, db)
+	}
+}

--- a/core/state/statedb.libevm.go
+++ b/core/state/statedb.libevm.go
@@ -90,8 +90,9 @@ func RegisterExtras(s StateDBHooks) {
 //
 // This MUST NOT be used on a live chain. It is solely intended for off-chain
 // consumers that require access to extras. Said consumers SHOULD NOT, however
-// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
-// function instead as it atomically overrides all possible packages.
+// call this function directly. Use the [libevm.WithTemporaryExtrasLock]
+// function instead in combination with all other registrations to ensure
+// that temporary registrations are atomically applied.
 func WithTempRegisteredExtras(lock libevm.ExtrasLock, s StateDBHooks, fn func() error) error {
 	if err := lock.Verify(); err != nil {
 		return err

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -109,8 +109,9 @@ func payloadsAndConstructors[
 //
 // This MUST NOT be used on a live chain. It is solely intended for off-chain
 // consumers that require access to extras. Said consumers SHOULD NOT, however
-// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
-// function instead as it atomically overrides all possible packages.
+// call this function directly. Use the [libevm.WithTemporaryExtrasLock]
+// function instead in combination with all other registrations to ensure
+// that temporary registrations are atomically applied.
 func WithTempRegisteredExtras[
 	H, B, SA any,
 	HPtr HeaderHooksPointer[H],

--- a/core/vm/hooks.libevm.go
+++ b/core/vm/hooks.libevm.go
@@ -36,8 +36,9 @@ func RegisterHooks(h Hooks) {
 //
 // This MUST NOT be used on a live chain. It is solely intended for off-chain
 // consumers that require access to extras. Said consumers SHOULD NOT, however
-// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
-// function instead as it atomically overrides all possible packages.
+// call this function directly. Use the [libevm.WithTemporaryExtrasLock]
+// function instead in combination with all other registrations to ensure
+// that temporary registrations are atomically applied.
 func WithTempRegisteredHooks(lock libevm.ExtrasLock, h Hooks, fn func() error) error {
 	if err := lock.Verify(); err != nil {
 		return err

--- a/params/config.libevm.go
+++ b/params/config.libevm.go
@@ -104,8 +104,9 @@ func payloadsAndConstructors[C ChainConfigHooks, R RulesHooks](e Extras[C, R]) (
 //
 // This MUST NOT be used on a live chain. It is solely intended for off-chain
 // consumers that require access to extras. Said consumers SHOULD NOT, however
-// call this function directly. Use the libevm/temporary.WithRegisteredExtras()
-// function instead as it atomically overrides all possible packages.
+// call this function directly. Use the [libevm.WithTemporaryExtrasLock]
+// function instead in combination with all other registrations to ensure
+// that temporary registrations are atomically applied.
 func WithTempRegisteredExtras[C ChainConfigHooks, R RulesHooks](
 	lock libevm.ExtrasLock,
 	e Extras[C, R],


### PR DESCRIPTION
## Why this should be merged

For Firewood, there's many places in libevm where it uses these methods to construct a `state.Database`, but we need a different implementation. Since this is separate from the `StateDB` interfaces (I don't want to have to register for each test, but rather in a single `init` function), I made it a separate registration for simplicity.

The ultimate goal is for ava-labs/avalancheg#5314, so if this approach is not correct to enable that, this PR should not be merged.

## How this works

Intercept each creation with the possibility of wrapping the state cache if it is registered.

## How this was tested

Added some no-op unit tests.