### PR TITLE
fix(core): skip minimum gas consumption for simulated calls

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -185,8 +185,8 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 // the gas used (which includes gas refunds) and an error if it failed. An error always
 // indicates a core error meaning that the message would always fail for that particular
 // state and would never be accepted within a block.
-func ApplyMessage(evm *vm.EVM, msg *Message, gp *GasPool) (*ExecutionResult, error) {
-	return NewStateTransition(evm, msg, gp).TransitionDb()
+func ApplyMessage(evm *vm.EVM, msg *Message, gp *GasPool, opts ...StateTransitionOption) (*ExecutionResult, error) {
+	return NewStateTransition(evm, msg, gp, opts...).TransitionDb()
 }
 
 // StateTransition represents a state transition.
@@ -218,15 +218,18 @@ type StateTransition struct {
 	initialGas   uint64
 	state        vm.StateDB
 	evm          *vm.EVM
+
+	opts []StateTransitionOption //libevm
 }
 
 // NewStateTransition initialises and returns a new state transition object.
-func NewStateTransition(evm *vm.EVM, msg *Message, gp *GasPool) *StateTransition {
+func NewStateTransition(evm *vm.EVM, msg *Message, gp *GasPool, opts ...StateTransitionOption) *StateTransition {
 	return &StateTransition{
 		gp:    gp,
 		evm:   evm,
 		msg:   msg,
 		state: evm.StateDB,
+		opts:  opts,
 	}
 }
 

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -49,8 +49,11 @@ type stateTransitionConfig struct {
 	disableMinimumGasConsumption bool
 }
 
+// StateTransitionOption configures a state transition.
 type StateTransitionOption = options.Option[stateTransitionConfig]
 
+// WithoutMinimumGasConsumption disables the minimum gas consumption hook for
+// a state transition.
 func WithoutMinimumGasConsumption() StateTransitionOption {
 	return options.Func[stateTransitionConfig](func(c *stateTransitionConfig) {
 		c.disableMinimumGasConsumption = true

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -49,11 +49,11 @@ type stateTransitionConfig struct {
 	disableMinimumGasConsumption bool
 }
 
-// StateTransitionOption configures a state transition.
+// StateTransitionOption configures a [StateTransition].
 type StateTransitionOption = options.Option[stateTransitionConfig]
 
-// WithoutMinimumGasConsumption disables the minimum gas consumption hook for
-// a state transition.
+// WithoutMinimumGasConsumption disables the
+// [params.RulesHooks.MinimumGasConsumption] hook for a state transition.
 func WithoutMinimumGasConsumption() StateTransitionOption {
 	return options.Func[stateTransitionConfig](func(c *stateTransitionConfig) {
 		c.disableMinimumGasConsumption = true

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -105,6 +105,12 @@ func (st *StateTransition) afterGasRefund(refunded uint64) {
 	if !st.rulesHooks().ShouldRefundGas() {
 		st.gasRemaining -= refunded
 	}
+	// Simulated calls do not incur transaction charges. Applying a
+	// gas-limit-derived charge would also make gas estimation depend on the
+	// upper bound being tested rather than the gas required for execution.
+	if st.msg.SkipAccountChecks && st.evm.Config.NoBaseFee {
+		return
+	}
 
 	limit := st.msg.GasLimit
 	minConsume := min(

--- a/core/state_transition.libevm.go
+++ b/core/state_transition.libevm.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm"
+	"github.com/ava-labs/libevm/libevm/options"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/params"
 )
@@ -43,6 +44,18 @@ func (st *StateTransition) rulesHooks() params.RulesHooks {
 // Keeps the vm package imported by this specific file so VS Code can support
 // comments like [vm.EVM].
 var _ = (*vm.EVM)(nil)
+
+type stateTransitionConfig struct {
+	disableMinimumGasConsumption bool
+}
+
+type StateTransitionOption = options.Option[stateTransitionConfig]
+
+func WithoutMinimumGasConsumption() StateTransitionOption {
+	return options.Func[stateTransitionConfig](func(c *stateTransitionConfig) {
+		c.disableMinimumGasConsumption = true
+	})
+}
 
 // TransitionDb will transition the state by applying the current message and
 // returning the evm execution result with following fields.
@@ -105,10 +118,9 @@ func (st *StateTransition) afterGasRefund(refunded uint64) {
 	if !st.rulesHooks().ShouldRefundGas() {
 		st.gasRemaining -= refunded
 	}
-	// Simulated calls do not incur transaction charges. Applying a
-	// gas-limit-derived charge would also make gas estimation depend on the
-	// upper bound being tested rather than the gas required for execution.
-	if st.msg.SkipAccountChecks && st.evm.Config.NoBaseFee {
+
+	c := options.As[stateTransitionConfig](st.opts...)
+	if c.disableMinimumGasConsumption {
 		return
 	}
 

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -323,6 +323,12 @@ func (stubEngine) Author(h *types.Header) (common.Address, error) {
 func TestGasEstimationIgnoresMinConsumption(t *testing.T) {
 	const limit = 1e8
 	from := common.Address{'m', 'e'}
+	hooks := &hookstest.Stub{
+		MinimumGasConsumptionFn: func(gasLimit uint64) uint64 {
+			return gasLimit / 2
+		},
+	}
+	hooks.Register(t)
 
 	_, _, sdb := ethtest.NewEmptyStateDB(t)
 	sdb.SetBalance(from, new(uint256.Int).SetAllOne())
@@ -350,7 +356,7 @@ func TestGasEstimationIgnoresMinConsumption(t *testing.T) {
 
 	got, _, err := gasestimator.Estimate(t.Context(), msg, opts, limit)
 	require.NoError(t, err)
-	t.Error(got) // DO NOT MERGE: for inspection of result to ensure that the bug has been reproduced
+	require.Equal(t, params.TxGasContractCreation, got)
 }
 
 // TestCreditBaseFeeToCoinbase tests that the coinbase is credited with the

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -304,6 +304,58 @@ func TestMinimumGasConsumption(t *testing.T) {
 	}
 }
 
+func TestMinimumGasConsumptionSimulation(t *testing.T) {
+	const gasLimit = 1_000_000
+	tests := []struct {
+		name      string
+		noBaseFee bool
+		want      uint64
+	}{
+		{
+			name: "skip account checks only",
+			want: gasLimit / 2,
+		},
+		{
+			name:      "RPC simulation",
+			noBaseFee: true,
+			want:      params.TxGas,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hooks := &hookstest.Stub{
+				MinimumGasConsumptionFn: func(limit uint64) uint64 {
+					require.Equal(t, uint64(gasLimit), limit, "MinimumGasConsumption() argument")
+					return limit / 2
+				},
+			}
+			hooks.Register(t)
+
+			stateDB, evm := ethtest.NewZeroEVM(t)
+			evm.Config.NoBaseFee = tt.noBaseFee
+			from := common.Address{0x01}
+			to := common.Address{0x02}
+			stateDB.SetBalance(from, uint256.NewInt(params.Ether))
+			msg := &core.Message{
+				From:              from,
+				To:                &to,
+				GasLimit:          gasLimit,
+				GasPrice:          new(big.Int),
+				GasFeeCap:         new(big.Int),
+				GasTipCap:         new(big.Int),
+				Value:             new(big.Int),
+				SkipAccountChecks: true,
+			}
+			gasPool := core.GasPool(gasLimit)
+
+			result, err := core.ApplyMessage(evm, msg, &gasPool)
+			require.NoError(t, err, "core.ApplyMessage()")
+			require.Equal(t, tt.want, result.UsedGas, "core.ApplyMessage() gas used")
+		})
+	}
+}
+
 // TestCreditBaseFeeToCoinbase tests that the coinbase is credited with the
 // base fee if enabled in the hooks and post-London. Additionally, these state
 // changes should be conveyed to the tracer.

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -28,10 +28,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/consensus"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/eth/gasestimator"
 	"github.com/ava-labs/libevm/eth/tracers"
 	"github.com/ava-labs/libevm/eth/tracers/native"
 	"github.com/ava-labs/libevm/libevm"
@@ -304,56 +306,51 @@ func TestMinimumGasConsumption(t *testing.T) {
 	}
 }
 
-func TestMinimumGasConsumptionSimulation(t *testing.T) {
-	const gasLimit = 1_000_000
-	tests := []struct {
-		name      string
-		noBaseFee bool
-		want      uint64
-	}{
-		{
-			name: "skip account checks only",
-			want: gasLimit / 2,
+type stubChainContext struct {
+	core.ChainContext
+}
+
+func (stubChainContext) Engine() consensus.Engine { return stubEngine{} }
+
+type stubEngine struct {
+	consensus.Engine
+}
+
+func (stubEngine) Author(h *types.Header) (common.Address, error) {
+	return h.Coinbase, nil
+}
+
+func TestGasEstimationIgnoresMinConsumption(t *testing.T) {
+	const limit = 1e8
+	from := common.Address{'m', 'e'}
+
+	_, _, sdb := ethtest.NewEmptyStateDB(t)
+	sdb.SetBalance(from, new(uint256.Int).SetAllOne())
+
+	opts := &gasestimator.Options{
+		Config: params.MergedTestChainConfig,
+		Chain:  stubChainContext{},
+		Header: &types.Header{
+			Number:     big.NewInt(1),
+			BaseFee:    big.NewInt(1),
+			GasLimit:   limit,
+			Coinbase:   common.Address{1},
+			Difficulty: big.NewInt(1),
 		},
-		{
-			name:      "RPC simulation",
-			noBaseFee: true,
-			want:      params.TxGas,
-		},
+		State: sdb,
+	}
+	msg := &core.Message{
+		From:      from,
+		GasPrice:  big.NewInt(1),
+		GasFeeCap: big.NewInt(1),
+		GasTipCap: big.NewInt(0),
+		GasLimit:  limit,
+		Value:     big.NewInt(0),
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			hooks := &hookstest.Stub{
-				MinimumGasConsumptionFn: func(limit uint64) uint64 {
-					require.Equal(t, uint64(gasLimit), limit, "MinimumGasConsumption() argument")
-					return limit / 2
-				},
-			}
-			hooks.Register(t)
-
-			stateDB, evm := ethtest.NewZeroEVM(t)
-			evm.Config.NoBaseFee = tt.noBaseFee
-			from := common.Address{0x01}
-			to := common.Address{0x02}
-			stateDB.SetBalance(from, uint256.NewInt(params.Ether))
-			msg := &core.Message{
-				From:              from,
-				To:                &to,
-				GasLimit:          gasLimit,
-				GasPrice:          new(big.Int),
-				GasFeeCap:         new(big.Int),
-				GasTipCap:         new(big.Int),
-				Value:             new(big.Int),
-				SkipAccountChecks: true,
-			}
-			gasPool := core.GasPool(gasLimit)
-
-			result, err := core.ApplyMessage(evm, msg, &gasPool)
-			require.NoError(t, err, "core.ApplyMessage()")
-			require.Equal(t, tt.want, result.UsedGas, "core.ApplyMessage() gas used")
-		})
-	}
+	got, _, err := gasestimator.Estimate(t.Context(), msg, opts, limit)
+	require.NoError(t, err)
+	t.Error(got) // DO NOT MERGE: for inspection of result to ensure that the bug has been reproduced
 }
 
 // TestCreditBaseFeeToCoinbase tests that the coinbase is credited with the

--- a/core/state_transition.libevm_test.go
+++ b/core/state_transition.libevm_test.go
@@ -355,8 +355,8 @@ func TestGasEstimationIgnoresMinConsumption(t *testing.T) {
 	}
 
 	got, _, err := gasestimator.Estimate(t.Context(), msg, opts, limit)
-	require.NoError(t, err)
-	require.Equal(t, params.TxGasContractCreation, got)
+	require.NoError(t, err, "gasestimator.Estimate(...)")
+	require.Equal(t, params.TxGasContractCreation, got, "gasestimator.Estimate(...)")
 }
 
 // TestCreditBaseFeeToCoinbase tests that the coinbase is credited with the

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -224,7 +224,7 @@ func run(ctx context.Context, call *core.Message, opts *Options) (*core.Executio
 		evm.Cancel()
 	}()
 	// Execute the call, returning a wrapped error or the result
-	result, err := core.ApplyMessage(evm, call, new(core.GasPool).AddGas(math.MaxUint64))
+	result, err := core.ApplyMessage(evm, call, new(core.GasPool).AddGas(math.MaxUint64), core.WithoutMinimumGasConsumption())
 	if vmerr := dirtyState.Error(); vmerr != nil {
 		return nil, vmerr
 	}

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -69,8 +69,8 @@ type RulesHooks interface {
 	// minimum quantity of gas units to be charged for said transaction. If the
 	// returned value is greater than the transaction's limit, the minimum spend
 	// will be capped at the limit. The minimum spend will be applied _after_
-	// refunds, if any. It is not applied to simulated calls that skip account
-	// checks and disable base-fee checks.
+	// refunds, if any. A state transition can explicitly disable the minimum,
+	// such as when estimating the gas required for execution.
 	MinimumGasConsumption(txGasLimit uint64) (gas uint64)
 	// ShouldCreditBaseFeeToCoinbase returns whether or not to credit the
 	// block's base fee to the coinbase address. By default, it will NOT be

--- a/params/hooks.libevm.go
+++ b/params/hooks.libevm.go
@@ -69,7 +69,8 @@ type RulesHooks interface {
 	// minimum quantity of gas units to be charged for said transaction. If the
 	// returned value is greater than the transaction's limit, the minimum spend
 	// will be capped at the limit. The minimum spend will be applied _after_
-	// refunds, if any.
+	// refunds, if any. It is not applied to simulated calls that skip account
+	// checks and disable base-fee checks.
 	MinimumGasConsumption(txGasLimit uint64) (gas uint64)
 	// ShouldCreditBaseFeeToCoinbase returns whether or not to credit the
 	// block's base fee to the coinbase address. By default, it will NOT be


### PR DESCRIPTION
## Why this should be merged

This was reported in ava-labs/avalanchego#5850.

ACP-194 charges real transactions: 

```
chargedGas
  = limit - min(limit - actualGasUsed, limit - minimumConsumption)
  = max(actualGasUsed, minimumConsumption)
  = max(actualGasUsed, ceil(limit / 2))
```

During `eth_estimateGas`, this floor makes `UsedGas` depend on the trial gas limit. The geth estimator assumes `UsedGas` is a lower bound on the gas required for execution, so it can return an estimate near half of the sender's balance-derived gas allowance. This is incorrect, as we [should not alter](https://build.avax.network/docs/acps/194-continuous-execution#json-rpc-methods) the behavior of RPCs as described in the issue report. 

- [Estimator caps the initial limit using balance and fee cap](https://github.com/ava-labs/libevm/blob/c1a647408c12e6431af7fc1857fb60bf0c92b64e/eth/gasestimator/gasestimator.go#L65-L94)
- [Estimator treats `UsedGas` as its lower bound](https://github.com/ava-labs/libevm/blob/c1a647408c12e6431af7fc1857fb60bf0c92b64e/eth/gasestimator/gasestimator.go#L113-L135)
- [Minimum consumption modifies `UsedGas` after refunds](https://github.com/ava-labs/libevm/blob/c1a647408c12e6431af7fc1857fb60bf0c92b64e/core/state_transition.libevm.go#L99-L117)
- [ACP-194 computes `ceil(gasLimit / 2)`](https://github.com/ava-labs/avalanchego/blob/0b0b57143c286b0653850a41839f4668f8e0b66e/vms/saevm/hook/hook.go#L200-L206)

## How this works

Adds a `StateTransitionOption` that explicitly disables minimum gas consumption for a state transition.

## How this was tested

All existing UTs pass and I added a minimum-consumption unit test. 