### PR TITLE
feat(params): Add `AfterExecutingTransaction` hook

### DIFF
--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -74,7 +74,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.state.RevertToSnapshot(snap)
 		err = fmt.Errorf("execution invalidated: %w", invalid)
 	}
-	return res, err
+
+	if err != nil {
+		return res, err
+	}
+
+	st.rulesHooks().AfterExecutingTransaction(st.state, st.evm.Context.BaseFee, res.UsedGas)
+	return res, nil
 }
 
 // canExecuteTransaction is a convenience wrapper for calling the

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -314,41 +314,36 @@ func TestAfterExecutingTransaction(t *testing.T) {
 	)
 
 	tests := []struct {
-		name           string
-		to             *common.Address
-		startingFunds  *uint256.Int
-		wantHookCalled bool
-		wantErr        error
+		name          string
+		to            *common.Address
+		startingFunds *uint256.Int
+		wantErr       error
 	}{
 		{
-			name:           "successful_execution",
-			to:             &common.Address{},
-			startingFunds:  new(uint256.Int).SetAllOne(),
-			wantHookCalled: true,
+			name:          "successful_execution",
+			to:            &common.Address{},
+			startingFunds: new(uint256.Int).SetAllOne(),
 		},
 		{
-			name:           "execution_invalidated",
-			to:             &invalidator,
-			startingFunds:  new(uint256.Int).SetAllOne(),
-			wantHookCalled: false,
-			wantErr:        testErr,
+			name:          "execution_invalidated",
+			to:            &invalidator,
+			startingFunds: new(uint256.Int).SetAllOne(),
+			wantErr:       testErr,
 		},
 		{
-			name:           "execution_error",
-			to:             &common.Address{},
-			startingFunds:  uint256.NewInt(1), // can't buy gas
-			wantHookCalled: false,
-			wantErr:        core.ErrInsufficientFunds,
+			name:          "execution_error",
+			to:            &common.Address{},
+			startingFunds: uint256.NewInt(1), // can't buy gas
+			wantErr:       core.ErrInsufficientFunds,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var (
-				hookCalled  bool
-				gotBaseFee  *big.Int
-				gotGasUsed  uint64
-				wantBaseFee = big.NewInt(gasPrice)
+				hookCalled bool
+				gotBaseFee *big.Int
+				gotGasUsed uint64
 			)
 			hooks := &hookstest.Stub{
 				AfterExecutingTransactionFn: func(state libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
@@ -387,22 +382,23 @@ func TestAfterExecutingTransaction(t *testing.T) {
 			receipt, err := core.ApplyTransaction(
 				evm.ChainConfig(), nil, &common.Address{}, &gp, sdb,
 				&types.Header{
-					BaseFee: wantBaseFee,
+					BaseFee: big.NewInt(gasPrice),
 					// Required but irrelevant fields
 					Number:     big.NewInt(0),
 					Difficulty: big.NewInt(0),
 				},
 				tx, &gasUsed, vm.Config{},
 			)
-
-			require.Equal(t, tt.wantHookCalled, hookCalled, "hook called i.f.f. execution succeeds")
 			require.ErrorIs(t, err, tt.wantErr, "core.ApplyTransaction(...)")
-			if tt.wantErr != nil {
-				assert.True(t, sdb.GetBalance(beneficiary).IsZero(), "no state modification by uncalled hook")
+
+			wantHookCalled := tt.wantErr == nil
+			require.Equal(t, wantHookCalled, hookCalled, "hook called i.f.f. execution succeeds")
+			if !wantHookCalled {
+				assert.Equal(t, new(uint256.Int), sdb.GetBalance(beneficiary), "balance of beneficiary unchanged when hook not called")
 				return
 			}
 
-			assert.Equal(t, wantBaseFee, gotBaseFee, "base fee received by hook")
+			assert.Equal(t, big.NewInt(gasPrice), gotBaseFee, "base fee received by hook")
 			assert.Equalf(t, receipt.GasUsed, gotGasUsed, "gas used received by hook vs %T.GasUsed", receipt)
 			assert.Equal(t, uint64(reward), sdb.GetBalance(beneficiary).Uint64(), "state modified by hook")
 		})

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -301,6 +301,114 @@ func TestMinimumGasConsumption(t *testing.T) {
 	}
 }
 
+func TestAfterExecutingTransaction(t *testing.T) {
+	const (
+		gasPrice = 3
+		reward   = 42
+	)
+
+	var (
+		beneficiary = common.Address{'b', 'e', 'n'}
+		invalidator = common.Address{'i', 'n', 'v'}
+		testErr     = errors.New("test error")
+	)
+
+	tests := []struct {
+		name           string
+		to             *common.Address
+		startingFunds  *uint256.Int
+		wantHookCalled bool
+		wantErr        error
+	}{
+		{
+			name:           "successful_execution",
+			to:             &common.Address{},
+			startingFunds:  new(uint256.Int).SetAllOne(),
+			wantHookCalled: true,
+		},
+		{
+			name:           "execution_invalidated",
+			to:             &invalidator,
+			startingFunds:  new(uint256.Int).SetAllOne(),
+			wantHookCalled: false,
+			wantErr:        testErr,
+		},
+		{
+			name:           "execution_error",
+			to:             &common.Address{},
+			startingFunds:  uint256.NewInt(1), // can't buy gas
+			wantHookCalled: false,
+			wantErr:        core.ErrInsufficientFunds,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				hookCalled  bool
+				gotBaseFee  *big.Int
+				gotGasUsed  uint64
+				wantBaseFee = big.NewInt(gasPrice)
+			)
+			hooks := &hookstest.Stub{
+				AfterExecutingTransactionFn: func(state libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
+					hookCalled = true
+					gotBaseFee = baseFee
+					gotGasUsed = gasUsed
+					state.AddBalance(beneficiary, uint256.NewInt(reward))
+				},
+				PrecompileOverrides: map[common.Address]libevm.PrecompiledContract{
+					invalidator: vm.NewStatefulPrecompile(func(env vm.PrecompileEnvironment, _ []byte) ([]byte, error) {
+						env.InvalidateExecution(testErr)
+						return nil, nil
+					}),
+				},
+			}
+			hooks.Register(t)
+
+			key, err := crypto.GenerateKey()
+			require.NoError(t, err, "crypto.GenerateKey()")
+
+			sdb, evm := ethtest.NewZeroEVM(t)
+			sdb.SetBalance(crypto.PubkeyToAddress(key.PublicKey), tt.startingFunds)
+
+			tx := types.MustSignNewTx(
+				key,
+				types.LatestSigner(evm.ChainConfig()),
+				&types.LegacyTx{
+					To:       tt.to,
+					Gas:      1e6,
+					GasPrice: big.NewInt(gasPrice),
+				},
+			)
+
+			gp := core.GasPool(math.MaxUint64)
+			var gasUsed uint64
+			receipt, err := core.ApplyTransaction(
+				evm.ChainConfig(), nil, &common.Address{}, &gp, sdb,
+				&types.Header{
+					BaseFee: wantBaseFee,
+					// Required but irrelevant fields
+					Number:     big.NewInt(0),
+					Difficulty: big.NewInt(0),
+				},
+				tx, &gasUsed, vm.Config{},
+			)
+
+			require.Equal(t, tt.wantHookCalled, hookCalled, "hook called i.f.f. execution succeeds")
+			require.ErrorIs(t, err, tt.wantErr, "core.ApplyTransaction(...)")
+			if tt.wantErr != nil {
+				assert.True(t, sdb.GetBalance(beneficiary).IsZero(), "no state modification by uncalled hook")
+				return
+			}
+
+			assert.Equal(t, wantBaseFee, gotBaseFee, "base fee received by hook")
+			assert.Equalf(t, receipt.GasUsed, gotGasUsed, "gas used received by hook vs %T.GasUsed", receipt)
+			assert.Equal(t, uint64(reward), sdb.GetBalance(beneficiary).Uint64(), "state modified by hook")
+		})
+	}
+}
+
 func TestGasRefunds(t *testing.T) {
 	const refund = 100
 

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -42,16 +42,17 @@ func Register[C params.ChainConfigHooks, R params.RulesHooks](tb testing.TB, ext
 // [params.RulesHooks]. Each of the fields, if non-nil, back their respective
 // hook methods, which otherwise fall back to the default behaviour.
 type Stub struct {
-	CheckConfigForkOrderFn  func() error
-	CheckConfigCompatibleFn func(*params.ChainConfig, *big.Int, uint64) *params.ConfigCompatError
-	DescriptionSuffix       string
-	PrecompileOverrides     map[common.Address]libevm.PrecompiledContract
-	ActivePrecompilesFn     func([]common.Address) []common.Address
-	AccessListGasFn         func(libevm.AccessList) (uint64, bool, error)
-	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
-	CanCreateContractFn     func(*libevm.AddressContext, uint64, libevm.StateReader) (uint64, error)
-	MinimumGasConsumptionFn func(txGasLimit uint64) uint64
-	DisableGasRefunds       bool
+	CheckConfigForkOrderFn      func() error
+	CheckConfigCompatibleFn     func(*params.ChainConfig, *big.Int, uint64) *params.ConfigCompatError
+	DescriptionSuffix           string
+	PrecompileOverrides         map[common.Address]libevm.PrecompiledContract
+	ActivePrecompilesFn         func([]common.Address) []common.Address
+	AccessListGasFn             func(libevm.AccessList) (uint64, bool, error)
+	CanExecuteTransactionFn     func(common.Address, *common.Address, libevm.StateReader) error
+	CanCreateContractFn         func(*libevm.AddressContext, uint64, libevm.StateReader) (uint64, error)
+	MinimumGasConsumptionFn     func(txGasLimit uint64) uint64
+	DisableGasRefunds           bool
+	AfterExecutingTransactionFn func(state libevm.StateDB, baseFee *big.Int, gasUsed uint64)
 }
 
 // Register is a convenience wrapper for registering s as both the
@@ -161,6 +162,15 @@ func (s Stub) MinimumGasConsumption(limit uint64) uint64 {
 		return f(limit)
 	}
 	return 0
+}
+
+// AfterExecutingTransaction proxies arguments to the
+// s.AfterExecutingTransactionFn function if non-nil, otherwise it acts as a
+// noop.
+func (s Stub) AfterExecutingTransaction(state libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
+	if f := s.AfterExecutingTransactionFn; f != nil {
+		f(state, baseFee, gasUsed)
+	}
 }
 
 var _ interface {

--- a/libevm/interfaces_test.go
+++ b/libevm/interfaces_test.go
@@ -31,5 +31,10 @@ var (
 	_ libevm.PrecompiledContract = (vm.PrecompiledContract)(nil)
 )
 
-// StateReader MUST be a subset vm.StateDB.
-var _ libevm.StateReader = (vm.StateDB)(nil)
+var (
+	// StateReader MUST be a subset vm.StateDB.
+	_ libevm.StateReader = (vm.StateDB)(nil)
+
+	// StateDB MUST be a subset of vm.StateDB.
+	_ libevm.StateDB = (vm.StateDB)(nil)
+)

--- a/libevm/interfaces_test.go
+++ b/libevm/interfaces_test.go
@@ -35,6 +35,6 @@ var (
 	// StateReader MUST be a subset vm.StateDB.
 	_ libevm.StateReader = (vm.StateDB)(nil)
 
-	// StateDB MUST be a subset of vm.StateDB.
+	// StateDB MUST be a non-strict subset of vm.StateDB.
 	_ libevm.StateDB = (vm.StateDB)(nil)
 )

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -72,10 +72,9 @@ type StateReader interface {
 	TxIndex() int
 }
 
-// StateDB is a subset of vm.StateDB, embedding [StateReader] and adding
-// balance mutation, mirrored here for packages that cannot import core/vm
-// without causing a circular dependency. See method comments in vm.StateDB,
-// which aren't copied here as they risk becoming outdated.
+// StateDB is a subset of vm.StateDB that embeds [StateReader] and adds balance
+// mutation, mirrored here to avoid a core/vm import cycle. See method comments
+// in vm.StateDB, which aren't copied here as they risk becoming outdated.
 type StateDB interface {
 	StateReader
 

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -72,6 +72,16 @@ type StateReader interface {
 	TxIndex() int
 }
 
+// StateDB is a subset of vm.StateDB, embedding [StateReader] and adding
+// balance mutation, mirrored here for packages that cannot import core/vm
+// without causing a circular dependency. See method comments in vm.StateDB,
+// which aren't copied here as they risk becoming outdated.
+type StateDB interface {
+	StateReader
+
+	AddBalance(common.Address, *uint256.Int)
+}
+
 // AddressContext carries addresses available to contexts such as calls and
 // contract creation.
 //

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -71,6 +71,10 @@ type RulesHooks interface {
 	// will be capped at the limit. The minimum spend will be applied _after_
 	// refunds, if any.
 	MinimumGasConsumption(txGasLimit uint64) (gas uint64)
+	// AfterExecutingTransaction is called after a transaction has executed
+	// successfully, allowing post-execution state modification. It is not
+	// called if execution failed or was invalidated.
+	AfterExecutingTransaction(state libevm.StateDB, baseFee *big.Int, gasUsed uint64)
 }
 
 // RulesAllowlistHooks are a subset of [RulesHooks] that gate actions, signalled
@@ -164,3 +168,6 @@ func (NOOPHooks) ShouldRefundGas() bool {
 func (NOOPHooks) MinimumGasConsumption(uint64) uint64 {
 	return 0
 }
+
+// AfterExecutingTransaction does nothing.
+func (NOOPHooks) AfterExecutingTransaction(libevm.StateDB, *big.Int, uint64) {}

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -72,8 +72,9 @@ type RulesHooks interface {
 	// refunds, if any.
 	MinimumGasConsumption(txGasLimit uint64) (gas uint64)
 	// AfterExecutingTransaction is called after a transaction has executed
-	// successfully, allowing post-execution state modification. It is not
-	// called if execution failed or was invalidated.
+	// without consensus errors, and the execution has not been invalidated.
+	// The exact qualifications for a "consensus error" can be found in the
+	// comment for core/state_transition.go:StateTransition.transitionDb.
 	AfterExecutingTransaction(state libevm.StateDB, baseFee *big.Int, gasUsed uint64)
 }
 


### PR DESCRIPTION
## Why this should be merged

Although SAE could avoid this since they wrap `core.AppyTransaction`, there's a lot of call sites that all require this behavior.

## How this works

Uses `TransitionDb` to add potential additional operations after the message is fully applied. Care is taken regarding execution invalidation.

## How this was tested

New UT
