### PR TITLE
feat(eth/tracers): Allow header overwrites

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -769,8 +769,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// If the transaction needs tracing, swap out the configs
 		if tx.Hash() == txHash || txHash == (common.Hash{}) {
 			// Generate a unique temporary file to dump it into
-			blockHash := api.blockHash(block)
-			prefix := fmt.Sprintf("block_%#x-%d-%#x-", blockHash.Bytes()[:4], i, tx.Hash().Bytes()[:4])
+			prefix := fmt.Sprintf("block_%#x-%d-%#x-", api.blockHash(block).Bytes()[:4], i, tx.Hash().Bytes()[:4])
 			if !canon {
 				prefix = fmt.Sprintf("%valt-", prefix)
 			}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -272,7 +272,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				for i, tx := range task.block.Transactions() {
 					msg, _ := core.TransactionToMessage(tx, signer, task.block.BaseFee())
 					txctx := &Context{
-						BlockHash:   task.block.Hash(),
+						BlockHash:   api.blockHash(task.block),
 						BlockNumber: task.block.Number(),
 						TxIndex:     i,
 						TxHash:      tx.Hash(),
@@ -407,7 +407,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			// Queue up next received result
 			result := &blockTraceResult{
 				Block:  hexutil.Uint64(res.block.NumberU64()),
-				Hash:   res.block.Hash(),
+				Hash:   api.blockHash(res.block),
 				Traces: res.results,
 			}
 			done[uint64(result.Block)] = result
@@ -597,7 +597,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	// Native tracers have low overhead
 	var (
 		txs       = block.Transactions()
-		blockHash = block.Hash()
+		blockHash = api.blockHash(block)
 		is158     = api.backend.ChainConfig().IsEIP158(block.Number())
 		blockCtx  = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		signer    = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
@@ -631,7 +631,7 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 	// Execute all the transaction contained within the block concurrently
 	var (
 		txs       = block.Transactions()
-		blockHash = block.Hash()
+		blockHash = api.blockHash(block)
 		blockCtx  = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		signer    = types.MakeSigner(api.backend.ChainConfig(), block.Number(), block.Time())
 		results   = make([]*txTraceResult, len(txs))
@@ -769,7 +769,8 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// If the transaction needs tracing, swap out the configs
 		if tx.Hash() == txHash || txHash == (common.Hash{}) {
 			// Generate a unique temporary file to dump it into
-			prefix := fmt.Sprintf("block_%#x-%d-%#x-", block.Hash().Bytes()[:4], i, tx.Hash().Bytes()[:4])
+			blockHash := api.blockHash(block)
+			prefix := fmt.Sprintf("block_%#x-%d-%#x-", blockHash.Bytes()[:4], i, tx.Hash().Bytes()[:4])
 			if !canon {
 				prefix = fmt.Sprintf("%valt-", prefix)
 			}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -141,7 +141,7 @@ func (api *API) blockByNumberAndHash(ctx context.Context, number rpc.BlockNumber
 	if err != nil {
 		return nil, err
 	}
-	if block.Hash() == hash {
+	if api.blockHash(block) == hash {
 		return block, nil
 	}
 	return api.blockByHash(ctx, hash)

--- a/eth/tracers/api.libevm.go
+++ b/eth/tracers/api.libevm.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 the libevm authors.
+// Copyright 2026 the libevm authors.
 //
 // The libevm additions to go-ethereum are free software: you can redistribute
 // them and/or modify them under the terms of the GNU Lesser General Public License

--- a/eth/tracers/api.libevm.go
+++ b/eth/tracers/api.libevm.go
@@ -1,0 +1,42 @@
+// Copyright 2024-2025 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package tracers
+
+import (
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
+)
+
+// BlockHashOverrider is an optional extension to [Backend], allowing an
+// arbitrary block hash to be returned for a block. If not implemented,
+// [types.Block.Hash] is used instead.
+//
+// This would be used in the case that the [types.Header] is manipulated in the
+// [Backend] for tracer-specific behavior. However, all hashes directly
+// returned by the [Backend] are expected to be correct.
+type BlockHashOverrider interface {
+	// BlockHash returns the hash of the provided block.
+	BlockHash(*types.Block) common.Hash
+}
+
+func (a *API) blockHash(block *types.Block) common.Hash {
+	overrider, ok := a.backend.(BlockHashOverrider)
+	if !ok {
+		return block.Hash()
+	}
+	return overrider.BlockHash(block)
+}

--- a/eth/tracers/api.libevm_test.go
+++ b/eth/tracers/api.libevm_test.go
@@ -251,18 +251,21 @@ func TestOverrideBlockHash_Propagation(t *testing.T) {
 		{
 			name: "traceBlock_sequential",
 			trace: func(t *testing.T) map[uint64][]common.Hash {
+				t.Helper()
 				return traceBlockHashes(t, api, blockHashCaptureTracerName)
 			},
 		},
 		{
 			name: "traceBlock_parallel",
 			trace: func(t *testing.T) map[uint64][]common.Hash {
+				t.Helper()
 				return traceBlockHashes(t, api, blockHashCaptureTracerJSName)
 			},
 		},
 		{
 			name: "traceChain",
 			trace: func(t *testing.T) map[uint64][]common.Hash {
+				t.Helper()
 				return traceChainHashes(t, api)
 			},
 		},
@@ -348,7 +351,7 @@ func TestOverrideBlockHash_StandardTraceBlockToFile(t *testing.T) {
 
 		t.Cleanup(func() {
 			for _, file := range files {
-				os.Remove(file)
+				assert.NoError(t, os.Remove(file), "os.Remove()")
 			}
 		})
 

--- a/eth/tracers/api.libevm_test.go
+++ b/eth/tracers/api.libevm_test.go
@@ -18,7 +18,6 @@ package tracers
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -29,9 +28,9 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
-	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/rpc"
 )
@@ -81,45 +80,76 @@ func (*blockHashCaptureTracer) CaptureState(uint64, vm.OpCode, uint64, uint64, *
 func (*blockHashCaptureTracer) CaptureFault(uint64, vm.OpCode, uint64, uint64, *vm.ScopeContext, int, error) {
 }
 
-// overriddenBlockHash returns the hash reported by
-// [blockHashOverrideBackend.BlockHash] for the block at height `num`. It is
-// deliberately different from any real block hash.
-func overriddenBlockHash(num uint64) common.Hash {
-	bytes := binary.BigEndian.AppendUint64(nil, num)
-	return crypto.Keccak256Hash(bytes)
-}
-
-// blockHashOverrideBackend wraps a [testBackend], implementing
-// [BlockHashOverrider] such that the "correct" hash of every block differs
-// from block.Hash(). As a real overriding backend would, it also indexes
-// transactions and resolves blocks by the overridden hashes.
-type blockHashOverrideBackend struct {
+// saeBackend models a Streaming Asynchronous Execution backend: it populates a
+// header's state root after consensus, so block.Hash() is not the canonical hash.
+type saeBackend struct {
 	*testBackend
 }
 
-var _ BlockHashOverrider = (*blockHashOverrideBackend)(nil)
+var _ BlockHashOverrider = (*saeBackend)(nil)
 
-func (b *blockHashOverrideBackend) BlockHash(block *types.Block) common.Hash {
-	return overriddenBlockHash(block.NumberU64())
+func (b *saeBackend) BlockHash(block *types.Block) common.Hash {
+	return b.canonicalHash(block.NumberU64())
 }
 
-func (b *blockHashOverrideBackend) GetTransaction(ctx context.Context, txHash common.Hash) (bool, *types.Transaction, common.Hash, uint64, uint64, error) {
-	found, tx, _, blockNumber, index, err := b.testBackend.GetTransaction(ctx, txHash)
-	return found, tx, overriddenBlockHash(blockNumber), blockNumber, index, err
+func (b *saeBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
+	block, err := b.testBackend.BlockByNumber(ctx, number)
+	return alterBlock(block), err
 }
 
-func (b *blockHashOverrideBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
-	for n := uint64(0); n <= b.chain.CurrentBlock().Number.Uint64(); n++ {
-		if overriddenBlockHash(n) == hash {
-			return b.chain.GetBlockByNumber(n), nil
-		}
+func (b *saeBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	return alterBlock(b.chain.GetBlockByHash(hash)), nil
+}
+
+func (b *saeBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
+	header, err := b.testBackend.HeaderByNumber(ctx, number)
+	return alterHeader(header), err
+}
+
+func (b *saeBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	header, err := b.testBackend.HeaderByHash(ctx, hash)
+	return alterHeader(header), err
+}
+
+func (b *saeBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly, preferDisk bool) (*state.StateDB, StateReleaseFunc, error) {
+	return b.testBackend.StateAtBlock(ctx, b.canonicalBlock(block.NumberU64()), reexec, base, readOnly, preferDisk)
+}
+
+func (b *saeBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, StateReleaseFunc, error) {
+	return b.testBackend.StateAtTransaction(ctx, b.canonicalBlock(block.NumberU64()), txIndex, reexec)
+}
+
+func (b *saeBackend) canonicalBlock(num uint64) *types.Block {
+	return b.chain.GetBlockByNumber(num)
+}
+
+func (b *saeBackend) canonicalHash(num uint64) common.Hash {
+	return b.chain.GetCanonicalHash(num)
+}
+
+// alterHeader simulates post-consensus population. ParentHash is preserved and
+// stays canonical.
+func alterHeader(header *types.Header) *types.Header {
+	if header == nil {
+		return nil
 	}
-	return b.testBackend.BlockByHash(ctx, hash)
+	altered := types.CopyHeader(header)
+	altered.Root = common.Hash{'a', 'l', 't', 'e', 'r', 'e', 'd'}
+	return altered
 }
 
-// newBlockHashOverrideBackend returns a [blockHashOverrideBackend] over a
-// chain of `n` blocks, each containing a single value-transfer transaction.
-func newBlockHashOverrideBackend(t *testing.T, n int) *blockHashOverrideBackend {
+func alterBlock(block *types.Block) *types.Block {
+	if block == nil {
+		return nil
+	}
+	return types.NewBlockWithHeader(alterHeader(block.Header())).WithBody(types.Body{
+		Transactions: block.Transactions(),
+		Uncles:       block.Uncles(),
+	})
+}
+
+// newSAEBackend returns a backend over n blocks of one value transfer each.
+func newSAEBackend(t *testing.T, n int) *saeBackend {
 	t.Helper()
 
 	accounts := newAccounts(2)
@@ -138,7 +168,7 @@ func newBlockHashOverrideBackend(t *testing.T, n int) *blockHashOverrideBackend 
 		nonce++
 	})
 	t.Cleanup(backend.teardown)
-	return &blockHashOverrideBackend{testBackend: backend}
+	return &saeBackend{testBackend: backend}
 }
 
 // hashFromTraceResult extracts the [common.Hash] reported by a
@@ -153,38 +183,30 @@ func hashFromTraceResult(t *testing.T, res interface{}) common.Hash {
 	return h
 }
 
-// TestOverrideBlockHash_TraceBlock tests that the [Context.BlockHash]
-// received by tracers is the overridden hash, on both the sequential
-// ([API.traceBlock]) and parallel ([API.traceBlockParallel]) paths.
-func TestOverrideBlockHash_TraceBlock(t *testing.T) {
-	const blockNum = 1
-	backend := newBlockHashOverrideBackend(t, blockNum)
-	api := NewAPI(backend)
+// numBlocks is the height of the chain these tests build.
+const numBlocks = 5
 
-	for _, tracer := range []string{blockHashCaptureTracerName, blockHashCaptureTracerJSName} {
-		t.Run(tracer, func(t *testing.T) {
-			results, err := api.TraceBlockByNumber(t.Context(), rpc.BlockNumber(blockNum), &TraceConfig{
-				Tracer: &tracer,
-			})
-			require.NoErrorf(t, err, "TraceBlockByNumber(%d)", blockNum)
-			require.NotEmpty(t, results, "trace results")
+// traceBlockHashes returns the hashes [API.TraceBlockByNumber] surfaces, keyed by block.
+func traceBlockHashes(t *testing.T, api *API, tracer string) map[uint64][]common.Hash {
+	t.Helper()
 
-			for i, res := range results {
-				require.Emptyf(t, res.Error, "trace error for tx %d", i)
-				require.Equalf(t, overriddenBlockHash(blockNum), hashFromTraceResult(t, res.Result),
-					"Context.BlockHash received by tracer for tx %d of block %d", i, blockNum)
-			}
+	seen := make(map[uint64][]common.Hash)
+	for n := uint64(1); n <= numBlocks; n++ {
+		results, err := api.TraceBlockByNumber(t.Context(), rpc.BlockNumber(n), &TraceConfig{
+			Tracer: &tracer,
 		})
+		require.NoErrorf(t, err, "TraceBlockByNumber(%d)", n)
+		for i, res := range results {
+			require.Emptyf(t, res.Error, "trace error for tx %d of block %d", i, n)
+			seen[n] = append(seen[n], hashFromTraceResult(t, res.Result))
+		}
 	}
+	return seen
 }
 
-// TestOverrideBlockHash_TraceChain tests that both the block hash
-// reported in [blockTraceResult] and the [Context.BlockHash] received by
-// tracers during [API.traceChain] are the overridden hashes.
-func TestOverrideBlockHash_TraceChain(t *testing.T) {
-	const numBlocks = 5
-	backend := newBlockHashOverrideBackend(t, numBlocks)
-	api := NewAPI(backend)
+// traceChainHashes returns the hashes [API.traceChain] surfaces, keyed by block.
+func traceChainHashes(t *testing.T, api *API) map[uint64][]common.Hash {
+	t.Helper()
 
 	from, err := api.blockByNumber(t.Context(), 0)
 	require.NoError(t, err, "blockByNumber(0)")
@@ -192,30 +214,131 @@ func TestOverrideBlockHash_TraceChain(t *testing.T) {
 	require.NoErrorf(t, err, "blockByNumber(%d)", numBlocks)
 
 	tracer := blockHashCaptureTracerName
-	resCh := api.traceChain(from, to, &TraceConfig{Tracer: &tracer}, nil)
+	seen := make(map[uint64][]common.Hash)
 
 	next := uint64(1)
-	for result := range resCh {
+	for result := range api.traceChain(from, to, &TraceConfig{Tracer: &tracer}, nil) {
 		require.Equal(t, next, uint64(result.Block), "traced block number")
-		require.Equalf(t, overriddenBlockHash(next), result.Hash, "blockTraceResult.Hash of block %d", next)
-
-		require.NotEmpty(t, result.Traces, "trace results of block %d", next)
+		seen[next] = append(seen[next], result.Hash)
 		for i, trace := range result.Traces {
 			require.Emptyf(t, trace.Error, "trace error for tx %d of block %d", i, next)
-			require.Equalf(t, overriddenBlockHash(next), hashFromTraceResult(t, trace.Result),
-				"Context.BlockHash received by tracer for tx %d of block %d", i, next)
+			seen[next] = append(seen[next], hashFromTraceResult(t, trace.Result))
 		}
 		next++
 	}
 	require.Equal(t, uint64(numBlocks+1), next, "all blocks traced")
+	return seen
 }
 
-// TestOverrideBlockHash_TraceTransaction tests that a transaction found
-// via [Backend.GetTransaction] under an overridden block hash can be traced,
-// and that the tracer receives that hash as [Context.BlockHash].
-func TestOverrideBlockHash_TraceTransaction(t *testing.T) {
+// requireCanonicalHashes asserts every surfaced hash is canonical and no block is missing.
+func requireCanonicalHashes(t *testing.T, backend *saeBackend, seen map[uint64][]common.Hash) {
+	t.Helper()
+
+	require.Lenf(t, seen, numBlocks, "blocks with surfaced hashes")
+	for n := uint64(1); n <= numBlocks; n++ {
+		require.NotEmptyf(t, seen[n], "hashes surfaced for block %d", n)
+		for _, got := range seen[n] {
+			require.Equalf(t, backend.canonicalHash(n), got, "block hash surfaced for block %d", n)
+		}
+	}
+}
+
+// TestOverrideBlockHash_Propagation tests that the tracing APIs surface canonical hashes.
+func TestOverrideBlockHash_Propagation(t *testing.T) {
+	t.Run("traceBlock_sequential", func(t *testing.T) {
+		backend := newSAEBackend(t, numBlocks)
+		api := NewAPI(backend)
+		requireCanonicalHashes(t, backend, traceBlockHashes(t, api, blockHashCaptureTracerName))
+	})
+
+	t.Run("traceBlock_parallel", func(t *testing.T) {
+		backend := newSAEBackend(t, numBlocks)
+		api := NewAPI(backend)
+		requireCanonicalHashes(t, backend, traceBlockHashes(t, api, blockHashCaptureTracerJSName))
+	})
+
+	t.Run("traceChain", func(t *testing.T) {
+		backend := newSAEBackend(t, numBlocks)
+		api := NewAPI(backend)
+		requireCanonicalHashes(t, backend, traceChainHashes(t, api))
+	})
+}
+
+func blockAt(t *testing.T, b *saeBackend, num uint64) *types.Block {
+	t.Helper()
+
+	block, err := b.BlockByNumber(t.Context(), rpc.BlockNumber(num))
+	require.NoErrorf(t, err, "BlockByNumber(%d)", num)
+	return block
+}
+
+func headerAt(t *testing.T, b *saeBackend, num uint64) *types.Header {
+	t.Helper()
+
+	header, err := b.HeaderByNumber(t.Context(), rpc.BlockNumber(num))
+	require.NoErrorf(t, err, "HeaderByNumber(%d)", num)
+	return header
+}
+
+// TestSAEBackend_AccessorsAgree tests that the header and block accessors serve
+// the same header, so header-only paths cannot see the unaltered form.
+func TestSAEBackend_AccessorsAgree(t *testing.T) {
+	backend := newSAEBackend(t, numBlocks)
+
+	for n := uint64(1); n <= numBlocks; n++ {
+		block, header := blockAt(t, backend, n), headerAt(t, backend, n)
+
+		byHash, err := backend.HeaderByHash(t.Context(), backend.canonicalHash(n))
+		require.NoErrorf(t, err, "HeaderByHash(canonical %d)", n)
+
+		require.Equalf(t, block.Hash(), header.Hash(), "HeaderByNumber() vs BlockByNumber() for block %d", n)
+		require.Equalf(t, header.Hash(), byHash.Hash(), "HeaderByHash() vs HeaderByNumber() for block %d", n)
+	}
+}
+
+// TestSAEBackend_ParentHashIsCanonical tests that ParentHash stays canonical
+// even though block.Hash() does not.
+func TestSAEBackend_ParentHashIsCanonical(t *testing.T) {
+	backend := newSAEBackend(t, numBlocks)
+
+	for n := uint64(1); n <= numBlocks; n++ {
+		block, parent := blockAt(t, backend, n), blockAt(t, backend, n-1)
+
+		require.NotEqualf(t, backend.canonicalHash(n), block.Hash(),
+			"altering the header changes block.Hash() away from the canonical hash, block %d", n)
+		require.Equalf(t, backend.canonicalHash(n-1), block.ParentHash(),
+			"ParentHash of block %d is the canonical hash of its parent", n)
+		require.NotEqualf(t, parent.Hash(), block.ParentHash(),
+			"ParentHash of block %d is not the altered parent's block.Hash()", n)
+	}
+}
+
+// TestBlockHash tests that [API.blockHash] falls back to block.Hash() unless
+// the [Backend] is a [BlockHashOverrider].
+func TestBlockHash(t *testing.T) {
 	const blockNum = 1
-	backend := newBlockHashOverrideBackend(t, blockNum)
+	backend := newSAEBackend(t, blockNum)
+
+	block, err := backend.BlockByNumber(t.Context(), blockNum)
+	require.NoErrorf(t, err, "BlockByNumber(%d)", blockNum)
+	require.NotEqual(t, backend.canonicalHash(blockNum), block.Hash(), "test precondition: altered header hashes differently")
+
+	t.Run("not_implemented", func(t *testing.T) {
+		api := NewAPI(backend.testBackend)
+		require.Equal(t, block.Hash(), api.blockHash(block), "API.blockHash() with a Backend that is not a BlockHashOverrider")
+	})
+
+	t.Run("implemented", func(t *testing.T) {
+		api := NewAPI(backend)
+		require.Equal(t, backend.canonicalHash(blockNum), api.blockHash(block), "API.blockHash() with a Backend that is a BlockHashOverrider")
+	})
+}
+
+// TestOverrideBlockHash_TraceTransactionResolvesBlock tests block resolution by
+// canonical hash. [API.TraceTransaction] never calls [API.blockHash].
+func TestOverrideBlockHash_TraceTransactionResolvesBlock(t *testing.T) {
+	const blockNum = 1
+	backend := newSAEBackend(t, blockNum)
 	api := NewAPI(backend)
 
 	block, err := backend.BlockByNumber(t.Context(), blockNum)
@@ -226,29 +349,25 @@ func TestOverrideBlockHash_TraceTransaction(t *testing.T) {
 	tracer := blockHashCaptureTracerName
 	res, err := api.TraceTransaction(t.Context(), txHash, &TraceConfig{Tracer: &tracer})
 	require.NoErrorf(t, err, "TraceTransaction()")
-	require.Equal(t, overriddenBlockHash(blockNum), hashFromTraceResult(t, res), "Context.BlockHash received by tracer")
+	require.Equal(t, backend.canonicalHash(blockNum), hashFromTraceResult(t, res), "Context.BlockHash received by tracer")
 }
 
-// TestOverrideBlockHash_StandardTraceBlockToFile tests that the dump
-// files created by [API.StandardTraceBlockToFile] are named after the
-// overridden block hash rather than block.Hash().
+// TestOverrideBlockHash_StandardTraceBlockToFile tests that dump files are named
+// after the canonical block hash.
 func TestOverrideBlockHash_StandardTraceBlockToFile(t *testing.T) {
 	const blockNum = 1
-	backend := newBlockHashOverrideBackend(t, blockNum)
+	backend := newSAEBackend(t, blockNum)
 	api := NewAPI(backend)
 
-	block, err := backend.BlockByNumber(t.Context(), blockNum)
-	require.NoErrorf(t, err, "BlockByNumber(%d)", blockNum)
-
-	files, err := api.StandardTraceBlockToFile(t.Context(), block.Hash(), nil)
+	files, err := api.StandardTraceBlockToFile(t.Context(), backend.canonicalHash(blockNum), nil)
 	for _, file := range files {
 		defer os.Remove(file)
 	}
 	require.NoError(t, err, "StandardTraceBlockToFile()")
 	require.NotEmpty(t, files, "dump files")
 
-	wantPrefix := fmt.Sprintf("block_%#x-", overriddenBlockHash(blockNum).Bytes()[:4])
+	wantPrefix := fmt.Sprintf("block_%#x-", backend.canonicalHash(blockNum).Bytes()[:4])
 	for _, file := range files {
-		require.Containsf(t, file, wantPrefix, "dump file %q named after overridden block hash", file)
+		require.Containsf(t, file, wantPrefix, "dump file %q named after canonical block hash", file)
 	}
 }

--- a/eth/tracers/api.libevm_test.go
+++ b/eth/tracers/api.libevm_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 the libevm authors.
+//
+// The libevm additions to go-ethereum are free software: you can redistribute
+// them and/or modify them under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// The libevm additions are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see
+// <http://www.gnu.org/licenses/>.
+
+package tracers
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/core/vm"
+	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/params"
+	"github.com/ava-labs/libevm/rpc"
+)
+
+const (
+	// blockHashCaptureTracerName is registered as a native tracer, exercising
+	// the sequential path of [API.traceBlock].
+	blockHashCaptureTracerName = "libevmBlockHashCaptureTracer"
+	// blockHashCaptureTracerJSName is the same tracer registered with
+	// isJS=true, forcing [API.traceBlock] onto the [API.traceBlockParallel]
+	// path.
+	blockHashCaptureTracerJSName = "libevmBlockHashCaptureTracerJS"
+)
+
+func TestMain(m *testing.M) {
+	DefaultDirectory.Register(blockHashCaptureTracerName, newBlockHashCaptureTracer, false)
+	DefaultDirectory.Register(blockHashCaptureTracerJSName, newBlockHashCaptureTracer, true)
+	os.Exit(m.Run())
+}
+
+// blockHashCaptureTracer records the [Context.BlockHash] it was constructed
+// with and returns it as its result, making the hash propagated by the API
+// observable from trace results.
+type blockHashCaptureTracer struct {
+	blockHash common.Hash
+}
+
+func newBlockHashCaptureTracer(ctx *Context, _ json.RawMessage) (Tracer, error) {
+	return &blockHashCaptureTracer{blockHash: ctx.BlockHash}, nil
+}
+
+func (t *blockHashCaptureTracer) GetResult() (json.RawMessage, error) {
+	return json.Marshal(t.blockHash)
+}
+
+func (*blockHashCaptureTracer) Stop(error)            {}
+func (*blockHashCaptureTracer) CaptureTxStart(uint64) {}
+func (*blockHashCaptureTracer) CaptureTxEnd(uint64)   {}
+func (*blockHashCaptureTracer) CaptureStart(*vm.EVM, common.Address, common.Address, bool, []byte, uint64, *big.Int) {
+}
+func (*blockHashCaptureTracer) CaptureEnd([]byte, uint64, error) {}
+func (*blockHashCaptureTracer) CaptureEnter(vm.OpCode, common.Address, common.Address, []byte, uint64, *big.Int) {
+}
+func (*blockHashCaptureTracer) CaptureExit([]byte, uint64, error) {}
+func (*blockHashCaptureTracer) CaptureState(uint64, vm.OpCode, uint64, uint64, *vm.ScopeContext, []byte, int, error) {
+}
+func (*blockHashCaptureTracer) CaptureFault(uint64, vm.OpCode, uint64, uint64, *vm.ScopeContext, int, error) {
+}
+
+// overriddenBlockHash returns the hash reported by
+// [blockHashOverrideBackend.BlockHash] for the block at height `num`. It is
+// deliberately different from any real block hash.
+func overriddenBlockHash(num uint64) common.Hash {
+	bytes := binary.BigEndian.AppendUint64(nil, num)
+	return crypto.Keccak256Hash(bytes)
+}
+
+// blockHashOverrideBackend wraps a [testBackend], implementing
+// [BlockHashOverrider] such that the "correct" hash of every block differs
+// from block.Hash(). As a real overriding backend would, it also indexes
+// transactions and resolves blocks by the overridden hashes.
+type blockHashOverrideBackend struct {
+	*testBackend
+}
+
+var _ BlockHashOverrider = (*blockHashOverrideBackend)(nil)
+
+func (b *blockHashOverrideBackend) BlockHash(block *types.Block) common.Hash {
+	return overriddenBlockHash(block.NumberU64())
+}
+
+func (b *blockHashOverrideBackend) GetTransaction(ctx context.Context, txHash common.Hash) (bool, *types.Transaction, common.Hash, uint64, uint64, error) {
+	found, tx, _, blockNumber, index, err := b.testBackend.GetTransaction(ctx, txHash)
+	return found, tx, overriddenBlockHash(blockNumber), blockNumber, index, err
+}
+
+func (b *blockHashOverrideBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	for n := uint64(0); n <= b.chain.CurrentBlock().Number.Uint64(); n++ {
+		if overriddenBlockHash(n) == hash {
+			return b.chain.GetBlockByNumber(n), nil
+		}
+	}
+	return b.testBackend.BlockByHash(ctx, hash)
+}
+
+// newBlockHashOverrideBackend returns a [blockHashOverrideBackend] over a
+// chain of `n` blocks, each containing a single value-transfer transaction.
+func newBlockHashOverrideBackend(t *testing.T, n int) *blockHashOverrideBackend {
+	t.Helper()
+
+	accounts := newAccounts(2)
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	signer := types.HomesteadSigner{}
+	nonce := uint64(0)
+	backend := newTestBackend(t, n, genesis, func(i int, b *core.BlockGen) {
+		tx, err := types.SignTx(types.NewTransaction(nonce, accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		require.NoError(t, err, "types.SignTx()")
+		b.AddTx(tx)
+		nonce++
+	})
+	t.Cleanup(backend.teardown)
+	return &blockHashOverrideBackend{testBackend: backend}
+}
+
+// hashFromTraceResult extracts the [common.Hash] reported by a
+// [blockHashCaptureTracer] from a trace result.
+func hashFromTraceResult(t *testing.T, res interface{}) common.Hash {
+	t.Helper()
+
+	raw, err := json.Marshal(res)
+	require.NoError(t, err, "json.Marshal() trace result")
+	var h common.Hash
+	require.NoError(t, json.Unmarshal(raw, &h), "json.Unmarshal() trace result into common.Hash")
+	return h
+}
+
+// TestOverrideBlockHash_TraceBlock tests that the [Context.BlockHash]
+// received by tracers is the overridden hash, on both the sequential
+// ([API.traceBlock]) and parallel ([API.traceBlockParallel]) paths.
+func TestOverrideBlockHash_TraceBlock(t *testing.T) {
+	const blockNum = 1
+	backend := newBlockHashOverrideBackend(t, blockNum)
+	api := NewAPI(backend)
+
+	for _, tracer := range []string{blockHashCaptureTracerName, blockHashCaptureTracerJSName} {
+		t.Run(tracer, func(t *testing.T) {
+			results, err := api.TraceBlockByNumber(t.Context(), rpc.BlockNumber(blockNum), &TraceConfig{
+				Tracer: &tracer,
+			})
+			require.NoErrorf(t, err, "TraceBlockByNumber(%d)", blockNum)
+			require.NotEmpty(t, results, "trace results")
+
+			for i, res := range results {
+				require.Emptyf(t, res.Error, "trace error for tx %d", i)
+				require.Equalf(t, overriddenBlockHash(blockNum), hashFromTraceResult(t, res.Result),
+					"Context.BlockHash received by tracer for tx %d of block %d", i, blockNum)
+			}
+		})
+	}
+}
+
+// TestOverrideBlockHash_TraceChain tests that both the block hash
+// reported in [blockTraceResult] and the [Context.BlockHash] received by
+// tracers during [API.traceChain] are the overridden hashes.
+func TestOverrideBlockHash_TraceChain(t *testing.T) {
+	const numBlocks = 5
+	backend := newBlockHashOverrideBackend(t, numBlocks)
+	api := NewAPI(backend)
+
+	from, err := api.blockByNumber(t.Context(), 0)
+	require.NoError(t, err, "blockByNumber(0)")
+	to, err := api.blockByNumber(t.Context(), numBlocks)
+	require.NoErrorf(t, err, "blockByNumber(%d)", numBlocks)
+
+	tracer := blockHashCaptureTracerName
+	resCh := api.traceChain(from, to, &TraceConfig{Tracer: &tracer}, nil)
+
+	next := uint64(1)
+	for result := range resCh {
+		require.Equal(t, next, uint64(result.Block), "traced block number")
+		require.Equalf(t, overriddenBlockHash(next), result.Hash, "blockTraceResult.Hash of block %d", next)
+
+		require.NotEmpty(t, result.Traces, "trace results of block %d", next)
+		for i, trace := range result.Traces {
+			require.Emptyf(t, trace.Error, "trace error for tx %d of block %d", i, next)
+			require.Equalf(t, overriddenBlockHash(next), hashFromTraceResult(t, trace.Result),
+				"Context.BlockHash received by tracer for tx %d of block %d", i, next)
+		}
+		next++
+	}
+	require.Equal(t, uint64(numBlocks+1), next, "all blocks traced")
+}
+
+// TestOverrideBlockHash_TraceTransaction tests that a transaction found
+// via [Backend.GetTransaction] under an overridden block hash can be traced,
+// and that the tracer receives that hash as [Context.BlockHash].
+func TestOverrideBlockHash_TraceTransaction(t *testing.T) {
+	const blockNum = 1
+	backend := newBlockHashOverrideBackend(t, blockNum)
+	api := NewAPI(backend)
+
+	block, err := backend.BlockByNumber(t.Context(), blockNum)
+	require.NoErrorf(t, err, "BlockByNumber(%d)", blockNum)
+	require.NotEmptyf(t, block.Transactions(), "%T.Transactions()", block)
+	txHash := block.Transactions()[0].Hash()
+
+	tracer := blockHashCaptureTracerName
+	res, err := api.TraceTransaction(t.Context(), txHash, &TraceConfig{Tracer: &tracer})
+	require.NoErrorf(t, err, "TraceTransaction()")
+	require.Equal(t, overriddenBlockHash(blockNum), hashFromTraceResult(t, res), "Context.BlockHash received by tracer")
+}
+
+// TestOverrideBlockHash_StandardTraceBlockToFile tests that the dump
+// files created by [API.StandardTraceBlockToFile] are named after the
+// overridden block hash rather than block.Hash().
+func TestOverrideBlockHash_StandardTraceBlockToFile(t *testing.T) {
+	const blockNum = 1
+	backend := newBlockHashOverrideBackend(t, blockNum)
+	api := NewAPI(backend)
+
+	block, err := backend.BlockByNumber(t.Context(), blockNum)
+	require.NoErrorf(t, err, "BlockByNumber(%d)", blockNum)
+
+	files, err := api.StandardTraceBlockToFile(t.Context(), block.Hash(), nil)
+	for _, file := range files {
+		defer os.Remove(file)
+	}
+	require.NoError(t, err, "StandardTraceBlockToFile()")
+	require.NotEmpty(t, files, "dump files")
+
+	wantPrefix := fmt.Sprintf("block_%#x-", overriddenBlockHash(blockNum).Bytes()[:4])
+	for _, file := range files {
+		require.Containsf(t, file, wantPrefix, "dump file %q named after overridden block hash", file)
+	}
+}

--- a/eth/tracers/api.libevm_test.go
+++ b/eth/tracers/api.libevm_test.go
@@ -46,8 +46,8 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	DefaultDirectory.Register(blockHashCaptureTracerName, newBlockHashCaptureTracer, false)
-	DefaultDirectory.Register(blockHashCaptureTracerJSName, newBlockHashCaptureTracer, true)
+	DefaultDirectory.Register(blockHashCaptureTracerName, newBlockHashCaptureTracer, false /*isJS*/)
+	DefaultDirectory.Register(blockHashCaptureTracerJSName, newBlockHashCaptureTracer, true /*isJS*/)
 	os.Exit(m.Run())
 }
 
@@ -80,50 +80,52 @@ func (*blockHashCaptureTracer) CaptureState(uint64, vm.OpCode, uint64, uint64, *
 func (*blockHashCaptureTracer) CaptureFault(uint64, vm.OpCode, uint64, uint64, *vm.ScopeContext, int, error) {
 }
 
-// saeBackend models a Streaming Asynchronous Execution backend: it populates a
-// header's state root after consensus, so block.Hash() is not the canonical hash.
-type saeBackend struct {
+// alteredBackend models a chain that uses a different design for their blocks,
+// likely due to an asynchronous execution model.
+// The state root in the header is ALWAYS altered before returning to the API,
+// resulting in a different block hash than the canonical one.
+type alteredBackend struct {
 	*testBackend
 }
 
-var _ BlockHashOverrider = (*saeBackend)(nil)
+var _ BlockHashOverrider = (*alteredBackend)(nil)
 
-func (b *saeBackend) BlockHash(block *types.Block) common.Hash {
+func (b *alteredBackend) BlockHash(block *types.Block) common.Hash {
 	return b.canonicalHash(block.NumberU64())
 }
 
-func (b *saeBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
+func (b *alteredBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
 	block, err := b.testBackend.BlockByNumber(ctx, number)
 	return alterBlock(block), err
 }
 
-func (b *saeBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+func (b *alteredBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
 	return alterBlock(b.chain.GetBlockByHash(hash)), nil
 }
 
-func (b *saeBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
+func (b *alteredBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	header, err := b.testBackend.HeaderByNumber(ctx, number)
 	return alterHeader(header), err
 }
 
-func (b *saeBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+func (b *alteredBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	header, err := b.testBackend.HeaderByHash(ctx, hash)
 	return alterHeader(header), err
 }
 
-func (b *saeBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly, preferDisk bool) (*state.StateDB, StateReleaseFunc, error) {
+func (b *alteredBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly, preferDisk bool) (*state.StateDB, StateReleaseFunc, error) {
 	return b.testBackend.StateAtBlock(ctx, b.canonicalBlock(block.NumberU64()), reexec, base, readOnly, preferDisk)
 }
 
-func (b *saeBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, StateReleaseFunc, error) {
+func (b *alteredBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, StateReleaseFunc, error) {
 	return b.testBackend.StateAtTransaction(ctx, b.canonicalBlock(block.NumberU64()), txIndex, reexec)
 }
 
-func (b *saeBackend) canonicalBlock(num uint64) *types.Block {
+func (b *alteredBackend) canonicalBlock(num uint64) *types.Block {
 	return b.chain.GetBlockByNumber(num)
 }
 
-func (b *saeBackend) canonicalHash(num uint64) common.Hash {
+func (b *alteredBackend) canonicalHash(num uint64) common.Hash {
 	return b.chain.GetCanonicalHash(num)
 }
 
@@ -148,8 +150,12 @@ func alterBlock(block *types.Block) *types.Block {
 	})
 }
 
-// newSAEBackend returns a backend over n blocks of one value transfer each.
-func newSAEBackend(t *testing.T, n int) *saeBackend {
+// numBlocks is the height of the chain [newAlteredBackend] build.
+const numBlocks = 5
+
+// newAlteredBackend returns a backend over [numBlocks] blocks of one value
+// transfer each.
+func newAlteredBackend(t *testing.T) *alteredBackend {
 	t.Helper()
 
 	accounts := newAccounts(2)
@@ -161,14 +167,14 @@ func newSAEBackend(t *testing.T, n int) *saeBackend {
 	}
 	signer := types.HomesteadSigner{}
 	nonce := uint64(0)
-	backend := newTestBackend(t, n, genesis, func(i int, b *core.BlockGen) {
+	backend := newTestBackend(t, numBlocks, genesis, func(i int, b *core.BlockGen) {
 		tx, err := types.SignTx(types.NewTransaction(nonce, accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
 		require.NoError(t, err, "types.SignTx()")
 		b.AddTx(tx)
 		nonce++
 	})
 	t.Cleanup(backend.teardown)
-	return &saeBackend{testBackend: backend}
+	return &alteredBackend{testBackend: backend}
 }
 
 // hashFromTraceResult extracts the [common.Hash] reported by a
@@ -182,9 +188,6 @@ func hashFromTraceResult(t *testing.T, res interface{}) common.Hash {
 	require.NoError(t, json.Unmarshal(raw, &h), "json.Unmarshal() trace result into common.Hash")
 	return h
 }
-
-// numBlocks is the height of the chain these tests build.
-const numBlocks = 5
 
 // traceBlockHashes returns the hashes [API.TraceBlockByNumber] surfaces, keyed by block.
 func traceBlockHashes(t *testing.T, api *API, tracer string) map[uint64][]common.Hash {
@@ -231,7 +234,7 @@ func traceChainHashes(t *testing.T, api *API) map[uint64][]common.Hash {
 }
 
 // requireCanonicalHashes asserts every surfaced hash is canonical and no block is missing.
-func requireCanonicalHashes(t *testing.T, backend *saeBackend, seen map[uint64][]common.Hash) {
+func requireCanonicalHashes(t *testing.T, backend *alteredBackend, seen map[uint64][]common.Hash) {
 	t.Helper()
 
 	require.Lenf(t, seen, numBlocks, "blocks with surfaced hashes")
@@ -245,26 +248,23 @@ func requireCanonicalHashes(t *testing.T, backend *saeBackend, seen map[uint64][
 
 // TestOverrideBlockHash_Propagation tests that the tracing APIs surface canonical hashes.
 func TestOverrideBlockHash_Propagation(t *testing.T) {
+	backend := newAlteredBackend(t)
+	api := NewAPI(backend)
+
 	t.Run("traceBlock_sequential", func(t *testing.T) {
-		backend := newSAEBackend(t, numBlocks)
-		api := NewAPI(backend)
 		requireCanonicalHashes(t, backend, traceBlockHashes(t, api, blockHashCaptureTracerName))
 	})
 
 	t.Run("traceBlock_parallel", func(t *testing.T) {
-		backend := newSAEBackend(t, numBlocks)
-		api := NewAPI(backend)
 		requireCanonicalHashes(t, backend, traceBlockHashes(t, api, blockHashCaptureTracerJSName))
 	})
 
 	t.Run("traceChain", func(t *testing.T) {
-		backend := newSAEBackend(t, numBlocks)
-		api := NewAPI(backend)
 		requireCanonicalHashes(t, backend, traceChainHashes(t, api))
 	})
 }
 
-func blockAt(t *testing.T, b *saeBackend, num uint64) *types.Block {
+func blockAt(t *testing.T, b *alteredBackend, num uint64) *types.Block {
 	t.Helper()
 
 	block, err := b.BlockByNumber(t.Context(), rpc.BlockNumber(num))
@@ -272,7 +272,7 @@ func blockAt(t *testing.T, b *saeBackend, num uint64) *types.Block {
 	return block
 }
 
-func headerAt(t *testing.T, b *saeBackend, num uint64) *types.Header {
+func headerAt(t *testing.T, b *alteredBackend, num uint64) *types.Header {
 	t.Helper()
 
 	header, err := b.HeaderByNumber(t.Context(), rpc.BlockNumber(num))
@@ -280,10 +280,12 @@ func headerAt(t *testing.T, b *saeBackend, num uint64) *types.Header {
 	return header
 }
 
-// TestSAEBackend_AccessorsAgree tests that the header and block accessors serve
+// TestAlteredHashBackend_AccessorsAgree tests that the header and block accessors serve
 // the same header, so header-only paths cannot see the unaltered form.
-func TestSAEBackend_AccessorsAgree(t *testing.T) {
-	backend := newSAEBackend(t, numBlocks)
+//
+// This test failure indicates a bug in the test implementation.
+func TestAlteredHashBackend_AccessorsAgree(t *testing.T) {
+	backend := newAlteredBackend(t)
 
 	for n := uint64(1); n <= numBlocks; n++ {
 		block, header := blockAt(t, backend, n), headerAt(t, backend, n)
@@ -296,10 +298,12 @@ func TestSAEBackend_AccessorsAgree(t *testing.T) {
 	}
 }
 
-// TestSAEBackend_ParentHashIsCanonical tests that ParentHash stays canonical
+// TestAlteredHashBackend_ParentHashIsCanonical tests that ParentHash stays canonical
 // even though block.Hash() does not.
-func TestSAEBackend_ParentHashIsCanonical(t *testing.T) {
-	backend := newSAEBackend(t, numBlocks)
+//
+// This test failure indicates a bug in the test implementation.
+func TestAlteredHashBackend_ParentHashIsCanonical(t *testing.T) {
+	backend := newAlteredBackend(t)
 
 	for n := uint64(1); n <= numBlocks; n++ {
 		block, parent := blockAt(t, backend, n), blockAt(t, backend, n-1)
@@ -313,11 +317,11 @@ func TestSAEBackend_ParentHashIsCanonical(t *testing.T) {
 	}
 }
 
-// TestBlockHash tests that [API.blockHash] falls back to block.Hash() unless
+// TestBlockHashOverriderOptional tests that [API.blockHash] falls back to block.Hash() unless
 // the [Backend] is a [BlockHashOverrider].
-func TestBlockHash(t *testing.T) {
-	const blockNum = 1
-	backend := newSAEBackend(t, blockNum)
+func TestBlockHashOverriderOptional(t *testing.T) {
+	const blockNum = 1 // must be <= numBlocks
+	backend := newAlteredBackend(t)
 
 	block, err := backend.BlockByNumber(t.Context(), blockNum)
 	require.NoErrorf(t, err, "BlockByNumber(%d)", blockNum)
@@ -337,8 +341,8 @@ func TestBlockHash(t *testing.T) {
 // TestOverrideBlockHash_TraceTransactionResolvesBlock tests block resolution by
 // canonical hash. [API.TraceTransaction] never calls [API.blockHash].
 func TestOverrideBlockHash_TraceTransactionResolvesBlock(t *testing.T) {
-	const blockNum = 1
-	backend := newSAEBackend(t, blockNum)
+	const blockNum = 1 // must be <= numBlocks
+	backend := newAlteredBackend(t)
 	api := NewAPI(backend)
 
 	block, err := backend.BlockByNumber(t.Context(), blockNum)
@@ -355,8 +359,8 @@ func TestOverrideBlockHash_TraceTransactionResolvesBlock(t *testing.T) {
 // TestOverrideBlockHash_StandardTraceBlockToFile tests that dump files are named
 // after the canonical block hash.
 func TestOverrideBlockHash_StandardTraceBlockToFile(t *testing.T) {
-	const blockNum = 1
-	backend := newSAEBackend(t, blockNum)
+	const blockNum = 1 // must be <= numBlocks
+	backend := newAlteredBackend(t)
 	api := NewAPI(backend)
 
 	files, err := api.StandardTraceBlockToFile(t.Context(), backend.canonicalHash(blockNum), nil)

--- a/eth/tracers/api.libevm_test.go
+++ b/eth/tracers/api.libevm_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/libevm/common"
@@ -91,7 +92,7 @@ type alteredBackend struct {
 var _ BlockHashOverrider = (*alteredBackend)(nil)
 
 func (b *alteredBackend) BlockHash(block *types.Block) common.Hash {
-	return b.canonicalHash(block.NumberU64())
+	return b.unalteredHash(block.NumberU64())
 }
 
 func (b *alteredBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
@@ -114,18 +115,18 @@ func (b *alteredBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*t
 }
 
 func (b *alteredBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly, preferDisk bool) (*state.StateDB, StateReleaseFunc, error) {
-	return b.testBackend.StateAtBlock(ctx, b.canonicalBlock(block.NumberU64()), reexec, base, readOnly, preferDisk)
+	return b.testBackend.StateAtBlock(ctx, b.unalteredBlock(block.NumberU64()), reexec, base, readOnly, preferDisk)
 }
 
 func (b *alteredBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, StateReleaseFunc, error) {
-	return b.testBackend.StateAtTransaction(ctx, b.canonicalBlock(block.NumberU64()), txIndex, reexec)
+	return b.testBackend.StateAtTransaction(ctx, b.unalteredBlock(block.NumberU64()), txIndex, reexec)
 }
 
-func (b *alteredBackend) canonicalBlock(num uint64) *types.Block {
+func (b *alteredBackend) unalteredBlock(num uint64) *types.Block {
 	return b.chain.GetBlockByNumber(num)
 }
 
-func (b *alteredBackend) canonicalHash(num uint64) common.Hash {
+func (b *alteredBackend) unalteredHash(num uint64) common.Hash {
 	return b.chain.GetCanonicalHash(num)
 }
 
@@ -144,10 +145,7 @@ func alterBlock(block *types.Block) *types.Block {
 	if block == nil {
 		return nil
 	}
-	return types.NewBlockWithHeader(alterHeader(block.Header())).WithBody(types.Body{
-		Transactions: block.Transactions(),
-		Uncles:       block.Uncles(),
-	})
+	return block.WithSeal(alterHeader(block.Header()))
 }
 
 // numBlocks is the height of the chain [newAlteredBackend] build.
@@ -158,17 +156,25 @@ const numBlocks = 5
 func newAlteredBackend(t *testing.T) *alteredBackend {
 	t.Helper()
 
-	accounts := newAccounts(2)
+	account := newAccounts(1)[0]
 	genesis := &core.Genesis{
 		Config: params.TestChainConfig,
 		Alloc: types.GenesisAlloc{
-			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+			account.addr: {Balance: big.NewInt(params.Ether)},
 		},
 	}
-	signer := types.HomesteadSigner{}
 	nonce := uint64(0)
 	backend := newTestBackend(t, numBlocks, genesis, func(i int, b *core.BlockGen) {
-		tx, err := types.SignTx(types.NewTransaction(nonce, accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		tx, err := types.SignTx(
+			types.NewTx(&types.LegacyTx{
+				Nonce:    nonce,
+				GasPrice: b.BaseFee(),
+				Gas:      params.TxGas,
+				To:       &common.Address{},
+			}),
+			types.HomesteadSigner{},
+			account.key,
+		)
 		require.NoError(t, err, "types.SignTx()")
 		b.AddTx(tx)
 		nonce++
@@ -179,7 +185,7 @@ func newAlteredBackend(t *testing.T) *alteredBackend {
 
 // hashFromTraceResult extracts the [common.Hash] reported by a
 // [blockHashCaptureTracer] from a trace result.
-func hashFromTraceResult(t *testing.T, res interface{}) common.Hash {
+func hashFromTraceResult(t *testing.T, res any) common.Hash {
 	t.Helper()
 
 	raw, err := json.Marshal(res)
@@ -223,97 +229,57 @@ func traceChainHashes(t *testing.T, api *API) map[uint64][]common.Hash {
 	for result := range api.traceChain(from, to, &TraceConfig{Tracer: &tracer}, nil) {
 		require.Equal(t, next, uint64(result.Block), "traced block number")
 		seen[next] = append(seen[next], result.Hash)
+		hashes := []common.Hash{result.Hash}
 		for i, trace := range result.Traces {
 			require.Emptyf(t, trace.Error, "trace error for tx %d of block %d", i, next)
-			seen[next] = append(seen[next], hashFromTraceResult(t, trace.Result))
+			hashes = append(hashes, hashFromTraceResult(t, trace.Result))
 		}
+		seen[next] = hashes
 		next++
 	}
 	require.Equal(t, uint64(numBlocks+1), next, "all blocks traced")
 	return seen
 }
 
-// requireCanonicalHashes asserts every surfaced hash is canonical and no block is missing.
-func requireCanonicalHashes(t *testing.T, backend *alteredBackend, seen map[uint64][]common.Hash) {
-	t.Helper()
-
-	require.Lenf(t, seen, numBlocks, "blocks with surfaced hashes")
-	for n := uint64(1); n <= numBlocks; n++ {
-		require.NotEmptyf(t, seen[n], "hashes surfaced for block %d", n)
-		for _, got := range seen[n] {
-			require.Equalf(t, backend.canonicalHash(n), got, "block hash surfaced for block %d", n)
-		}
-	}
-}
-
 // TestOverrideBlockHash_Propagation tests that the tracing APIs surface canonical hashes.
 func TestOverrideBlockHash_Propagation(t *testing.T) {
 	backend := newAlteredBackend(t)
 	api := NewAPI(backend)
-
-	t.Run("traceBlock_sequential", func(t *testing.T) {
-		requireCanonicalHashes(t, backend, traceBlockHashes(t, api, blockHashCaptureTracerName))
-	})
-
-	t.Run("traceBlock_parallel", func(t *testing.T) {
-		requireCanonicalHashes(t, backend, traceBlockHashes(t, api, blockHashCaptureTracerJSName))
-	})
-
-	t.Run("traceChain", func(t *testing.T) {
-		requireCanonicalHashes(t, backend, traceChainHashes(t, api))
-	})
-}
-
-func blockAt(t *testing.T, b *alteredBackend, num uint64) *types.Block {
-	t.Helper()
-
-	block, err := b.BlockByNumber(t.Context(), rpc.BlockNumber(num)) //#nosec G115 -- block number is small
-	require.NoErrorf(t, err, "BlockByNumber(%d)", num)
-	return block
-}
-
-func headerAt(t *testing.T, b *alteredBackend, num uint64) *types.Header {
-	t.Helper()
-
-	header, err := b.HeaderByNumber(t.Context(), rpc.BlockNumber(num)) //#nosec G115 -- block number is small
-	require.NoErrorf(t, err, "HeaderByNumber(%d)", num)
-	return header
-}
-
-// TestAlteredHashBackend_AccessorsAgree tests that the header and block accessors serve
-// the same header, so header-only paths cannot see the unaltered form.
-//
-// This test failure indicates a bug in the test implementation.
-func TestAlteredHashBackend_AccessorsAgree(t *testing.T) {
-	backend := newAlteredBackend(t)
-
-	for n := uint64(1); n <= numBlocks; n++ {
-		block, header := blockAt(t, backend, n), headerAt(t, backend, n)
-
-		byHash, err := backend.HeaderByHash(t.Context(), backend.canonicalHash(n))
-		require.NoErrorf(t, err, "HeaderByHash(canonical %d)", n)
-
-		require.Equalf(t, block.Hash(), header.Hash(), "HeaderByNumber() vs BlockByNumber() for block %d", n)
-		require.Equalf(t, header.Hash(), byHash.Hash(), "HeaderByHash() vs HeaderByNumber() for block %d", n)
+	tests := []struct {
+		name  string
+		trace func(t *testing.T) map[uint64][]common.Hash
+	}{
+		{
+			name: "traceBlock_sequential",
+			trace: func(t *testing.T) map[uint64][]common.Hash {
+				return traceBlockHashes(t, api, blockHashCaptureTracerName)
+			},
+		},
+		{
+			name: "traceBlock_parallel",
+			trace: func(t *testing.T) map[uint64][]common.Hash {
+				return traceBlockHashes(t, api, blockHashCaptureTracerJSName)
+			},
+		},
+		{
+			name: "traceChain",
+			trace: func(t *testing.T) map[uint64][]common.Hash {
+				return traceChainHashes(t, api)
+			},
+		},
 	}
-}
-
-// TestAlteredHashBackend_ParentHashIsCanonical tests that ParentHash stays canonical
-// even though block.Hash() does not.
-//
-// This test failure indicates a bug in the test implementation.
-func TestAlteredHashBackend_ParentHashIsCanonical(t *testing.T) {
-	backend := newAlteredBackend(t)
-
-	for n := uint64(1); n <= numBlocks; n++ {
-		block, parent := blockAt(t, backend, n), blockAt(t, backend, n-1)
-
-		require.NotEqualf(t, backend.canonicalHash(n), block.Hash(),
-			"altering the header changes block.Hash() away from the canonical hash, block %d", n)
-		require.Equalf(t, backend.canonicalHash(n-1), block.ParentHash(),
-			"ParentHash of block %d is the canonical hash of its parent", n)
-		require.NotEqualf(t, parent.Hash(), block.ParentHash(),
-			"ParentHash of block %d is not the altered parent's block.Hash()", n)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			seen := test.trace(t)
+			require.Lenf(t, seen, numBlocks, "blocks with surfaced hashes")
+			for n := uint64(1); n <= numBlocks; n++ {
+				require.NotEmptyf(t, seen[n], "hashes surfaced for block %d", n)
+				want := backend.unalteredHash(n)
+				for _, got := range seen[n] {
+					require.Equalf(t, want, got, "block hash surfaced for block %d", n)
+				}
+			}
+		})
 	}
 }
 
@@ -325,17 +291,30 @@ func TestBlockHashOverriderOptional(t *testing.T) {
 
 	block, err := backend.BlockByNumber(t.Context(), blockNum)
 	require.NoErrorf(t, err, "BlockByNumber(%d)", blockNum)
-	require.NotEqual(t, backend.canonicalHash(blockNum), block.Hash(), "test precondition: altered header hashes differently")
+	require.NotEqual(t, backend.unalteredHash(blockNum), block.Hash(), "test precondition: altered header hashes differently")
 
-	t.Run("not_implemented", func(t *testing.T) {
-		api := NewAPI(backend.testBackend)
-		require.Equal(t, block.Hash(), api.blockHash(block), "API.blockHash() with a Backend that is not a BlockHashOverrider")
-	})
-
-	t.Run("implemented", func(t *testing.T) {
-		api := NewAPI(backend)
-		require.Equal(t, backend.canonicalHash(blockNum), api.blockHash(block), "API.blockHash() with a Backend that is a BlockHashOverrider")
-	})
+	tests := []struct {
+		name         string
+		backend      Backend
+		expectedHash common.Hash
+	}{
+		{
+			name:         "not_implemented",
+			backend:      backend.testBackend,
+			expectedHash: block.Hash(),
+		},
+		{
+			name:         "implemented",
+			backend:      backend,
+			expectedHash: backend.unalteredHash(blockNum),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := NewAPI(tt.backend)
+			require.Equalf(t, tt.expectedHash, api.blockHash(block), "%T.blockHash()", api)
+		})
+	}
 }
 
 // TestOverrideBlockHash_TraceTransactionResolvesBlock tests block resolution by
@@ -353,25 +332,28 @@ func TestOverrideBlockHash_TraceTransactionResolvesBlock(t *testing.T) {
 	tracer := blockHashCaptureTracerName
 	res, err := api.TraceTransaction(t.Context(), txHash, &TraceConfig{Tracer: &tracer})
 	require.NoErrorf(t, err, "TraceTransaction()")
-	require.Equal(t, backend.canonicalHash(blockNum), hashFromTraceResult(t, res), "Context.BlockHash received by tracer")
+	require.Equal(t, backend.unalteredHash(blockNum), hashFromTraceResult(t, res), "Context.BlockHash received by tracer")
 }
 
 // TestOverrideBlockHash_StandardTraceBlockToFile tests that dump files are named
 // after the canonical block hash.
 func TestOverrideBlockHash_StandardTraceBlockToFile(t *testing.T) {
-	const blockNum = 1 // must be <= numBlocks
 	backend := newAlteredBackend(t)
 	api := NewAPI(backend)
 
-	files, err := api.StandardTraceBlockToFile(t.Context(), backend.canonicalHash(blockNum), nil)
-	for _, file := range files {
-		defer os.Remove(file)
-	}
-	require.NoError(t, err, "StandardTraceBlockToFile()")
-	require.NotEmpty(t, files, "dump files")
+	for blockNum := uint64(1); blockNum <= numBlocks; blockNum++ {
+		expectedHash := backend.unalteredHash(blockNum)
+		files, err := api.StandardTraceBlockToFile(t.Context(), expectedHash, nil)
+		require.NoErrorf(t, err, "StandardTraceBlockToFile() block %d", blockNum)
+		require.NotEmptyf(t, files, "StandardTraceBlockToFile() block %d returned no files", blockNum)
 
-	wantPrefix := fmt.Sprintf("block_%#x-", backend.canonicalHash(blockNum).Bytes()[:4])
-	for _, file := range files {
-		require.Containsf(t, file, wantPrefix, "dump file %q named after canonical block hash", file)
+		for _, file := range files {
+			defer os.Remove(file)
+		}
+
+		wantPrefix := fmt.Sprintf("block_%#x-", expectedHash.Bytes()[:4])
+		for _, file := range files {
+			assert.Containsf(t, file, wantPrefix, "file name should contain expected hash for block %d", blockNum)
+		}
 	}
 }

--- a/eth/tracers/api.libevm_test.go
+++ b/eth/tracers/api.libevm_test.go
@@ -267,7 +267,7 @@ func TestOverrideBlockHash_Propagation(t *testing.T) {
 func blockAt(t *testing.T, b *alteredBackend, num uint64) *types.Block {
 	t.Helper()
 
-	block, err := b.BlockByNumber(t.Context(), rpc.BlockNumber(num))
+	block, err := b.BlockByNumber(t.Context(), rpc.BlockNumber(num)) //#nosec G115 -- block number is small
 	require.NoErrorf(t, err, "BlockByNumber(%d)", num)
 	return block
 }
@@ -275,7 +275,7 @@ func blockAt(t *testing.T, b *alteredBackend, num uint64) *types.Block {
 func headerAt(t *testing.T, b *alteredBackend, num uint64) *types.Header {
 	t.Helper()
 
-	header, err := b.HeaderByNumber(t.Context(), rpc.BlockNumber(num))
+	header, err := b.HeaderByNumber(t.Context(), rpc.BlockNumber(num)) //#nosec G115 -- block number is small
 	require.NoErrorf(t, err, "HeaderByNumber(%d)", num)
 	return header
 }

--- a/eth/tracers/api.libevm_test.go
+++ b/eth/tracers/api.libevm_test.go
@@ -228,7 +228,6 @@ func traceChainHashes(t *testing.T, api *API) map[uint64][]common.Hash {
 	next := uint64(1)
 	for result := range api.traceChain(from, to, &TraceConfig{Tracer: &tracer}, nil) {
 		require.Equal(t, next, uint64(result.Block), "traced block number")
-		seen[next] = append(seen[next], result.Hash)
 		hashes := []common.Hash{result.Hash}
 		for i, trace := range result.Traces {
 			require.Emptyf(t, trace.Error, "trace error for tx %d of block %d", i, next)
@@ -347,9 +346,11 @@ func TestOverrideBlockHash_StandardTraceBlockToFile(t *testing.T) {
 		require.NoErrorf(t, err, "StandardTraceBlockToFile() block %d", blockNum)
 		require.NotEmptyf(t, files, "StandardTraceBlockToFile() block %d returned no files", blockNum)
 
-		for _, file := range files {
-			defer os.Remove(file)
-		}
+		t.Cleanup(func() {
+			for _, file := range files {
+				os.Remove(file)
+			}
+		})
 
 		wantPrefix := fmt.Sprintf("block_%#x-", expectedHash.Bytes()[:4])
 		for _, file := range files {


### PR DESCRIPTION
## Why this should be merged

The `types.Header` must be altered in SAE to return the appropriate state root and base fee, so that the API can accurately find the these values for execution. However, this will modify the block hash (since this is found runtime in the header), so this provides the option to overwrite the block hash via an optional interface. Instead of getting the block hash from the header, an implementer can retrieve the block again, and use the original hash instead.

## How this works

Use optional interface for every call of `block.Hash()`

## How this was tested

New UT
