### PR TITLE
chore: export `callFrame`

### DIFF
--- a/eth/tracers/native/call.libevm.go
+++ b/eth/tracers/native/call.libevm.go
@@ -17,5 +17,5 @@
 package native
 
 // CallFrame exports the [callFrame] type, used for JSON-marshalling the
-// results of the callTracer tracer.
+// results of the callTracer.
 type CallFrame = callFrame

--- a/eth/tracers/native/call.libevm.go
+++ b/eth/tracers/native/call.libevm.go
@@ -17,5 +17,5 @@
 package native
 
 // CallFrame exports the [callFrame] type, used for JSON-marshalling the
-// results of the "callTracer" tracer.
+// results of the callTracer tracer.
 type CallFrame = callFrame

--- a/eth/tracers/native/call.libevm.go
+++ b/eth/tracers/native/call.libevm.go
@@ -1,0 +1,21 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package native
+
+// CallFrame exports the [callFrame] type, used for JSON-marshalling the
+// results of the "callTracer" tracer.
+type CallFrame = callFrame


### PR DESCRIPTION
## Why this should be merged

SAE tests need to assert on `callTracer` results returned by the `debug_trace*` APIs. 

## How this works

Exports the `callFrame` type with the alias `CallFrame`, following the pattern
of #267 and #276.

## How this was tested
N/A