### PR TITLE
chore: export BlockTraceResult

### DIFF
--- a/eth/tracers/api.libevm.go
+++ b/eth/tracers/api.libevm.go
@@ -54,3 +54,7 @@ func TraceBlock(ctx context.Context, api *API, block *types.Block, config *Trace
 // TxTraceResult exports the [txTraceResult] type, returned per transaction
 // by the TraceBlock* methods.
 type TxTraceResult = txTraceResult
+
+// BlockTraceResult exports the [blockTraceResult] type, returned per block
+// by the TraceChain* methods.
+type BlockTraceResult = blockTraceResult


### PR DESCRIPTION
## Why this should be merged

I deleted this from the other PR because it wasn't used for the async PR, but it was for the sync PR oops. 

## How this works
exports as default 

## How this was tested
no 
