### PR TITLE
fix(vm): remove duplicate precompile call trace frame

### DIFF
--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -878,3 +878,50 @@ func TestPrecompileCallWithTracer(t *testing.T) {
 	require.NoErrorf(t, json.Unmarshal(gotJSON, &got), "json.Unmarshal(%T.GetResult(), %T)", tracer, &got)
 	require.Equal(t, value, got[contract].Storage[zeroHash], "value loaded with SLOAD")
 }
+
+func TestPrecompileCallWithCallTracer(t *testing.T) {
+	rng := ethtest.NewPseudoRand(42 * 142857)
+	precompile := rng.Address()
+	contract := rng.Address()
+	caller := rng.Address()
+
+	hooks := &hookstest.Stub{
+		PrecompileOverrides: map[common.Address]libevm.PrecompiledContract{
+			precompile: vm.NewStatefulPrecompile(func(env vm.PrecompileEnvironment, input []byte) (ret []byte, err error) {
+				return env.Call(contract, nil, env.Gas(), uint256.NewInt(0))
+			}),
+		},
+	}
+	hooks.Register(t)
+
+	state, evm := ethtest.NewZeroEVM(t)
+	state.CreateAccount(contract)
+	state.SetCode(contract, convertBytes[vm.OpCode, byte](vm.STOP))
+
+	const tracerName = "callTracer"
+	tracer, err := tracers.DefaultDirectory.New(tracerName, nil, nil)
+	require.NoErrorf(t, err, "tracers.DefaultDirectory.New(%q)", tracerName)
+	evm.Config.Tracer = tracer
+
+	_, _, err = evm.Call(vm.AccountRef(caller), precompile, nil, 1e6, uint256.NewInt(0))
+	require.NoError(t, err, "evm.Call([precompile that calls regular contract])")
+
+	gotJSON, err := tracer.GetResult()
+	require.NoErrorf(t, err, "%T.GetResult()", tracer)
+	var got struct {
+		From  common.Address `json:"from"`
+		To    common.Address `json:"to"`
+		Calls []struct {
+			From  common.Address    `json:"from"`
+			To    common.Address    `json:"to"`
+			Calls []json.RawMessage `json:"calls"`
+		} `json:"calls"`
+	}
+	require.NoErrorf(t, json.Unmarshal(gotJSON, &got), "json.Unmarshal(%T.GetResult(), %T)", tracer, &got)
+	require.Equal(t, caller, got.From)
+	require.Equal(t, precompile, got.To)
+	require.Len(t, got.Calls, 1)
+	require.Equal(t, precompile, got.Calls[0].From)
+	require.Equal(t, contract, got.Calls[0].To)
+	require.Empty(t, got.Calls[0].Calls)
+}

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -910,6 +910,7 @@ func TestPrecompileCallWithCallTracer(t *testing.T) {
 	type call struct {
 		From  common.Address `json:"from"`
 		To    common.Address `json:"to"`
+		Type  string         `json:"type"`
 		Calls []call         `json:"calls"`
 	}
 	var got call
@@ -918,9 +919,11 @@ func TestPrecompileCallWithCallTracer(t *testing.T) {
 	want := call{
 		From: caller,
 		To:   precompile,
+		Type: "CALL",
 		Calls: []call{{
 			From: precompile,
 			To:   contract,
+			Type: "CALL",
 		}},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/core/vm/contracts.libevm_test.go
+++ b/core/vm/contracts.libevm_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -836,7 +837,7 @@ func TestPrecompileMakeCall(t *testing.T) {
 	}
 }
 
-func TestPrecompileCallWithTracer(t *testing.T) {
+func TestPrecompileCallWithPrestateTracer(t *testing.T) {
 	// The native pre-state tracer, when logging storage, assumes an invariant
 	// that is broken by a precompile calling another contract. This is a test
 	// of the fix, ensuring that an SLOADed value is properly handled by the
@@ -894,34 +895,35 @@ func TestPrecompileCallWithCallTracer(t *testing.T) {
 	}
 	hooks.Register(t)
 
-	state, evm := ethtest.NewZeroEVM(t)
-	state.CreateAccount(contract)
-	state.SetCode(contract, convertBytes[vm.OpCode, byte](vm.STOP))
-
 	const tracerName = "callTracer"
 	tracer, err := tracers.DefaultDirectory.New(tracerName, nil, nil)
 	require.NoErrorf(t, err, "tracers.DefaultDirectory.New(%q)", tracerName)
-	evm.Config.Tracer = tracer
 
+	_, evm := ethtest.NewZeroEVM(t)
+	evm.Config.Tracer = tracer
 	_, _, err = evm.Call(vm.AccountRef(caller), precompile, nil, 1e6, uint256.NewInt(0))
 	require.NoError(t, err, "evm.Call([precompile that calls regular contract])")
 
 	gotJSON, err := tracer.GetResult()
 	require.NoErrorf(t, err, "%T.GetResult()", tracer)
-	var got struct {
+
+	type call struct {
 		From  common.Address `json:"from"`
 		To    common.Address `json:"to"`
-		Calls []struct {
-			From  common.Address    `json:"from"`
-			To    common.Address    `json:"to"`
-			Calls []json.RawMessage `json:"calls"`
-		} `json:"calls"`
+		Calls []call         `json:"calls"`
 	}
+	var got call
 	require.NoErrorf(t, json.Unmarshal(gotJSON, &got), "json.Unmarshal(%T.GetResult(), %T)", tracer, &got)
-	require.Equal(t, caller, got.From)
-	require.Equal(t, precompile, got.To)
-	require.Len(t, got.Calls, 1)
-	require.Equal(t, precompile, got.Calls[0].From)
-	require.Equal(t, contract, got.Calls[0].To)
-	require.Empty(t, got.Calls[0].Calls)
+
+	want := call{
+		From: caller,
+		To:   precompile,
+		Calls: []call{{
+			From: precompile,
+			To:   contract,
+		}},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("%q tracer diff (-want +got):\n%s", tracerName, diff)
+	}
 }

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -135,7 +135,8 @@ func (e *environment) callContract(typ CallType, addr common.Address, input []by
 		// early abstraction, to signal to future maintainers. If implementing
 		// them, there's likely no need to honour the
 		// [callOptUNSAFECallerAddressProxy] because it's purely for backwards
-		// compatibility.
+		// compatibility, however the "callTracer" test MUST be extended to
+		// demonstrate the correct type.
 		fallthrough
 	default:
 		return nil, fmt.Errorf("unimplemented precompile call type %v", typ)

--- a/core/vm/environment.libevm.go
+++ b/core/vm/environment.libevm.go
@@ -103,7 +103,7 @@ func (e *environment) Call(addr common.Address, input []byte, gas uint64, value 
 	return e.callContract(Call, addr, input, gas, value, opts...)
 }
 
-func (e *environment) callContract(typ CallType, addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) (retData []byte, retErr error) {
+func (e *environment) callContract(typ CallType, addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...CallOption) ([]byte, error) {
 	var caller ContractRef = e.self
 	if options.As[callConfig](opts...).unsafeCallerAddressProxying {
 		// Note that, in addition to being unsafe, this breaks an EVM
@@ -121,19 +121,6 @@ func (e *environment) callContract(typ CallType, addr common.Address, input []by
 	}
 	if !e.UseGas(gas) {
 		return nil, ErrOutOfGas
-	}
-
-	if t := e.evm.Config.Tracer; t != nil {
-		var bigVal *big.Int
-		if value != nil {
-			bigVal = value.ToBig()
-		}
-		t.CaptureEnter(typ.OpCode(), caller.Address(), addr, input, gas, bigVal)
-
-		startGas := gas
-		defer func() {
-			t.CaptureEnd(retData, startGas-e.Gas(), retErr)
-		}()
 	}
 
 	switch typ {


### PR DESCRIPTION
## Why this should be merged

When a stateful precompile calls `env.Call()`, the same call is reported twice:

- `PrecompileEnvironment.Call()` reports it manually.
- `EVM.Call()` reports it again.

The manual frame starts with `CaptureEnter()` but ends with `CaptureEnd()`. `callTracer` never pops that frame and fails with:

`incorrect number of top-level calls`

## Reproduction

Avalanche C-Chain block `5,456,905` (`0x534409`) contains a transaction calling the `NativeAssetCall` precompile.

```bash
curl -s -X POST \
  -H 'Content-Type: application/json' \
  --data '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceBlockByNumber",
    "params": [
      "0x534409",
      {
        "tracer": "callTracer",
        "timeout": "30s"
      }
    ]
  }' "$RPC"
```

Result:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "incorrect number of top-level calls"
  }
}
```

Affected transaction: [SnowScan VM trace](https://snowscan.xyz/vmtrace?txhash=0xc5ad6d3c56b8a5245e0bebca8d8f0d588cab306799d6a901e7480aaa3648aee7&type=gethtrace2#raw)

## How this works

Remove the manual tracer block and let `EVM.Call()` emit the balanced `CaptureEnter()` / `CaptureExit()` pair.

Changing `CaptureEnd()` to `CaptureExit()` is not enough because it would keep the duplicate call frame.

## How this was tested

- Existing `prestateTracer` regression test still passes.
- Added a `callTracer` regression test that checks for one child call with no duplicate frame.
- `go test ./core/vm/... ./eth/tracers/... -count=1`
- `go vet ./core/vm/... ./eth/tracers/...`