### PR TITLE
feat: `types.{Header,BlockBody}Hooks.PostRPCMarshal` methods

### DIFF
--- a/core/types/backwards_compat.libevm_test.go
+++ b/core/types/backwards_compat.libevm_test.go
@@ -200,6 +200,7 @@ func TestBlockRLPBackwardsCompatibility(t *testing.T) {
 type cChainBodyExtras struct {
 	Version uint32
 	ExtData *[]byte
+	NOOPBlockBodyHooks
 }
 
 var _ BlockBodyHooks = (*cChainBodyExtras)(nil)

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -32,7 +32,7 @@ type HeaderHooks interface {
 	EncodeRLP(*Header, io.Writer) error
 	DecodeRLP(*Header, *rlp.Stream) error
 	PostCopy(dst *Header)
-	PostRPCMarshal(map[string]any) map[string]any
+	PostRPCMarshal(h *Header, marshalled map[string]any)
 }
 
 var _ interface {
@@ -86,9 +86,7 @@ func (*NOOPHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 }
 func (*NOOPHeaderHooks) PostCopy(dst *Header) {}
 
-func (*NOOPHeaderHooks) PostRPCMarshal(m map[string]any) map[string]any {
-	return m
-}
+func (*NOOPHeaderHooks) PostRPCMarshal(*Header, map[string]any) {}
 
 var _ = []interface {
 	rlp.Encoder
@@ -129,7 +127,7 @@ type BlockBodyHooks interface {
 	BlockRLPFieldPointersForDecoding(*BlockRLPProxy) *rlp.Fields
 	BodyRLPFieldsForEncoding(*Body) *rlp.Fields
 	BodyRLPFieldPointersForDecoding(*Body) *rlp.Fields
-	PostRPCMarshal(map[string]any) map[string]any
+	PostRPCMarshal(b *Block, marshalled map[string]any)
 }
 
 // NOOPBlockBodyHooks implements [BlockBodyHooks] such that they are equivalent
@@ -186,6 +184,4 @@ func (NOOPBlockBodyHooks) BodyRLPFieldPointersForDecoding(b *Body) *rlp.Fields {
 	}
 }
 
-func (NOOPBlockBodyHooks) PostRPCMarshal(m map[string]any) map[string]any {
-	return m
-}
+func (NOOPBlockBodyHooks) PostRPCMarshal(*Block, map[string]any) {}

--- a/core/types/block.libevm.go
+++ b/core/types/block.libevm.go
@@ -32,6 +32,7 @@ type HeaderHooks interface {
 	EncodeRLP(*Header, io.Writer) error
 	DecodeRLP(*Header, *rlp.Stream) error
 	PostCopy(dst *Header)
+	PostRPCMarshal(map[string]any) map[string]any
 }
 
 var _ interface {
@@ -85,6 +86,10 @@ func (*NOOPHeaderHooks) DecodeRLP(h *Header, s *rlp.Stream) error {
 }
 func (*NOOPHeaderHooks) PostCopy(dst *Header) {}
 
+func (*NOOPHeaderHooks) PostRPCMarshal(m map[string]any) map[string]any {
+	return m
+}
+
 var _ = []interface {
 	rlp.Encoder
 	rlp.Decoder
@@ -124,6 +129,7 @@ type BlockBodyHooks interface {
 	BlockRLPFieldPointersForDecoding(*BlockRLPProxy) *rlp.Fields
 	BodyRLPFieldsForEncoding(*Body) *rlp.Fields
 	BodyRLPFieldPointersForDecoding(*Body) *rlp.Fields
+	PostRPCMarshal(map[string]any) map[string]any
 }
 
 // NOOPBlockBodyHooks implements [BlockBodyHooks] such that they are equivalent
@@ -178,4 +184,8 @@ func (NOOPBlockBodyHooks) BodyRLPFieldPointersForDecoding(b *Body) *rlp.Fields {
 		Required: []any{&b.Transactions, &b.Uncles},
 		Optional: []any{&b.Withdrawals},
 	}
+}
+
+func (NOOPBlockBodyHooks) PostRPCMarshal(m map[string]any) map[string]any {
+	return m
 }

--- a/core/types/block.libevm_test.go
+++ b/core/types/block.libevm_test.go
@@ -43,6 +43,8 @@ type stubHeaderHooks struct {
 	toCopy                                   *stubHeaderHooks
 
 	errMarshal, errUnmarshal, errEncode, errDecode error
+
+	NOOPHeaderHooks
 }
 
 func fakeHeaderJSON(h *Header, suffix []byte) []byte {

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -210,6 +210,10 @@ func (h *Header) hooks() HeaderHooks {
 	return new(NOOPHeaderHooks)
 }
 
+func (h *Header) PostRPCMarshal(m map[string]any) map[string]any {
+	return h.hooks().PostRPCMarshal(m)
+}
+
 func (b *Body) hooks() BlockBodyHooks {
 	if r := registeredExtras; r.Registered() {
 		return r.Get().hooks.hooksFromBody(b)
@@ -222,6 +226,10 @@ func (b *Block) hooks() BlockBodyHooks {
 		return r.Get().hooks.hooksFromBlock(b)
 	}
 	return NOOPBlockBodyHooks{}
+}
+
+func (b *Block) PostRPCMarshal(m map[string]any) map[string]any {
+	return b.hooks().PostRPCMarshal(m)
 }
 
 func (e *StateAccountExtra) clone() *StateAccountExtra {

--- a/core/types/rlp_payload.libevm.go
+++ b/core/types/rlp_payload.libevm.go
@@ -210,8 +210,10 @@ func (h *Header) hooks() HeaderHooks {
 	return new(NOOPHeaderHooks)
 }
 
-func (h *Header) PostRPCMarshal(m map[string]any) map[string]any {
-	return h.hooks().PostRPCMarshal(m)
+// PostRPCMarshal propagates `h` and `m` to the respective method on the
+// registered [HeaderHooks], if any, and is otherwise a noop.
+func (h *Header) PostRPCMarshal(m map[string]any) {
+	h.hooks().PostRPCMarshal(h, m)
 }
 
 func (b *Body) hooks() BlockBodyHooks {
@@ -228,8 +230,10 @@ func (b *Block) hooks() BlockBodyHooks {
 	return NOOPBlockBodyHooks{}
 }
 
-func (b *Block) PostRPCMarshal(m map[string]any) map[string]any {
-	return b.hooks().PostRPCMarshal(m)
+// PostRPCMarshal propagates `b` and `m` to the respective method on the
+// registered [BlockBodyHooks], if any, and is otherwise a noop.
+func (b *Block) PostRPCMarshal(m map[string]any) {
+	b.hooks().PostRPCMarshal(b, m)
 }
 
 func (e *StateAccountExtra) clone() *StateAccountExtra {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1245,7 +1245,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	if head.ParentBeaconRoot != nil {
 		result["parentBeaconBlockRoot"] = head.ParentBeaconRoot
 	}
-	return result
+	return head.PostRPCMarshal(result)
 }
 
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
@@ -1280,7 +1280,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 	if block.Header().WithdrawalsHash != nil {
 		fields["withdrawals"] = block.Withdrawals()
 	}
-	return fields
+	return block.PostRPCMarshal(fields)
 }
 
 // rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1245,7 +1245,8 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	if head.ParentBeaconRoot != nil {
 		result["parentBeaconBlockRoot"] = head.ParentBeaconRoot
 	}
-	return head.PostRPCMarshal(result)
+	head.PostRPCMarshal(result) //libevm
+	return result
 }
 
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
@@ -1280,7 +1281,8 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 	if block.Header().WithdrawalsHash != nil {
 		fields["withdrawals"] = block.Withdrawals()
 	}
-	return block.PostRPCMarshal(fields)
+	block.PostRPCMarshal(fields) //libevm
+	return fields
 }
 
 // rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires

--- a/libevm/ethapi/ethapi_test.go
+++ b/libevm/ethapi/ethapi_test.go
@@ -1,3 +1,19 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
 package ethapi
 
 import (

--- a/libevm/ethapi/ethapi_test.go
+++ b/libevm/ethapi/ethapi_test.go
@@ -1,0 +1,101 @@
+package ethapi
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"math/big"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type headerHooks struct {
+	add map[string]any
+	types.NOOPHeaderHooks
+}
+
+func (hh *headerHooks) PostRPCMarshal(_ *types.Header, m map[string]any) {
+	maps.Copy(m, hh.add)
+}
+
+type blockHooks struct {
+	add map[string]any
+	types.NOOPBlockBodyHooks
+}
+
+func (bh *blockHooks) PostRPCMarshal(_ *types.Block, m map[string]any) {
+	maps.Copy(m, bh.add)
+}
+
+func (b *blockHooks) Copy() *blockHooks {
+	return &blockHooks{
+		add: maps.Clone(b.add),
+	}
+}
+
+type backend struct {
+	blocks map[common.Hash]*types.Block
+	Backend
+}
+
+func (be *backend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	b, ok := be.blocks[hash]
+	if !ok {
+		return nil, fmt.Errorf("%v not found", hash)
+	}
+	return b, nil
+}
+
+func (be *backend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	b, err := be.BlockByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	return b.Header(), nil
+}
+
+// Ancillary methods required by getters.
+func (*backend) ChainConfig() *params.ChainConfig            { return params.MergedTestChainConfig }
+func (*backend) GetTd(context.Context, common.Hash) *big.Int { return big.NewInt(0) }
+
+func TestPostRPCMarshalHooks(t *testing.T) {
+	extras := types.RegisterExtras[headerHooks, *headerHooks, blockHooks, *blockHooks, struct{}]()
+	t.Cleanup(types.TestOnlyClearRegisteredExtras)
+
+	const (
+		extraKey        = "libevm_extra_field"
+		headerValue int = 42
+		blockValue  int = 1e6
+	)
+
+	hdr := &types.Header{}
+	extras.Header.Set(hdr, &headerHooks{
+		add: map[string]any{extraKey: headerValue},
+	})
+
+	blk := types.NewBlockWithHeader(hdr)
+	extras.Block.Set(blk, &blockHooks{
+		add: map[string]any{extraKey: blockValue},
+	})
+
+	api := NewBlockChainAPI(&backend{
+		blocks: map[common.Hash]*types.Block{
+			blk.Hash(): blk,
+		},
+	})
+
+	t.Run("HeaderHooks", func(t *testing.T) {
+		got := api.GetHeaderByHash(t.Context(), blk.Hash())
+		assert.Equalf(t, headerValue, got[extraKey], "%T.GetHeaderByHash(...)[%q]", api, extraKey)
+	})
+	t.Run("BlockBodyHooks", func(t *testing.T) {
+		got, err := api.GetBlockByHash(t.Context(), blk.Hash(), false)
+		require.NoErrorf(t, err, "%T.GetBlockByHash(...)", api)
+		assert.Equalf(t, blockValue, got[extraKey], "%T.GetBlockByHash(...)[%q]", api, extraKey)
+	})
+}

--- a/libevm/ethapi/ethapi_test.go
+++ b/libevm/ethapi/ethapi_test.go
@@ -23,11 +23,12 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/params"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type headerHooks struct {


### PR DESCRIPTION
## Why this should be merged

RPC support of `types.Header` and `types.Block` extra payloads.

## How this works

Adds `PostRPCMarshal()` methods to `types.HeaderHooks` and `types.BlockBodyHooks`, which are called by the respect `ethapi` functions to allow for mutation of the output before being returned by the RPC endpoint.

## How this was tested

Integration test of new hooks with `internal/ethapi/BlockChainAPI`.