### PR TITLE
feat(core)!: optionally credit burnt base fee to coinbase address

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -463,6 +463,7 @@ func (st *StateTransition) transitionDb() (*ExecutionResult, error) {
 		fee := new(uint256.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTipU256)
 		st.state.AddBalance(st.evm.Context.Coinbase, fee)
+		st.maybeCreditBaseFeeToCoinbase() // libevm
 	}
 
 	return &ExecutionResult{

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -465,8 +465,6 @@ func (st *StateTransition) transitionDb() (*ExecutionResult, error) {
 		st.state.AddBalance(st.evm.Context.Coinbase, fee)
 	}
 
-	st.rulesHooks().AfterExecutingTransaction(st.state, st.evm.Context.BaseFee, st.gasUsed()) // libevm: must be done before tracer.CaptureEnd() in defer.
-
 	return &ExecutionResult{
 		UsedGas:     st.gasUsed(),
 		RefundedGas: gasRefund,

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -465,6 +465,8 @@ func (st *StateTransition) transitionDb() (*ExecutionResult, error) {
 		st.state.AddBalance(st.evm.Context.Coinbase, fee)
 	}
 
+	st.rulesHooks().AfterExecutingTransaction(st.state, st.evm.Context.BaseFee, st.gasUsed()) // libevm: must be done before tracer.CaptureEnd() in defer.
+
 	return &ExecutionResult{
 		UsedGas:     st.gasUsed(),
 		RefundedGas: gasRefund,

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -115,8 +115,6 @@ func (st *StateTransition) afterGasRefund(refunded uint64) {
 		st.gasRemaining,
 		limit-minConsume,
 	)
-
-	st.maybeCreditBaseFeeToCoinbase()
 }
 
 // maybeCreditBaseFeeToCoinbase credits the coinbase with the base-fee portion
@@ -131,14 +129,12 @@ func (st *StateTransition) maybeCreditBaseFeeToCoinbase() {
 		return
 	}
 
-	baseFee := st.evm.Context.BaseFee
+	baseFee, _ := uint256.FromBig(st.evm.Context.BaseFee)
 	if baseFee == nil {
 		return
 	}
-
-	baseFeeU256, _ := uint256.FromBig(baseFee)
-	fee := new(uint256.Int).SetUint64(st.gasUsed())
-	fee.Mul(fee, baseFeeU256)
+	fee := uint256.NewInt(st.gasUsed())
+	fee.Mul(fee, baseFee)
 	st.state.AddBalance(st.evm.Context.Coinbase, fee)
 }
 

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/params"
+	"github.com/holiman/uint256"
 )
 
 func (st *StateTransition) rulesHooks() params.RulesHooks {
@@ -74,7 +75,6 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.state.RevertToSnapshot(snap)
 		err = fmt.Errorf("execution invalidated: %w", invalid)
 	}
-
 	return res, err
 }
 
@@ -114,6 +114,31 @@ func (st *StateTransition) afterGasRefund(refunded uint64) {
 		st.gasRemaining,
 		limit-minConsume,
 	)
+
+	st.maybeCreditBaseFeeToCoinbase()
+}
+
+// maybeCreditBaseFeeToCoinbase credits the coinbase with the base-fee portion
+// of the transaction fee, which EIP-1559 would otherwise burn. The effective
+// tip is unconditionally credited by transitionDb so MUST NOT be included here.
+//
+// This MUST be called after [StateTransition.refundGas] and before
+// [vm.EVMLogger.CaptureEnd] in the defer of
+// [StateTransition.transitionDb].
+func (st *StateTransition) maybeCreditBaseFeeToCoinbase() {
+	if !st.rulesHooks().ShouldCreditBaseFeeToCoinbase() {
+		return
+	}
+
+	baseFee := st.evm.Context.BaseFee
+	if baseFee == nil {
+		return
+	}
+
+	baseFeeU256, _ := uint256.FromBig(baseFee)
+	fee := new(uint256.Int).SetUint64(st.gasUsed())
+	fee.Mul(fee, baseFeeU256)
+	st.state.AddBalance(st.evm.Context.Coinbase, fee)
 }
 
 // libevmAccessListGas is a convenience wrapper for calling the

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/params"
-	"github.com/holiman/uint256"
 )
 
 func (st *StateTransition) rulesHooks() params.RulesHooks {

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -75,12 +75,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		err = fmt.Errorf("execution invalidated: %w", invalid)
 	}
 
-	if err != nil {
-		return res, err
-	}
-
-	st.rulesHooks().AfterExecutingTransaction(st.state, st.evm.Context.BaseFee, res.UsedGas)
-	return res, nil
+	return res, err
 }
 
 // canExecuteTransaction is a convenience wrapper for calling the

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -16,6 +16,7 @@
 package core_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -31,6 +32,8 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/eth/tracers"
+	"github.com/ava-labs/libevm/eth/tracers/native"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/libevm/ethtest"
 	"github.com/ava-labs/libevm/libevm/hookstest"
@@ -307,11 +310,7 @@ func TestAfterExecutingTransaction(t *testing.T) {
 		reward   = 42
 	)
 
-	var (
-		beneficiary = common.Address{'b', 'e', 'n'}
-		invalidator = common.Address{'i', 'n', 'v'}
-		testErr     = errors.New("test error")
-	)
+	beneficiary := common.Address{'b', 'e', 'n'}
 
 	tests := []struct {
 		name          string
@@ -324,12 +323,7 @@ func TestAfterExecutingTransaction(t *testing.T) {
 			to:            &common.Address{},
 			startingFunds: new(uint256.Int).SetAllOne(),
 		},
-		{
-			name:          "execution_invalidated",
-			to:            &invalidator,
-			startingFunds: new(uint256.Int).SetAllOne(),
-			wantErr:       testErr,
-		},
+
 		{
 			name:          "execution_error",
 			to:            &common.Address{},
@@ -350,13 +344,9 @@ func TestAfterExecutingTransaction(t *testing.T) {
 					hookCalled = true
 					gotBaseFee = baseFee
 					gotGasUsed = gasUsed
+					curr := state.GetBalance(beneficiary)
+					state.SubBalance(beneficiary, curr)
 					state.AddBalance(beneficiary, uint256.NewInt(reward))
-				},
-				PrecompileOverrides: map[common.Address]libevm.PrecompiledContract{
-					invalidator: vm.NewStatefulPrecompile(func(env vm.PrecompileEnvironment, _ []byte) ([]byte, error) {
-						env.InvalidateExecution(testErr)
-						return nil, nil
-					}),
 				},
 			}
 			hooks.Register(t)
@@ -377,17 +367,21 @@ func TestAfterExecutingTransaction(t *testing.T) {
 				},
 			)
 
+			// All edits MUST be captured by the tracer.
+			tracer, err := tracers.DefaultDirectory.New("prestateTracer", &tracers.Context{}, json.RawMessage(`{"diffMode":true}`))
+			require.NoError(t, err, `tracers.DefaultDirectory.New("prestateTracer", ...)`)
+
 			gp := core.GasPool(math.MaxUint64)
 			var gasUsed uint64
 			receipt, err := core.ApplyTransaction(
-				evm.ChainConfig(), nil, &common.Address{}, &gp, sdb,
+				evm.ChainConfig(), nil, &beneficiary, &gp, sdb,
 				&types.Header{
 					BaseFee: big.NewInt(gasPrice),
 					// Required but irrelevant fields
 					Number:     big.NewInt(0),
 					Difficulty: big.NewInt(0),
 				},
-				tx, &gasUsed, vm.Config{},
+				tx, &gasUsed, vm.Config{Tracer: tracer},
 			)
 			require.ErrorIs(t, err, tt.wantErr, "core.ApplyTransaction(...)")
 
@@ -401,6 +395,16 @@ func TestAfterExecutingTransaction(t *testing.T) {
 			assert.Equal(t, big.NewInt(gasPrice), gotBaseFee, "base fee received by hook")
 			assert.Equalf(t, receipt.GasUsed, gotGasUsed, "gas used received by hook vs %T.GasUsed", receipt)
 			assert.Equal(t, uint64(reward), sdb.GetBalance(beneficiary).Uint64(), "state modified by hook")
+
+			traced, err := tracer.GetResult()
+			require.NoError(t, err, "tracer.GetResult()")
+			var diff struct {
+				Post map[common.Address]*native.Account `json:"post"`
+				Pre  map[common.Address]*native.Account `json:"pre"`
+			}
+			require.NoError(t, json.Unmarshal(traced, &diff), "json.Unmarshal(tracer.GetResult(), ...)")
+			require.Containsf(t, diff.Post, beneficiary, "beneficiary in post-state diff of native prestate tracer")
+			assert.Equal(t, big.NewInt(reward), diff.Post[beneficiary].Balance, "balance added by hook in post-state diff of native prestate tracer")
 		})
 	}
 }

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -311,43 +311,48 @@ func TestCreditBaseFeeToCoinbase(t *testing.T) {
 	// The tip and base fee MUST differ so crediting the wrong one (or both
 	// twice) is detectable in the coinbase balance.
 	const (
-		baseFee = 3
-		tip     = 2
-		feeCap  = baseFee + tip + 1 // not binding, so the effective tip is [tip]
+		gas         = params.TxGas
+		baseFee     = 3
+		tip         = 2
+		feeCap      = baseFee + tip + 1 // not binding, so the effective tip is [tip]
+		legacyPrice = 7
 	)
+
+	pre1559 := &types.LegacyTx{
+		To:       &common.Address{},
+		Gas:      gas,
+		GasPrice: big.NewInt(legacyPrice),
+	}
+	post1559 := &types.DynamicFeeTx{
+		To:        &common.Address{},
+		Gas:       gas,
+		GasFeeCap: big.NewInt(feeCap),
+		GasTipCap: big.NewInt(tip),
+	}
 
 	tests := []struct {
 		name          string
 		creditBaseFee bool
-		preLondon     bool
-		startingFunds *uint256.Int
-		wantErr       error
-		wantFeePerGas uint64 // credited to the coinbase, per unit of gas used
+		tx            types.TxData // concrete type also dictates pre- vs post- EIP1559 behaviour
+		wantFeePerGas uint64       // credited to the coinbase, per unit of gas used
 	}{
 		{
 			name:          "disabled_coinbase_receives_only_tip",
 			creditBaseFee: false,
-			startingFunds: new(uint256.Int).SetAllOne(),
+			tx:            post1559,
 			wantFeePerGas: tip,
 		},
 		{
 			name:          "enabled_coinbase_receives_tip_and_base_fee",
 			creditBaseFee: true,
-			startingFunds: new(uint256.Int).SetAllOne(),
+			tx:            post1559,
 			wantFeePerGas: tip + baseFee,
 		},
 		{
 			name:          "enabled_pre_london_hook_is_noop",
 			creditBaseFee: true,
-			preLondon:     true,
-			startingFunds: new(uint256.Int).SetAllOne(),
-			wantFeePerGas: tip, // i.e. the legacy tx's full gas price, exactly once
-		},
-		{
-			name:          "execution_error",
-			creditBaseFee: true,
-			startingFunds: uint256.NewInt(1), // can't buy gas
-			wantErr:       core.ErrInsufficientFunds,
+			tx:            pre1559,
+			wantFeePerGas: legacyPrice,
 		},
 	}
 
@@ -361,31 +366,21 @@ func TestCreditBaseFeeToCoinbase(t *testing.T) {
 			key, err := crypto.GenerateKey()
 			require.NoError(t, err, "crypto.GenerateKey()")
 
-			// With London active there is a base fee to (optionally) credit;
-			// without it, the effective tip alone equals the full gas price.
-			config := params.TestChainConfig
-			txData := types.TxData(&types.DynamicFeeTx{
-				ChainID:   config.ChainID,
-				To:        &common.Address{},
-				Gas:       1e6,
-				GasFeeCap: big.NewInt(feeCap),
-				GasTipCap: big.NewInt(tip),
-			})
+			config := *params.TestChainConfig
 			headerBaseFee := big.NewInt(baseFee)
-			if tt.preLondon {
-				config = &params.ChainConfig{}
-				txData = &types.LegacyTx{
-					To:       &common.Address{},
-					Gas:      1e6,
-					GasPrice: big.NewInt(tip),
-				}
+			switch tt.tx.(type) {
+			case *types.LegacyTx:
+				config.LondonBlock = nil
 				headerBaseFee = nil
+			case *types.DynamicFeeTx:
+			default:
+				t.Fatalf("Bad test setup: unsupported tx type %T", tt.tx)
 			}
 
-			sdb, evm := ethtest.NewZeroEVM(t, ethtest.WithChainConfig(config))
-			sdb.SetBalance(crypto.PubkeyToAddress(key.PublicKey), tt.startingFunds)
+			sdb, evm := ethtest.NewZeroEVM(t, ethtest.WithChainConfig(&config))
+			sdb.SetBalance(crypto.PubkeyToAddress(key.PublicKey), new(uint256.Int).SetAllOne())
 
-			tx := types.MustSignNewTx(key, types.LatestSigner(config), txData)
+			tx := types.MustSignNewTx(key, types.LatestSigner(&config), tt.tx)
 
 			// All edits MUST be captured by the tracer.
 			tracer, err := tracers.DefaultDirectory.New("prestateTracer", &tracers.Context{}, json.RawMessage(`{"diffMode":true}`))
@@ -404,12 +399,7 @@ func TestCreditBaseFeeToCoinbase(t *testing.T) {
 				},
 				tx, &gasUsed, vm.Config{Tracer: tracer},
 			)
-			require.ErrorIs(t, err, tt.wantErr, "core.ApplyTransaction(...)")
-
-			if tt.wantErr != nil {
-				assert.Equal(t, new(uint256.Int), sdb.GetBalance(coinbase), "balance of coinbase unchanged when transaction not applied")
-				return
-			}
+			require.NoError(t, err, "core.ApplyTransaction(...)")
 			require.Equalf(t, types.ReceiptStatusSuccessful, receipt.Status, "%T.Status", receipt)
 
 			wantFee := receipt.GasUsed * tt.wantFeePerGas
@@ -419,7 +409,6 @@ func TestCreditBaseFeeToCoinbase(t *testing.T) {
 			require.NoError(t, err, "tracer.GetResult()")
 			var diff struct { // from [native.PrestateTracer.GetResult]
 				Post map[common.Address]*native.Account `json:"post"`
-				Pre  map[common.Address]*native.Account `json:"pre"`
 			}
 			require.NoError(t, json.Unmarshal(traced, &diff), "json.Unmarshal(tracer.GetResult(), ...)")
 

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -382,7 +382,9 @@ func TestCreditBaseFeeToCoinbase(t *testing.T) {
 
 			tx := types.MustSignNewTx(key, types.LatestSigner(&config), tt.tx)
 
-			// All edits MUST be captured by the tracer.
+			// Unlike checking the state DB directly, a tracer gives insight as
+			// to _when_ the coinbase balance was updated, not just _that_ it
+			// was. If the update is too late then traces are incomplete.
 			tracer, err := tracers.DefaultDirectory.New("prestateTracer", &tracers.Context{}, json.RawMessage(`{"diffMode":true}`))
 			require.NoError(t, err, `tracers.DefaultDirectory.New("prestateTracer", ...)`)
 

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -304,29 +304,48 @@ func TestMinimumGasConsumption(t *testing.T) {
 	}
 }
 
-func TestAfterExecutingTransaction(t *testing.T) {
+// TestCreditBaseFeeToCoinbase tests that the coinbase is credited with the
+// base fee if enabled in the hooks and post-London. Additionally, these state
+// changes should be conveyed to the tracer.
+func TestCreditBaseFeeToCoinbase(t *testing.T) {
+	// The tip and base fee MUST differ so crediting the wrong one (or both
+	// twice) is detectable in the coinbase balance.
 	const (
-		gasPrice = 3
-		reward   = 42
+		baseFee = 3
+		tip     = 2
+		feeCap  = baseFee + tip + 1 // not binding, so the effective tip is [tip]
 	)
-
-	beneficiary := common.Address{'b', 'e', 'n'}
 
 	tests := []struct {
 		name          string
-		to            *common.Address
+		creditBaseFee bool
+		preLondon     bool
 		startingFunds *uint256.Int
 		wantErr       error
+		wantFeePerGas uint64 // credited to the coinbase, per unit of gas used
 	}{
 		{
-			name:          "successful_execution",
-			to:            &common.Address{},
+			name:          "disabled_coinbase_receives_only_tip",
+			creditBaseFee: false,
 			startingFunds: new(uint256.Int).SetAllOne(),
+			wantFeePerGas: tip,
 		},
-
+		{
+			name:          "enabled_coinbase_receives_tip_and_base_fee",
+			creditBaseFee: true,
+			startingFunds: new(uint256.Int).SetAllOne(),
+			wantFeePerGas: tip + baseFee,
+		},
+		{
+			name:          "enabled_pre_london_hook_is_noop",
+			creditBaseFee: true,
+			preLondon:     true,
+			startingFunds: new(uint256.Int).SetAllOne(),
+			wantFeePerGas: tip, // i.e. the legacy tx's full gas price, exactly once
+		},
 		{
 			name:          "execution_error",
-			to:            &common.Address{},
+			creditBaseFee: true,
 			startingFunds: uint256.NewInt(1), // can't buy gas
 			wantErr:       core.ErrInsufficientFunds,
 		},
@@ -334,49 +353,51 @@ func TestAfterExecutingTransaction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var (
-				hookCalled bool
-				gotBaseFee *big.Int
-				gotGasUsed uint64
-			)
 			hooks := &hookstest.Stub{
-				AfterExecutingTransactionFn: func(state libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
-					hookCalled = true
-					gotBaseFee = baseFee
-					gotGasUsed = gasUsed
-					curr := state.GetBalance(beneficiary)
-					state.SubBalance(beneficiary, curr)
-					state.AddBalance(beneficiary, uint256.NewInt(reward))
-				},
+				CreditBaseFeeToCoinbase: tt.creditBaseFee,
 			}
 			hooks.Register(t)
 
 			key, err := crypto.GenerateKey()
 			require.NoError(t, err, "crypto.GenerateKey()")
 
-			sdb, evm := ethtest.NewZeroEVM(t)
+			// With London active there is a base fee to (optionally) credit;
+			// without it, the effective tip alone equals the full gas price.
+			config := params.TestChainConfig
+			txData := types.TxData(&types.DynamicFeeTx{
+				ChainID:   config.ChainID,
+				To:        &common.Address{},
+				Gas:       1e6,
+				GasFeeCap: big.NewInt(feeCap),
+				GasTipCap: big.NewInt(tip),
+			})
+			headerBaseFee := big.NewInt(baseFee)
+			if tt.preLondon {
+				config = &params.ChainConfig{}
+				txData = &types.LegacyTx{
+					To:       &common.Address{},
+					Gas:      1e6,
+					GasPrice: big.NewInt(tip),
+				}
+				headerBaseFee = nil
+			}
+
+			sdb, evm := ethtest.NewZeroEVM(t, ethtest.WithChainConfig(config))
 			sdb.SetBalance(crypto.PubkeyToAddress(key.PublicKey), tt.startingFunds)
 
-			tx := types.MustSignNewTx(
-				key,
-				types.LatestSigner(evm.ChainConfig()),
-				&types.LegacyTx{
-					To:       tt.to,
-					Gas:      1e6,
-					GasPrice: big.NewInt(gasPrice),
-				},
-			)
+			tx := types.MustSignNewTx(key, types.LatestSigner(config), txData)
 
 			// All edits MUST be captured by the tracer.
 			tracer, err := tracers.DefaultDirectory.New("prestateTracer", &tracers.Context{}, json.RawMessage(`{"diffMode":true}`))
 			require.NoError(t, err, `tracers.DefaultDirectory.New("prestateTracer", ...)`)
 
+			coinbase := common.Address{'c', 'o', 'i', 'n'}
 			gp := core.GasPool(math.MaxUint64)
 			var gasUsed uint64
 			receipt, err := core.ApplyTransaction(
-				evm.ChainConfig(), nil, &beneficiary, &gp, sdb,
+				evm.ChainConfig(), nil, &coinbase, &gp, sdb,
 				&types.Header{
-					BaseFee: big.NewInt(gasPrice),
+					BaseFee: headerBaseFee,
 					// Required but irrelevant fields
 					Number:     big.NewInt(0),
 					Difficulty: big.NewInt(0),
@@ -385,26 +406,25 @@ func TestAfterExecutingTransaction(t *testing.T) {
 			)
 			require.ErrorIs(t, err, tt.wantErr, "core.ApplyTransaction(...)")
 
-			wantHookCalled := tt.wantErr == nil
-			require.Equal(t, wantHookCalled, hookCalled, "hook called i.f.f. execution succeeds")
-			if !wantHookCalled {
-				assert.Equal(t, new(uint256.Int), sdb.GetBalance(beneficiary), "balance of beneficiary unchanged when hook not called")
+			if tt.wantErr != nil {
+				assert.Equal(t, new(uint256.Int), sdb.GetBalance(coinbase), "balance of coinbase unchanged when transaction not applied")
 				return
 			}
+			require.Equalf(t, types.ReceiptStatusSuccessful, receipt.Status, "%T.Status", receipt)
 
-			assert.Equal(t, big.NewInt(gasPrice), gotBaseFee, "base fee received by hook")
-			assert.Equalf(t, receipt.GasUsed, gotGasUsed, "gas used received by hook vs %T.GasUsed", receipt)
-			assert.Equal(t, uint64(reward), sdb.GetBalance(beneficiary).Uint64(), "state modified by hook")
+			wantFee := receipt.GasUsed * tt.wantFeePerGas
+			assert.Equal(t, wantFee, sdb.GetBalance(coinbase).Uint64(), "balance of coinbase")
 
 			traced, err := tracer.GetResult()
 			require.NoError(t, err, "tracer.GetResult()")
-			var diff struct {
+			var diff struct { // from [native.PrestateTracer.GetResult]
 				Post map[common.Address]*native.Account `json:"post"`
 				Pre  map[common.Address]*native.Account `json:"pre"`
 			}
 			require.NoError(t, json.Unmarshal(traced, &diff), "json.Unmarshal(tracer.GetResult(), ...)")
-			require.Containsf(t, diff.Post, beneficiary, "beneficiary in post-state diff of native prestate tracer")
-			assert.Equal(t, big.NewInt(reward), diff.Post[beneficiary].Balance, "balance added by hook in post-state diff of native prestate tracer")
+
+			require.Containsf(t, diff.Post, coinbase, "coinbase in post-state diff of native prestate tracer")
+			assert.Equal(t, new(big.Int).SetUint64(wantFee), diff.Post[coinbase].Balance, "balance of coinbase in post-state diff of native prestate tracer")
 		})
 	}
 }

--- a/libevm/hookstest/stub.go
+++ b/libevm/hookstest/stub.go
@@ -42,17 +42,17 @@ func Register[C params.ChainConfigHooks, R params.RulesHooks](tb testing.TB, ext
 // [params.RulesHooks]. Each of the fields, if non-nil, back their respective
 // hook methods, which otherwise fall back to the default behaviour.
 type Stub struct {
-	CheckConfigForkOrderFn      func() error
-	CheckConfigCompatibleFn     func(*params.ChainConfig, *big.Int, uint64) *params.ConfigCompatError
-	DescriptionSuffix           string
-	PrecompileOverrides         map[common.Address]libevm.PrecompiledContract
-	ActivePrecompilesFn         func([]common.Address) []common.Address
-	AccessListGasFn             func(libevm.AccessList) (uint64, bool, error)
-	CanExecuteTransactionFn     func(common.Address, *common.Address, libevm.StateReader) error
-	CanCreateContractFn         func(*libevm.AddressContext, uint64, libevm.StateReader) (uint64, error)
-	MinimumGasConsumptionFn     func(txGasLimit uint64) uint64
-	DisableGasRefunds           bool
-	AfterExecutingTransactionFn func(state libevm.StateDB, baseFee *big.Int, gasUsed uint64)
+	CheckConfigForkOrderFn  func() error
+	CheckConfigCompatibleFn func(*params.ChainConfig, *big.Int, uint64) *params.ConfigCompatError
+	DescriptionSuffix       string
+	PrecompileOverrides     map[common.Address]libevm.PrecompiledContract
+	ActivePrecompilesFn     func([]common.Address) []common.Address
+	AccessListGasFn         func(libevm.AccessList) (uint64, bool, error)
+	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
+	CanCreateContractFn     func(*libevm.AddressContext, uint64, libevm.StateReader) (uint64, error)
+	MinimumGasConsumptionFn func(txGasLimit uint64) uint64
+	DisableGasRefunds       bool
+	CreditBaseFeeToCoinbase bool
 }
 
 // Register is a convenience wrapper for registering s as both the
@@ -164,13 +164,9 @@ func (s Stub) MinimumGasConsumption(limit uint64) uint64 {
 	return 0
 }
 
-// AfterExecutingTransaction proxies arguments to the
-// s.AfterExecutingTransactionFn function if non-nil, otherwise it acts as a
-// noop.
-func (s Stub) AfterExecutingTransaction(state libevm.StateDB, baseFee *big.Int, gasUsed uint64) {
-	if f := s.AfterExecutingTransactionFn; f != nil {
-		f(state, baseFee, gasUsed)
-	}
+// ShouldCreditBaseFeeToCoinbase returns the value of [Stub.CreditBaseFeeToCoinbase].
+func (s Stub) ShouldCreditBaseFeeToCoinbase() bool {
+	return s.CreditBaseFeeToCoinbase
 }
 
 var _ interface {

--- a/libevm/interfaces_test.go
+++ b/libevm/interfaces_test.go
@@ -31,10 +31,5 @@ var (
 	_ libevm.PrecompiledContract = (vm.PrecompiledContract)(nil)
 )
 
-var (
-	// StateReader MUST be a subset vm.StateDB.
-	_ libevm.StateReader = (vm.StateDB)(nil)
-
-	// StateDB MUST be a non-strict subset of vm.StateDB.
-	_ libevm.StateDB = (vm.StateDB)(nil)
-)
+// StateReader MUST be a subset vm.StateDB.
+var _ libevm.StateReader = (vm.StateDB)(nil)

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -72,16 +72,6 @@ type StateReader interface {
 	TxIndex() int
 }
 
-// StateDB is a subset of vm.StateDB that embeds [StateReader] and adds balance
-// mutation, mirrored here to avoid a core/vm import cycle. See method comments
-// in vm.StateDB, which aren't copied here as they risk becoming outdated.
-type StateDB interface {
-	StateReader
-
-	AddBalance(common.Address, *uint256.Int)
-	SubBalance(common.Address, *uint256.Int)
-}
-
 // AddressContext carries addresses available to contexts such as calls and
 // contract creation.
 //

--- a/libevm/libevm.go
+++ b/libevm/libevm.go
@@ -79,6 +79,7 @@ type StateDB interface {
 	StateReader
 
 	AddBalance(common.Address, *uint256.Int)
+	SubBalance(common.Address, *uint256.Int)
 }
 
 // AddressContext carries addresses available to contexts such as calls and

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -71,11 +71,10 @@ type RulesHooks interface {
 	// will be capped at the limit. The minimum spend will be applied _after_
 	// refunds, if any.
 	MinimumGasConsumption(txGasLimit uint64) (gas uint64)
-	// AfterExecutingTransaction is called after a transaction has executed
-	// without consensus errors, and the execution has not been invalidated.
-	// The exact qualifications for a "consensus error" can be found in the
-	// comment for core/state_transition.go:StateTransition.transitionDb.
-	AfterExecutingTransaction(state libevm.StateDB, baseFee *big.Int, gasUsed uint64)
+	// ShouldCreditBaseFeeToCoinbase returns whether or not to credit the
+	// block's base fee to the coinbase address. By default, it will NOT be
+	// credited.
+	ShouldCreditBaseFeeToCoinbase() bool
 }
 
 // RulesAllowlistHooks are a subset of [RulesHooks] that gate actions, signalled
@@ -170,5 +169,7 @@ func (NOOPHooks) MinimumGasConsumption(uint64) uint64 {
 	return 0
 }
 
-// AfterExecutingTransaction does nothing.
-func (NOOPHooks) AfterExecutingTransaction(libevm.StateDB, *big.Int, uint64) {}
+// ShouldCreditBaseFeeToCoinbase always returns false.
+func (NOOPHooks) ShouldCreditBaseFeeToCoinbase() bool {
+	return false
+}


### PR DESCRIPTION
## Why this should be merged

Coreth and Subnet-EVM both credit the entire base fee and tip to the coinbase, which is enforced at verification time to be a specific blackhole address. Prior to #294, this wasn't possible at all through libevm, and was performed after `core.ApplyMessage` in SAE.

The previous solution with the `AfterExecutingTransaction` hook allows modifying the statedb to reflect the blackhole updates, but the tracers did not capture these changes, as `CaptureTxEnd` had already been called.  Additionally, the API surface cannot include arbitrary operations on the StateDB, since the tracers wouldn't know which accounts/storage to look at during `GetResult`.

## How this works

Reverts all prod changes of #294 and provides a different hook which is more targeted to the specific problem SAE faces.

## How this was tested

UT including the `prestate` tracer to ensure that the common tracer workflows are correctly updated.
