### PR TITLE
feat(eth/tracers): Add extra execution logic

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -377,6 +377,10 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				failed = err
 				break
 			}
+			if err := beforeBlock(api.backend, statedb, block.Header(), next.Header()); err != nil {
+				failed = err
+				break
+			}
 			// Clean out any pending release functions of trace state. Note this
 			// step must be done after constructing tracing state, because the
 			// tracing state of block next depends on the parent state and construction
@@ -519,6 +523,10 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	}
 	defer release()
 
+	if err := beforeBlock(api.backend, statedb, parent.Header(), block.Header()); err != nil {
+		return nil, err
+	}
+
 	var (
 		roots              []common.Hash
 		signer             = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
@@ -536,7 +544,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			vmenv     = vm.NewEVM(vmctx, txContext, statedb, chainConfig, vm.Config{})
 		)
 		statedb.SetTxContext(tx.Hash(), i)
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit)); err != nil {
+		if err := applyMessage(api.backend, vmenv, statedb, msg); err != nil {
 			log.Warn("Tracing intermediate roots did not complete", "txindex", i, "txhash", tx.Hash(), "err", err)
 			// We intentionally don't return the error here: if we do, then the RPC server will not
 			// return the roots. Most likely, the caller already knows that a certain transaction fails to
@@ -585,6 +593,10 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		return nil, err
 	}
 	defer release()
+
+	if err := beforeBlock(api.backend, statedb, parent.Header(), block.Header()); err != nil {
+		return nil, err
+	}
 
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
@@ -682,7 +694,7 @@ txloop:
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
 		statedb.SetTxContext(tx.Hash(), i)
 		vmenv := vm.NewEVM(blockCtx, core.NewEVMTxContext(msg), statedb, api.backend.ChainConfig(), vm.Config{})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit)); err != nil {
+		if err := applyMessage(api.backend, vmenv, statedb, msg); err != nil {
 			failed = err
 			break txloop
 		}
@@ -727,6 +739,10 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		return nil, err
 	}
 	defer release()
+
+	if err := beforeBlock(api.backend, statedb, parent.Header(), block.Header()); err != nil {
+		return nil, err
+	}
 
 	// Retrieve the tracing configurations, or use default values
 	var (
@@ -789,7 +805,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		statedb.SetTxContext(tx.Hash(), i)
-		_, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit))
+		err = applyMessage(api.backend, vmenv, statedb, msg)
 		if writer != nil {
 			writer.Flush()
 		}
@@ -973,7 +989,7 @@ func (api *API) traceTx(ctx context.Context, message *core.Message, txctx *Conte
 
 	// Call Prepare to clear out the statedb access list
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	if _, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.GasLimit)); err != nil {
+	if err := applyMessage(api.backend, vmenv, statedb, message); err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}
 	return tracer.GetResult()

--- a/eth/tracers/api.libevm.go
+++ b/eth/tracers/api.libevm.go
@@ -1,0 +1,66 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package tracers
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/core/vm"
+)
+
+// ExtraExecutor is an optional interface that a [Backend] can implement to
+// inject extra state changes when the tracing APIs re-execute blocks.
+type ExtraExecutor interface {
+	// BeforeExecutingBlock is called on the state returned by
+	// [Backend.StateAtBlock] before any of the block's transactions are
+	// applied.
+	BeforeExecutingBlock(sdb *state.StateDB, parent, header *types.Header) error
+	// AfterExecutingTransaction is called on the state for each transaction
+	// after being applied.
+	AfterExecutingTransaction(sdb *state.StateDB, bf *big.Int, gasUsed uint64) error
+}
+
+func beforeBlock(b Backend, sdb *state.StateDB, parent, header *types.Header) error {
+	ex, ok := b.(ExtraExecutor)
+	if !ok {
+		return nil
+	}
+	if err := ex.BeforeExecutingBlock(sdb, parent, header); err != nil {
+		return fmt.Errorf("before executing block failed: %w", err)
+	}
+	return nil
+}
+
+func applyMessage(b Backend, vmenv *vm.EVM, sdb *state.StateDB, message *core.Message) error {
+	res, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.GasLimit))
+	if err != nil {
+		return err
+	}
+
+	ex, ok := b.(ExtraExecutor)
+	if !ok {
+		return nil
+	}
+	if err := ex.AfterExecutingTransaction(sdb, vmenv.Context.BaseFee, res.UsedGas); err != nil {
+		return fmt.Errorf("after executing transaction failed: %w", err)
+	}
+	return nil
+}

--- a/eth/tracers/api.libevm_test.go
+++ b/eth/tracers/api.libevm_test.go
@@ -1,0 +1,306 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package tracers
+
+import (
+	"errors"
+	"math/big"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/common/hexutil"
+	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/internal/ethapi"
+	"github.com/ava-labs/libevm/params"
+	"github.com/ava-labs/libevm/rpc"
+)
+
+// extraExecutorBackend wraps a [testBackend] with [ExtraExecutor] hooks that
+// count their invocations and return the configured errors.
+type extraExecutorBackend struct {
+	*testBackend
+
+	t   *testing.T
+	api *API
+
+	account  Account
+	txHashes [][]common.Hash // [block-1][txIndex] of the generated blocks
+
+	errBeforeBlock, errAfterTx     error
+	beforeBlockCalls, afterTxCalls atomic.Int64
+}
+
+var _ ExtraExecutor = (*extraExecutorBackend)(nil)
+
+const (
+	extraExecGenBlocks   = 3
+	extraExecTxsPerBlock = 2
+)
+
+func newExtraExecutorSUT(t *testing.T, errBeforeBlock, errAfterTx error) *extraExecutorBackend {
+	t.Helper()
+
+	account := newAccounts(1)[0]
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			account.addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	signer := types.HomesteadSigner{}
+
+	txHashes := make([][]common.Hash, extraExecGenBlocks)
+	backend := newTestBackend(t, extraExecGenBlocks, genesis, func(i int, b *core.BlockGen) {
+		for j := range extraExecTxsPerBlock {
+			tx, err := types.SignTx(types.NewTx(&types.LegacyTx{
+				Nonce:    uint64(i*extraExecTxsPerBlock + j), // #nosec G115 -- known non-negative
+				To:       &common.Address{},
+				Value:    big.NewInt(1000),
+				Gas:      params.TxGas,
+				GasPrice: b.BaseFee(),
+			}), signer, account.key)
+			require.NoError(t, err, "types.SignTx()")
+			b.AddTx(tx)
+			txHashes[i] = append(txHashes[i], tx.Hash())
+		}
+	})
+
+	sut := &extraExecutorBackend{
+		testBackend:    backend,
+		t:              t,
+		account:        account,
+		txHashes:       txHashes,
+		errBeforeBlock: errBeforeBlock,
+		errAfterTx:     errAfterTx,
+	}
+	sut.api = NewAPI(sut)
+	return sut
+}
+
+func (b *extraExecutorBackend) BeforeExecutingBlock(sdb *state.StateDB, parent, header *types.Header) error {
+	b.beforeBlockCalls.Add(1)
+	assert.Equalf(b.t, parent.Number.Uint64()+1, header.Number.Uint64(), "BeforeExecutingBlock() header.Number, given parent.Number %d", parent.Number.Uint64())
+	return b.errBeforeBlock
+}
+
+func (b *extraExecutorBackend) AfterExecutingTransaction(sdb *state.StateDB, baseFee *big.Int, gasUsed uint64) error {
+	b.afterTxCalls.Add(1)
+	assert.Equal(b.t, params.TxGas, gasUsed, "AfterExecutingTransaction() gasUsed of plain transfer")
+	assert.NotNil(b.t, baseFee, "AfterExecutingTransaction() baseFee")
+	return b.errAfterTx
+}
+
+func (b *extraExecutorBackend) assertCalls(t *testing.T, wantBeforeBlock, wantAfterTx int64) {
+	t.Helper()
+	assert.Equal(t, wantBeforeBlock, b.beforeBlockCalls.Load(), "number of calls to BeforeExecutingBlock()")
+	assert.Equal(t, wantAfterTx, b.afterTxCalls.Load(), "number of calls to AfterExecutingTransaction()")
+}
+
+var (
+	errBeforeBlock = errors.New("BeforeExecutingBlock error")
+	errAfterTx     = errors.New("AfterExecutingTransaction error")
+)
+
+func TestExtraExecutorTraceBlockByNumber(t *testing.T) {
+	tests := []struct {
+		name                       string
+		errBeforeBlock, errAfterTx error
+		wantErr                    error
+		wantAfterTxCalls           int64
+	}{
+		{
+			name:             "no_errors",
+			wantAfterTxCalls: extraExecTxsPerBlock,
+		},
+		{
+			name:             "BeforeExecutingBlock_error",
+			errBeforeBlock:   errBeforeBlock,
+			wantErr:          errBeforeBlock,
+			wantAfterTxCalls: 0,
+		},
+		{
+			name:             "AfterExecutingTransaction_error",
+			errAfterTx:       errAfterTx,
+			wantErr:          errAfterTx,
+			wantAfterTxCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut := newExtraExecutorSUT(t, tt.errBeforeBlock, tt.errAfterTx)
+			defer sut.teardown()
+
+			results, err := sut.api.TraceBlockByNumber(t.Context(), rpc.LatestBlockNumber, nil)
+			require.ErrorIsf(t, err, tt.wantErr, "%T.TraceBlockByNumber() error", sut.api)
+			sut.assertCalls(t, 1, tt.wantAfterTxCalls)
+			if tt.wantErr != nil {
+				return
+			}
+			require.Len(t, results, extraExecTxsPerBlock, "number of traced transactions")
+		})
+	}
+}
+
+func TestExtraExecutorIntermediateRoots(t *testing.T) {
+	tests := []struct {
+		name                       string
+		errBeforeBlock, errAfterTx error
+		wantErr                    error
+		wantAfterTxCalls           int64
+	}{
+		{
+			name:             "no_errors",
+			wantAfterTxCalls: extraExecTxsPerBlock,
+		},
+		{
+			name:           "BeforeExecutingBlock_error",
+			errBeforeBlock: errBeforeBlock,
+			wantErr:        errBeforeBlock,
+		},
+		{
+			name:       "AfterExecutingTransaction_error",
+			errAfterTx: errAfterTx,
+			// IntermediateRoots intentionally swallows transaction errors and
+			// returns the roots accumulated up to that point.
+			wantErr:          nil,
+			wantAfterTxCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut := newExtraExecutorSUT(t, tt.errBeforeBlock, tt.errAfterTx)
+			defer sut.teardown()
+
+			head := sut.chain.CurrentHeader()
+			_, err := sut.api.IntermediateRoots(t.Context(), head.Hash(), nil)
+			require.ErrorIsf(t, err, tt.wantErr, "%T.IntermediateRoots() error", sut.api)
+			sut.assertCalls(t, 1, tt.wantAfterTxCalls)
+		})
+	}
+}
+
+func TestExtraExecutorTraceChain(t *testing.T) {
+	sut := newExtraExecutorSUT(t, nil, nil)
+	defer sut.teardown()
+
+	// TraceChain is only available via subscription, which requires an actual
+	// RPC connection.
+	server := rpc.NewServer()
+	defer server.Stop()
+	require.NoError(t, server.RegisterName("debug", sut.api), "rpc.Server.RegisterName()")
+	client := rpc.DialInProc(server)
+	defer client.Close()
+
+	ch := make(chan *blockTraceResult)
+	sub, err := client.Subscribe(t.Context(), "debug", ch, "traceChain", rpc.BlockNumber(0), rpc.BlockNumber(extraExecGenBlocks), nil)
+	require.NoError(t, err, `rpc.Client.Subscribe("traceChain")`)
+	defer sub.Unsubscribe()
+
+	for i := 1; i <= extraExecGenBlocks; i++ {
+		select {
+		case res := <-ch:
+			assert.Equalf(t, hexutil.Uint64(i), res.Block, "block number of result %d", i)
+			assert.Lenf(t, res.Traces, extraExecTxsPerBlock, "number of traced transactions in block %d", i)
+		case err := <-sub.Err():
+			t.Fatalf("subscription error before receiving all results: %v", err)
+		}
+	}
+	sut.assertCalls(t, extraExecGenBlocks, extraExecGenBlocks*extraExecTxsPerBlock)
+}
+
+// The state given to TraceTransaction and TraceCall is sourced at the
+// transaction, without re-executing the block, so BeforeExecutingBlock is
+// never called (its error MUST NOT be reported) and AfterExecutingTransaction
+// runs after the result has been captured (only its error is observable).
+
+func TestExtraExecutorTraceTransaction(t *testing.T) {
+	tests := []struct {
+		name                       string
+		errBeforeBlock, errAfterTx error
+		wantErr                    error
+	}{
+		{
+			name: "no_errors",
+		},
+		{
+			name:           "BeforeExecutingBlock_error_not_reported",
+			errBeforeBlock: errBeforeBlock,
+			wantErr:        nil,
+		},
+		{
+			name:       "AfterExecutingTransaction_error",
+			errAfterTx: errAfterTx,
+			wantErr:    errAfterTx,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut := newExtraExecutorSUT(t, tt.errBeforeBlock, tt.errAfterTx)
+			defer sut.teardown()
+
+			_, err := sut.api.TraceTransaction(t.Context(), sut.txHashes[extraExecGenBlocks-1][0], nil)
+			require.ErrorIsf(t, err, tt.wantErr, "%T.TraceTransaction() error", sut.api)
+			sut.assertCalls(t, 0, 1)
+		})
+	}
+}
+
+func TestExtraExecutorTraceCall(t *testing.T) {
+	tests := []struct {
+		name                       string
+		errBeforeBlock, errAfterTx error
+		wantErr                    error
+	}{
+		{
+			name: "no_errors",
+		},
+		{
+			name:           "BeforeExecutingBlock_error_not_reported",
+			errBeforeBlock: errBeforeBlock,
+			wantErr:        nil,
+		},
+		{
+			name:       "AfterExecutingTransaction_error",
+			errAfterTx: errAfterTx,
+			wantErr:    errAfterTx,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut := newExtraExecutorSUT(t, tt.errBeforeBlock, tt.errAfterTx)
+			defer sut.teardown()
+
+			args := ethapi.TransactionArgs{
+				From: &sut.account.addr,
+				To:   &common.Address{},
+			}
+			_, err := sut.api.TraceCall(t.Context(), args, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), nil)
+			require.ErrorIsf(t, err, tt.wantErr, "%T.TraceCall() error", sut.api)
+			sut.assertCalls(t, 0, 1)
+		})
+	}
+}


### PR DESCRIPTION
## Why this should be merged

As a possible solution to simplify ava-labs/avalanchego#5622, we can create an optional interface and perform the extra computation needed by SAE within the tracer package.

## How this works

Optional interfaces, no changes if not implemented.

## How this was tested

New + existing UT