### PR TITLE
feat: `core.SetBeaconBlockRoot()` direct state setting

### DIFF
--- a/core/state_processor.libevm.go
+++ b/core/state_processor.libevm.go
@@ -41,6 +41,7 @@ func SetBeaconBlockRoot(sdb *state.StateDB, hdr *types.Header) {
 
 	sdb.SetState(params.BeaconRootsStorageAddress, uint64ToHash(timeIdx), uint64ToHash(hdr.Time))
 	sdb.SetState(params.BeaconRootsStorageAddress, uint64ToHash(rootIdx), *hdr.ParentBeaconRoot)
+	sdb.Finalise(true)
 }
 
 func uint64ToHash(x uint64) (h common.Hash) {

--- a/core/state_processor.libevm.go
+++ b/core/state_processor.libevm.go
@@ -1,0 +1,49 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"encoding/binary"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/params"
+)
+
+var beaconRootsCodeHash = common.HexToHash(`0xf57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c`)
+
+// SetBeaconBlockRoot is equivalent to [ProcessBeaconBlockRoot] except that it
+// acts directly on the [state.StateDB] instead of calling the EIP-4788 `set()`
+// function. If [types.Header.ParentBeaconRoot] is nil or the EIP-4788 contract
+// hasn't been deployed, then this function is a no-op.
+func SetBeaconBlockRoot(sdb *state.StateDB, hdr *types.Header) {
+	if hdr.ParentBeaconRoot == nil || sdb.GetCodeHash(params.BeaconRootsStorageAddress) != beaconRootsCodeHash {
+		return
+	}
+	const bufferLen = 8191
+	timeIdx := hdr.Time % bufferLen
+	rootIdx := timeIdx + bufferLen
+
+	sdb.SetState(params.BeaconRootsStorageAddress, uint64ToHash(timeIdx), uint64ToHash(hdr.Time))
+	sdb.SetState(params.BeaconRootsStorageAddress, uint64ToHash(rootIdx), *hdr.ParentBeaconRoot)
+}
+
+func uint64ToHash(x uint64) (h common.Hash) {
+	binary.BigEndian.PutUint64(h[24:], x)
+	return
+}

--- a/core/state_processor.libevm_test.go
+++ b/core/state_processor.libevm_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto"
@@ -38,35 +39,15 @@ import (
 
 func TestSetBeaconBlockRoot(t *testing.T) {
 	for time := uint64(1); time < 1<<14; time += 100 {
-		sdb, evm := ethtest.NewZeroEVM(t,
-			ethtest.WithBlockContext(vm.BlockContext{
-				CanTransfer: CanTransfer,
-				Transfer:    Transfer,
-				BlockNumber: big.NewInt(1),
-				Time:        time,
-				Random:      &common.Hash{}, // implies post-Merge, required for PUSH0
-			}),
-			ethtest.WithChainConfig(params.MergedTestChainConfig),
-		)
-
-		_, addr, _, err := evm.Create(
-			// https://eips.ethereum.org/EIPS/eip-4788
-			vm.AccountRef(common.HexToAddress(`0x0B799C86a49DEeb90402691F1041aa3AF2d3C875`)),
-			common.FromHex(`0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500`),
-			0x3d090,
-			uint256.NewInt(0),
-		)
-		require.NoErrorf(t, err, "%T.Create([EIP-4788 contract])", evm)
-		require.Equalf(t, params.BeaconRootsStorageAddress, addr, "%T.Create([EIP-4788 contract]) deployed address", evm)
 
 		root := crypto.Keccak256Hash(binary.BigEndian.AppendUint64(nil, time))
 		tests := []struct {
 			name  string
-			setup func()
+			setup func(*vm.EVM, *state.StateDB)
 		}{
 			{
 				name: "SetBeaconBlockRoot_SUT",
-				setup: func() {
+				setup: func(_ *vm.EVM, sdb *state.StateDB) {
 					hdr := &types.Header{
 						Time:             time,
 						ParentBeaconRoot: &root,
@@ -76,20 +57,39 @@ func TestSetBeaconBlockRoot(t *testing.T) {
 			},
 			{
 				name: "ProcessBeaconBlockRoot_gold_standard",
-				setup: func() {
+				setup: func(evm *vm.EVM, sdb *state.StateDB) {
 					ProcessBeaconBlockRoot(root, evm, sdb)
 				},
 			},
 		}
 
+		var gotStateRoots [2]common.Hash
+
 		for i, tt := range tests {
 			t.Run(fmt.Sprintf("%s_time_%d", tt.name, time), func(t *testing.T) {
-				if i == 0 { // ProcessBeaconBlockRoot() calls sdb.Finalise() so the snapshot revert would panic
-					snap := sdb.Snapshot()
-					defer sdb.RevertToSnapshot(snap)
-				}
+				sdb, evm := ethtest.NewZeroEVM(t,
+					ethtest.WithBlockContext(vm.BlockContext{
+						CanTransfer: CanTransfer,
+						Transfer:    Transfer,
+						BlockNumber: big.NewInt(1),
+						Time:        time,
+						Random:      &common.Hash{}, // implies post-Merge, required for PUSH0
+					}),
+					ethtest.WithChainConfig(params.MergedTestChainConfig),
+				)
 
-				tt.setup()
+				_, addr, _, err := evm.Create(
+					// https://eips.ethereum.org/EIPS/eip-4788
+					vm.AccountRef(common.HexToAddress(`0x0B799C86a49DEeb90402691F1041aa3AF2d3C875`)),
+					common.FromHex(`0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500`),
+					0x3d090,
+					uint256.NewInt(0),
+				)
+				require.NoErrorf(t, err, "%T.Create([EIP-4788 contract])", evm)
+				require.Equalf(t, params.BeaconRootsStorageAddress, addr, "%T.Create([EIP-4788 contract]) deployed address", evm)
+
+				tt.setup(evm, sdb)
+				gotStateRoots[i] = sdb.IntermediateRoot(true)
 
 				got, _, err := evm.StaticCall(
 					vm.AccountRef{},
@@ -101,5 +101,7 @@ func TestSetBeaconBlockRoot(t *testing.T) {
 				assert.Equal(t, root.Bytes(), got, "%T.StaticCall([EIP-4788 contract], [just-set root's time])")
 			})
 		}
+
+		assert.Equalf(t, gotStateRoots[1], gotStateRoots[0], "%T.IntermediateRoot() after SetBeaconBlockRoot() vs gold-standard ProcessBeaconBlockRoot()", &state.StateDB{})
 	}
 }

--- a/core/state_processor.libevm_test.go
+++ b/core/state_processor.libevm_test.go
@@ -22,6 +22,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/types"
@@ -29,9 +33,6 @@ import (
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/libevm/ethtest"
 	"github.com/ava-labs/libevm/params"
-	"github.com/holiman/uint256"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	. "github.com/ava-labs/libevm/core"
 )

--- a/core/state_processor.libevm_test.go
+++ b/core/state_processor.libevm_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package core_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/core/vm"
+	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/libevm/ethtest"
+	"github.com/ava-labs/libevm/params"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/ava-labs/libevm/core"
+)
+
+func TestSetBeaconBlockRoot(t *testing.T) {
+	for time := uint64(1); time < 1<<14; time += 100 {
+		sdb, evm := ethtest.NewZeroEVM(t,
+			ethtest.WithBlockContext(vm.BlockContext{
+				CanTransfer: core.CanTransfer,
+				Transfer:    core.Transfer,
+				BlockNumber: big.NewInt(1),
+				Time:        time,
+				Random:      &common.Hash{}, // implies post-Merge, required for PUSH0
+			}),
+			ethtest.WithChainConfig(params.MergedTestChainConfig),
+		)
+
+		_, addr, _, err := evm.Create(
+			// https://eips.ethereum.org/EIPS/eip-4788
+			vm.AccountRef(common.HexToAddress(`0x0B799C86a49DEeb90402691F1041aa3AF2d3C875`)),
+			common.FromHex(`0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500`),
+			0x3d090,
+			uint256.NewInt(0),
+		)
+		require.NoErrorf(t, err, "%T.Create([EIP-4788 contract])", evm)
+		require.Equalf(t, params.BeaconRootsStorageAddress, addr, "%T.Create([EIP-4788 contract]) deployed address", evm)
+
+		root := crypto.Keccak256Hash(binary.BigEndian.AppendUint64(nil, time))
+		tests := []struct {
+			name  string
+			setup func()
+		}{
+			{
+				name: "SetBeaconBlockRoot_SUT",
+				setup: func() {
+					hdr := &types.Header{
+						Time:             time,
+						ParentBeaconRoot: &root,
+					}
+					SetBeaconBlockRoot(sdb, hdr)
+				},
+			},
+			{
+				name: "ProcessBeaconBlockRoot_gold_standard",
+				setup: func() {
+					ProcessBeaconBlockRoot(root, evm, sdb)
+				},
+			},
+		}
+
+		for i, tt := range tests {
+			t.Run(fmt.Sprintf("%s_time_%d", tt.name, time), func(t *testing.T) {
+				if i == 0 { // ProcessBeaconBlockRoot() calls sdb.Finalise() so the snapshot revert would panic
+					snap := sdb.Snapshot()
+					defer sdb.RevertToSnapshot(snap)
+				}
+
+				tt.setup()
+
+				got, _, err := evm.StaticCall(
+					vm.AccountRef{},
+					params.BeaconRootsStorageAddress,
+					uint256.NewInt(time).PaddedBytes(32),
+					1e6,
+				)
+				require.NoErrorf(t, err, "%T.StaticCall([EIP-4788 contract], [just-set root's time])", evm)
+				assert.Equal(t, root.Bytes(), got, "%T.StaticCall([EIP-4788 contract], [just-set root's time])")
+			})
+		}
+	}
+}

--- a/core/state_processor.libevm_test.go
+++ b/core/state_processor.libevm_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto"
@@ -41,8 +40,8 @@ func TestSetBeaconBlockRoot(t *testing.T) {
 	for time := uint64(1); time < 1<<14; time += 100 {
 		sdb, evm := ethtest.NewZeroEVM(t,
 			ethtest.WithBlockContext(vm.BlockContext{
-				CanTransfer: core.CanTransfer,
-				Transfer:    core.Transfer,
+				CanTransfer: CanTransfer,
+				Transfer:    Transfer,
 				BlockNumber: big.NewInt(1),
 				Time:        time,
 				Random:      &common.Hash{}, // implies post-Merge, required for PUSH0

--- a/core/state_processor.libevm_test.go
+++ b/core/state_processor.libevm_test.go
@@ -27,19 +27,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/libevm/ethtest"
 	"github.com/ava-labs/libevm/params"
-
-	. "github.com/ava-labs/libevm/core"
 )
 
 func TestSetBeaconBlockRoot(t *testing.T) {
 	for time := uint64(1); time < 1<<14; time += 100 {
-
 		root := crypto.Keccak256Hash(binary.BigEndian.AppendUint64(nil, time))
 		tests := []struct {
 			name  string
@@ -52,13 +50,13 @@ func TestSetBeaconBlockRoot(t *testing.T) {
 						Time:             time,
 						ParentBeaconRoot: &root,
 					}
-					SetBeaconBlockRoot(sdb, hdr)
+					core.SetBeaconBlockRoot(sdb, hdr)
 				},
 			},
 			{
 				name: "ProcessBeaconBlockRoot_gold_standard",
 				setup: func(evm *vm.EVM, sdb *state.StateDB) {
-					ProcessBeaconBlockRoot(root, evm, sdb)
+					core.ProcessBeaconBlockRoot(root, evm, sdb)
 				},
 			},
 		}
@@ -69,8 +67,8 @@ func TestSetBeaconBlockRoot(t *testing.T) {
 			t.Run(fmt.Sprintf("%s_time_%d", tt.name, time), func(t *testing.T) {
 				sdb, evm := ethtest.NewZeroEVM(t,
 					ethtest.WithBlockContext(vm.BlockContext{
-						CanTransfer: CanTransfer,
-						Transfer:    Transfer,
+						CanTransfer: core.CanTransfer,
+						Transfer:    core.Transfer,
 						BlockNumber: big.NewInt(1),
 						Time:        time,
 						Random:      &common.Hash{}, // implies post-Merge, required for PUSH0


### PR DESCRIPTION
## Why this should be merged

Simplify setting of the beacon block root in the EIP-4788 history contract without having to construct a `vm.EVM`.

## How this works

Directly sets storage slots, [as allowed by the EIP](https://eips.ethereum.org/EIPS/eip-4788#:~:text=Clients%20may%20decide%20to%20omit%20an%20explicit%20EVM%20call%20and%20directly%20set%20the%20storage%20values). The caveat in the EIP is not relevant to us because we are concerned with the canonical contract.

## How this was tested

Integration test setting the root via the new function and getting via a contract call. Also exercises the upstream `core.ProcessBeaconBlockRoot()` gold standard as a test of the test.
