### PR TITLE
feat: allow disabling gas refunds

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -479,12 +479,9 @@ func (st *StateTransition) refundGas(refundQuotient uint64) uint64 {
 	if refund > st.state.GetRefund() {
 		refund = st.state.GetRefund()
 	}
-	if !st.shouldRefundGas() { // libevm
-		refund = 0
-	}
 	st.gasRemaining += refund
 
-	st.consumeMinimumGas() // libevm: see comment on method re call-site requirements
+	st.afterGasRefund(refund) // libevm: see [StateTransition.consumeMinimumGas] re call-site requirements
 
 	// Return ETH for remaining gas, exchanged at the original rate.
 	remaining := uint256.NewInt(st.gasRemaining)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -479,6 +479,9 @@ func (st *StateTransition) refundGas(refundQuotient uint64) uint64 {
 	if refund > st.state.GetRefund() {
 		refund = st.state.GetRefund()
 	}
+	if !st.shouldRefundGas() { // libevm
+		refund = 0
+	}
 	st.gasRemaining += refund
 
 	st.consumeMinimumGas() // libevm: see comment on method re call-site requirements

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -94,6 +94,10 @@ func (st *StateTransition) canExecuteTransaction() error {
 	return nil
 }
 
+func (st *StateTransition) shouldRefundGas() bool {
+	return st.rulesHooks().ShouldRefundGas()
+}
+
 // consumeMinimumGas updates the gas remaining to reflect the value returned by
 // [params.RulesHooks.MinimumGasConsumption]. It MUST be called after all code
 // that modifies gas consumption but before the balance is returned for

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -94,8 +94,11 @@ func (st *StateTransition) canExecuteTransaction() error {
 	return nil
 }
 
-func (st *StateTransition) shouldRefundGas() bool {
-	return st.rulesHooks().ShouldRefundGas()
+func (st *StateTransition) afterGasRefund(refunded uint64) {
+	if !st.rulesHooks().ShouldRefundGas() {
+		st.gasRemaining -= refunded
+	}
+	st.consumeMinimumGas()
 }
 
 // consumeMinimumGas updates the gas remaining to reflect the value returned by

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -94,18 +94,16 @@ func (st *StateTransition) canExecuteTransaction() error {
 	return nil
 }
 
+// afterGasRefund updates the gas remaining to reflect the
+// [params.RulesHooks.ShouldRefundGas] and
+// [params.RulesHooks.MinimumGasConsumption] methods. It MUST be called after
+// all code that modifies gas consumption but before the balance is returned for
+// remaining gas.
 func (st *StateTransition) afterGasRefund(refunded uint64) {
 	if !st.rulesHooks().ShouldRefundGas() {
 		st.gasRemaining -= refunded
 	}
-	st.consumeMinimumGas()
-}
 
-// consumeMinimumGas updates the gas remaining to reflect the value returned by
-// [params.RulesHooks.MinimumGasConsumption]. It MUST be called after all code
-// that modifies gas consumption but before the balance is returned for
-// remaining gas.
-func (st *StateTransition) consumeMinimumGas() {
 	limit := st.msg.GasLimit
 	minConsume := min(
 		limit, // as documented in [params.RulesHooks]

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -300,3 +300,69 @@ func TestMinimumGasConsumption(t *testing.T) {
 		})
 	}
 }
+
+func TestGasRefunds(t *testing.T) {
+	const refund = 100
+
+	tests := []struct {
+		shouldRefund bool
+		want         uint64
+	}{
+		{
+			shouldRefund: true,
+			want:         params.TxGas - refund,
+		},
+		{
+			shouldRefund: false,
+			want:         params.TxGas,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("should_refund_%t", tt.shouldRefund), func(t *testing.T) {
+			refunder := common.Address{'r', 'e'}
+			hooks := &hookstest.Stub{
+				DisableGasRefunds: !tt.shouldRefund,
+				PrecompileOverrides: map[common.Address]libevm.PrecompiledContract{
+					refunder: vm.NewStatefulPrecompile(func(env vm.PrecompileEnvironment, _ []byte) ([]byte, error) {
+						env.StateDB().AddRefund(refund)
+						return nil, nil
+					}),
+				},
+			}
+			hooks.Register(t)
+
+			sdb, evm := ethtest.NewZeroEVM(t)
+
+			key, err := crypto.GenerateKey()
+			require.NoError(t, err, "crypto.GenerateKey()")
+			sdb.AddBalance(crypto.PubkeyToAddress(key.PublicKey), new(uint256.Int).SetAllOne())
+
+			tx := types.MustSignNewTx(
+				key,
+				types.LatestSigner(evm.ChainConfig()),
+				&types.LegacyTx{
+					To:       &refunder,
+					Gas:      1e6,
+					GasPrice: big.NewInt(1),
+				},
+			)
+
+			gp := core.GasPool(math.MaxUint64)
+			var got uint64
+			receipt, err := core.ApplyTransaction(
+				evm.ChainConfig(), nil, &common.Address{}, &gp, sdb,
+				&types.Header{
+					Number:     big.NewInt(0),
+					Difficulty: big.NewInt(0),
+				},
+				tx, &got, vm.Config{},
+			)
+			require.NoError(t, err, "core.ApplyTransaction(...)")
+			require.Equalf(t, types.ReceiptStatusSuccessful, receipt.Status, "%T.Status", receipt)
+
+			assert.Equal(t, tt.want, got, "core.ApplyTransaction(..., gasUsed *uint64, ...)")
+			assert.Equalf(t, tt.want, receipt.GasUsed, "%T.GasUsed", receipt)
+		})
+	}
+}

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -336,7 +336,7 @@ func TestGasRefunds(t *testing.T) {
 
 			key, err := crypto.GenerateKey()
 			require.NoError(t, err, "crypto.GenerateKey()")
-			sdb.AddBalance(crypto.PubkeyToAddress(key.PublicKey), new(uint256.Int).SetAllOne())
+			sdb.SetBalance(crypto.PubkeyToAddress(key.PublicKey), new(uint256.Int).SetAllOne())
 
 			tx := types.MustSignNewTx(
 				key,

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -142,6 +142,10 @@ func (s Stub) CanCreateContract(cc *libevm.AddressContext, gas uint64, sr libevm
 	return gas, nil
 }
 
+func (s Stub) ShouldRefundGas() bool {
+	return true
+}
+
 // MinimumGasConsumption proxies arguments to the s.MinimumGasConsumptionFn
 // function if non-nil, otherwise it acts as a noop.
 func (s Stub) MinimumGasConsumption(limit uint64) uint64 {

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -51,6 +51,7 @@ type Stub struct {
 	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
 	CanCreateContractFn     func(*libevm.AddressContext, uint64, libevm.StateReader) (uint64, error)
 	MinimumGasConsumptionFn func(txGasLimit uint64) uint64
+	DisableGasRefunds       bool
 }
 
 // Register is a convenience wrapper for registering s as both the
@@ -142,8 +143,15 @@ func (s Stub) CanCreateContract(cc *libevm.AddressContext, gas uint64, sr libevm
 	return gas, nil
 }
 
+// ShouldRefundGas returns the negation of [Stub.DisableGasRefund].
+//
+// Although the double-negation of the boolean isn't ideal for readability, this
+// allows the zero [Stub] to mirror default behaviour, while keeping the
+// production hook name as a [positive boolean].
+//
+// [positive boolean]: https://testing.googleblog.com/2023/10/improve-readability-with-positive.html
 func (s Stub) ShouldRefundGas() bool {
-	return true
+	return !s.DisableGasRefunds
 }
 
 // MinimumGasConsumption proxies arguments to the s.MinimumGasConsumptionFn

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -62,6 +62,8 @@ type RulesHooks interface {
 	// called if the access list is nil. The hook MAY return an error (e.g., for
 	// gas overflow).
 	AccessListGas(accessList libevm.AccessList) (gas uint64, override bool, err error)
+	// ShouldRefundGas returns whether or not to honour gas refunds, which is
+	// otherwise the default behaviour.
 	ShouldRefundGas() bool
 	// MinimumGasConsumption receives a transaction's gas limit and returns the
 	// minimum quantity of gas units to be charged for said transaction. If the

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -62,6 +62,7 @@ type RulesHooks interface {
 	// called if the access list is nil. The hook MAY return an error (e.g., for
 	// gas overflow).
 	AccessListGas(accessList libevm.AccessList) (gas uint64, override bool, err error)
+	ShouldRefundGas() bool
 	// MinimumGasConsumption receives a transaction's gas limit and returns the
 	// minimum quantity of gas units to be charged for said transaction. If the
 	// returned value is greater than the transaction's limit, the minimum spend
@@ -150,6 +151,11 @@ func (NOOPHooks) ActivePrecompiles(active []common.Address) []common.Address {
 // AccessListGas returns override=false and nil error, signalling to use the default calculation.
 func (NOOPHooks) AccessListGas(_ libevm.AccessList) (uint64, bool, error) {
 	return 0, false, nil
+}
+
+// ShouldRefundGas always returns true.
+func (NOOPHooks) ShouldRefundGas() bool {
+	return true
 }
 
 // MinimumGasConsumption always returns 0.


### PR DESCRIPTION
## Why this should be merged

Avalanche C-Chain doesn't refund gas and needs to use the `libevm/core.ApplyTransaction()` function for SAE.

## How this works

Adds `params.RulesHooks.ShouldRefundGas() bool` with a no-op implementation that always returns `true`.

## How this was tested

Integration test exercised via `core.ApplyTransaction()`, demonstrating refund behaviour in both the default and disabled states.