### PR TITLE
fix: `reentrancy.Guard()` panic on static call

### DIFF
--- a/libevm/reentrancy/guard.go
+++ b/libevm/reentrancy/guard.go
@@ -33,11 +33,16 @@ var slotPreimagePrefix = []byte("libevm-reentrancy-guard-")
 
 // Guard returns [vm.ErrExecutionReverted] i.f.f. it has already been called
 // with the same `key`, by the same contract, in the same transaction. It
-// otherwise returns nil. The `key` MAY be nil.
+// otherwise returns nil unless in a read-only context, in which case it always
+// returns [vm.ErrWriteProtection]. The `key` MAY be nil.
 //
 // Contract equality is defined as the [libevm.AddressContext] "self" address
 // being the same under EVM semantics.
 func Guard(env vm.PrecompileEnvironment, key []byte) error {
+	if env.ReadOnly() {
+		return vm.ErrWriteProtection
+	}
+
 	self := env.Addresses().EVMSemantic.Self
 	slot := crypto.Keccak256Hash(slotPreimagePrefix, key)
 

--- a/libevm/reentrancy/guard_test.go
+++ b/libevm/reentrancy/guard_test.go
@@ -76,6 +76,11 @@ func TestGuardIntegration(t *testing.T) {
 	// This MUST NOT be [assert.ErrorIs] as such errors are never wrapped in geth.
 	assert.Equal(t, err, vm.ErrExecutionReverted, "Precompile reverted")
 	assert.Equal(t, returnIfGuarded, got, "Precompile reverted with expected data")
+
+	t.Run("static_call", func(t *testing.T) {
+		_, _, err := evm.StaticCall(vm.AccountRef{}, sut, []byte{}, 1e6)
+		require.Equal(t, vm.ErrWriteProtection, err, "StaticCall()")
+	})
 }
 
 type envStub struct {
@@ -90,6 +95,10 @@ func (s *envStub) Addresses() *libevm.AddressContext {
 			Self: s.self,
 		},
 	}
+}
+
+func (*envStub) ReadOnly() bool {
+	return false
 }
 
 func (s *envStub) StateDB() vm.StateDB {


### PR DESCRIPTION
## Why this should be merged

Could cause a panic on a live chain. This isn't in production anywhere so no upgrade is required.

## How this works

Checks for a read-only environment before using the state DB, which would otherwise result in a nil-pointer dereference.

This actually points to a deeper code smell about `vm.PrecompileEnvironment` in that it's too easy to misuse the `StateDB()` method. It should probably have its return signature changed to `(*state.StateDB, error)` and return `vm.ErrWriteProtection` instead of a `nil` DB when in read-only contexts.

## How this was tested

Extended existing integration test to perform a static call to the guarded precompile, asserting a `vm.ErrWriteProtection`.