### PR TITLE
feat(eth/tracers): export callback-driven `TraceTx` 

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -377,6 +377,10 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				failed = err
 				break
 			}
+			if err := beforeExecutingBlock(api.backend, statedb, block.Header(), next.Header()); err != nil {
+				failed = err
+				break
+			}
 			// Clean out any pending release functions of trace state. Note this
 			// step must be done after constructing tracing state, because the
 			// tracing state of block next depends on the parent state and construction
@@ -519,6 +523,10 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	}
 	defer release()
 
+	if err := beforeExecutingBlock(api.backend, statedb, parent.Header(), block.Header()); err != nil {
+		return nil, err
+	}
+
 	var (
 		roots              []common.Hash
 		signer             = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
@@ -536,7 +544,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			vmenv     = vm.NewEVM(vmctx, txContext, statedb, chainConfig, vm.Config{})
 		)
 		statedb.SetTxContext(tx.Hash(), i)
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit)); err != nil {
+		if err := applyMessage(api.backend, vmenv, statedb, msg); err != nil {
 			log.Warn("Tracing intermediate roots did not complete", "txindex", i, "txhash", tx.Hash(), "err", err)
 			// We intentionally don't return the error here: if we do, then the RPC server will not
 			// return the roots. Most likely, the caller already knows that a certain transaction fails to
@@ -585,6 +593,10 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		return nil, err
 	}
 	defer release()
+
+	if err := beforeExecutingBlock(api.backend, statedb, parent.Header(), block.Header()); err != nil {
+		return nil, err
+	}
 
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
@@ -682,7 +694,7 @@ txloop:
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
 		statedb.SetTxContext(tx.Hash(), i)
 		vmenv := vm.NewEVM(blockCtx, core.NewEVMTxContext(msg), statedb, api.backend.ChainConfig(), vm.Config{})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit)); err != nil {
+		if err := applyMessage(api.backend, vmenv, statedb, msg); err != nil {
 			failed = err
 			break txloop
 		}
@@ -727,6 +739,10 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		return nil, err
 	}
 	defer release()
+
+	if err := beforeExecutingBlock(api.backend, statedb, parent.Header(), block.Header()); err != nil {
+		return nil, err
+	}
 
 	// Retrieve the tracing configurations, or use default values
 	var (
@@ -789,7 +805,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		statedb.SetTxContext(tx.Hash(), i)
-		_, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit))
+		err = applyMessage(api.backend, vmenv, statedb, msg)
 		if writer != nil {
 			writer.Flush()
 		}
@@ -973,7 +989,7 @@ func (api *API) traceTx(ctx context.Context, message *core.Message, txctx *Conte
 
 	// Call Prepare to clear out the statedb access list
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	if _, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.GasLimit)); err != nil {
+	if err := applyMessage(api.backend, vmenv, statedb, message); err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}
 	return tracer.GetResult()

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -951,48 +951,16 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.
 func (api *API) traceTx(ctx context.Context, message *core.Message, txctx *Context, vmctx vm.BlockContext, statedb *state.StateDB, config *TraceConfig) (interface{}, error) {
-	var (
-		tracer    Tracer
-		err       error
-		timeout   = defaultTraceTimeout
-		txContext = core.NewEVMTxContext(message)
-	)
-	if config == nil {
-		config = &TraceConfig{}
-	}
-	// Default tracer is the struct logger
-	tracer = logger.NewStructLogger(config.Config)
-	if config.Tracer != nil {
-		tracer, err = DefaultDirectory.New(*config.Tracer, txctx, config.TracerConfig)
-		if err != nil {
-			return nil, err
-		}
-	}
-	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer, NoBaseFee: true})
+	txContext := core.NewEVMTxContext(message)
+	return TraceTx(ctx, config, txctx, func(cfg vm.Config) error {
+		cfg.NoBaseFee = true
+		vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), cfg)
 
-	// Define a meaningful timeout of a single transaction trace
-	if config.Timeout != nil {
-		if timeout, err = time.ParseDuration(*config.Timeout); err != nil {
-			return nil, err
-		}
-	}
-	deadlineCtx, cancel := context.WithTimeout(ctx, timeout)
-	go func() {
-		<-deadlineCtx.Done()
-		if errors.Is(deadlineCtx.Err(), context.DeadlineExceeded) {
-			tracer.Stop(errors.New("execution timeout"))
-			// Stop evm execution. Note cancellation is not necessarily immediate.
-			vmenv.Cancel()
-		}
-	}()
-	defer cancel()
-
-	// Call Prepare to clear out the statedb access list
-	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	if err := applyMessage(api.backend, vmenv, statedb, message); err != nil {
-		return nil, fmt.Errorf("tracing failed: %w", err)
-	}
-	return tracer.GetResult()
+		// Call Prepare to clear out the statedb access list
+		statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
+		// [applyMessage] wraps any error as "tracing failed".
+		return applyMessage(api.backend, vmenv, statedb, message)
+	})
 }
 
 // APIs return the collection of RPC services the tracer package offers.

--- a/eth/tracers/api.libevm.go
+++ b/eth/tracers/api.libevm.go
@@ -1,0 +1,69 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package tracers
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/state"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/core/vm"
+)
+
+// DefaultTraceTimeout exports defaultTraceTimeout.
+const DefaultTraceTimeout = defaultTraceTimeout
+
+// ExtraExecutor is an optional interface that a [Backend] can implement to
+// inject extra state changes when the tracing APIs re-execute blocks.
+type ExtraExecutor interface {
+	// BeforeExecutingBlock is called on the state returned by
+	// [Backend.StateAtBlock] before any of the block's transactions are
+	// applied.
+	BeforeExecutingBlock(sdb *state.StateDB, parent, header *types.Header) error
+	// AfterExecutingTransaction is called on the state for each transaction
+	// after being applied.
+	AfterExecutingTransaction(sdb *state.StateDB, bf *big.Int, gasUsed uint64) error
+}
+
+func beforeExecutingBlock(b Backend, sdb *state.StateDB, parent, header *types.Header) error {
+	ex, ok := b.(ExtraExecutor)
+	if !ok {
+		return nil
+	}
+	if err := ex.BeforeExecutingBlock(sdb, parent, header); err != nil {
+		return fmt.Errorf("before executing block failed: %w", err)
+	}
+	return nil
+}
+
+func applyMessage(b Backend, vmenv *vm.EVM, sdb *state.StateDB, message *core.Message) error {
+	res, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.GasLimit))
+	if err != nil {
+		return fmt.Errorf("tracing failed: %w", err)
+	}
+
+	ex, ok := b.(ExtraExecutor)
+	if !ok {
+		return nil
+	}
+	if err := ex.AfterExecutingTransaction(sdb, vmenv.Context.BaseFee, res.UsedGas); err != nil {
+		return fmt.Errorf("after executing transaction failed: %w", err)
+	}
+	return nil
+}

--- a/eth/tracers/api.libevm.go
+++ b/eth/tracers/api.libevm.go
@@ -17,13 +17,19 @@
 package tracers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"math/big"
+	"sync"
+	"time"
 
+	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
+	"github.com/ava-labs/libevm/eth/tracers/logger"
 )
 
 // DefaultTraceTimeout exports defaultTraceTimeout.
@@ -66,4 +72,83 @@ func applyMessage(b Backend, vmenv *vm.EVM, sdb *state.StateDB, message *core.Me
 		return fmt.Errorf("after executing transaction failed: %w", err)
 	}
 	return nil
+}
+
+// TraceTx traces a transaction executed by `execute`, which MUST apply the
+// transaction with the provided [vm.Config] attached. The [Tracer] specified
+// by config observes the execution.
+func TraceTx(ctx context.Context, config *TraceConfig, txctx *Context, execute func(vm.Config) error) (interface{}, error) {
+	var (
+		tracer  Tracer
+		err     error
+		timeout = defaultTraceTimeout
+	)
+	if config == nil {
+		config = &TraceConfig{}
+	}
+	// Default tracer is the struct logger
+	tracer = logger.NewStructLogger(config.Config)
+	if config.Tracer != nil {
+		tracer, err = DefaultDirectory.New(*config.Tracer, txctx, config.TracerConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	cancelling := &evmCancellingTracer{Tracer: tracer}
+
+	// Define a meaningful timeout of a single transaction trace
+	if config.Timeout != nil {
+		if timeout, err = time.ParseDuration(*config.Timeout); err != nil {
+			return nil, err
+		}
+	}
+	deadlineCtx, cancel := context.WithTimeout(ctx, timeout)
+	go func() {
+		<-deadlineCtx.Done()
+		if errors.Is(deadlineCtx.Err(), context.DeadlineExceeded) {
+			// Also cancels the EVM; note cancellation is not necessarily
+			// immediate.
+			cancelling.Stop(errors.New("execution timeout"))
+		}
+	}()
+	defer cancel()
+
+	if err := execute(vm.Config{Tracer: cancelling}); err != nil {
+		return nil, err
+	}
+	return cancelling.GetResult()
+}
+
+// evmCancellingTracer wraps a [Tracer] so that Stop also cancels the [vm.EVM]
+// executing the traced transaction.
+type evmCancellingTracer struct {
+	Tracer
+
+	mu      sync.Mutex
+	env     *vm.EVM
+	stopped bool
+}
+
+func (t *evmCancellingTracer) CaptureStart(env *vm.EVM, from, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+	t.mu.Lock()
+	t.env = env
+	stopped := t.stopped
+	t.mu.Unlock()
+
+	if stopped {
+		env.Cancel()
+	}
+	t.Tracer.CaptureStart(env, from, to, create, input, gas, value)
+}
+
+func (t *evmCancellingTracer) Stop(err error) {
+	t.mu.Lock()
+	t.stopped = true
+	env := t.env
+	t.mu.Unlock()
+
+	t.Tracer.Stop(err)
+	if env != nil {
+		env.Cancel()
+	}
 }


### PR DESCRIPTION
## Why this should be merged
for the executor approach 

## How this works

## How this was tested
