### PR TITLE
feat(eth/tracers): export `txTraceResult` and prestate `account`

### DIFF
--- a/eth/tracers/api.libevm.go
+++ b/eth/tracers/api.libevm.go
@@ -40,3 +40,7 @@ func (a *API) blockHash(block *types.Block) common.Hash {
 	}
 	return overrider.BlockHash(block)
 }
+
+// TxTraceResult exports the [txTraceResult] type, returned per transaction
+// by the TraceBlock* methods.
+type TxTraceResult = txTraceResult

--- a/eth/tracers/native/prestate_libevm.go
+++ b/eth/tracers/native/prestate_libevm.go
@@ -35,3 +35,7 @@ func (t *prestateTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 	// idempotent.
 	t.lookupAccount(to)
 }
+
+// Account exports the [account] type, used for JSON-marshalling the results
+// of the prestateTracer.
+type Account = account


### PR DESCRIPTION
## Why this should be merged

Consumers of the `debug_traceBlock*` currently have to mirror the response types with anonymous structs to
decode results, because they are unexported.

## How this works

I just exported type aliases, following the existing pattern.

## How this was tested
N/A 