### PR TITLE
feat(eth/tracers): export `blockTraceResult` as `BlockTraceResult`

### DIFF
--- a/eth/tracers/api.libevm.go
+++ b/eth/tracers/api.libevm.go
@@ -44,3 +44,7 @@ func (a *API) blockHash(block *types.Block) common.Hash {
 // TxTraceResult exports the [txTraceResult] type, returned per transaction
 // by the TraceBlock* methods.
 type TxTraceResult = txTraceResult
+
+// BlockTraceResult exports the [blockTraceResult] type, streamed per block
+// by the TraceChain subscription.
+type BlockTraceResult = blockTraceResult


### PR DESCRIPTION
## Why this should be merged

Consumers of `debug_traceChain` currently have to mirror the streamed per-block result type with local structs to decode results, because it ss unexported.

## How this works

I just exported a type alias, following the existing pattern. 

## How this was tested

N/A